### PR TITLE
Sync physics transforms at the end of the physic schedule

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@ impl Plugin for XpbdPlugin {
                 PhysicsSet::Prepare,
                 PhysicsSet::BroadPhase,
                 PhysicsSet::Substeps,
+                PhysicsSet::Sync,
             )
                 .chain(),
         );
@@ -111,7 +112,8 @@ impl Plugin for XpbdPlugin {
         app.add_plugin(PreparePlugin)
             .add_plugin(BroadPhasePlugin)
             .add_plugin(IntegratorPlugin)
-            .add_plugin(SolverPlugin);
+            .add_plugin(SolverPlugin)
+            .add_plugin(SyncPlugin);
 
         app.add_plugin(DebugLinesPlugin::default());
 

--- a/src/steps/mod.rs
+++ b/src/steps/mod.rs
@@ -16,7 +16,6 @@ use bevy::prelude::SystemSet;
 #[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum PhysicsSet {
     /// In the preparation step, necessary preparations and updates will be run before the rest of the physics simulation loop.
-    /// For example, bevy `Transform`s are synchronized with the physics world, AABBs are updated etc.
     Prepare,
     /// During the broad phase, potential collisions will be collected into the [`BroadCollisions`] resource using simple AABB intersection checks. These will be further checked for collision in the [`PhysicsStep::NarrowPhase`].
     ///
@@ -24,6 +23,7 @@ pub enum PhysicsSet {
     BroadPhase,
     /// Substepping is an inner loop inside a physics step, see [`PhysicsSubstep`] and [`XpbdSubstepSchedule`]
     Substeps,
+    /// In the sync step, Bevy `Transform`s are synchronized with the physics world.
     Sync,
 }
 

--- a/src/steps/mod.rs
+++ b/src/steps/mod.rs
@@ -2,11 +2,13 @@ pub mod broad_phase;
 pub mod integrator;
 pub mod prepare;
 pub mod solver;
+pub mod sync;
 
 pub use broad_phase::BroadPhasePlugin;
 pub use integrator::IntegratorPlugin;
 pub use prepare::PreparePlugin;
 pub use solver::SolverPlugin;
+pub use sync::SyncPlugin;
 
 use bevy::prelude::SystemSet;
 
@@ -22,6 +24,7 @@ pub enum PhysicsSet {
     BroadPhase,
     /// Substepping is an inner loop inside a physics step, see [`PhysicsSubstep`] and [`XpbdSubstepSchedule`]
     Substeps,
+    Sync,
 }
 
 /// The steps in the inner substepping loop

--- a/src/steps/prepare.rs
+++ b/src/steps/prepare.rs
@@ -8,32 +8,8 @@ impl Plugin for PreparePlugin {
         app.get_schedule_mut(XpbdSchedule)
             .expect("add xpbd schedule first")
             .add_systems(
-                (
-                    sync_transforms,
-                    update_sub_delta_time,
-                    update_aabb,
-                    update_mass_props,
-                )
-                    .in_set(PhysicsSet::Prepare),
+                (update_sub_delta_time, update_aabb, update_mass_props).in_set(PhysicsSet::Prepare),
             );
-    }
-}
-
-/// Copies positions from the physics world to bevy Transforms
-#[cfg(feature = "2d")]
-fn sync_transforms(mut bodies: Query<(&mut Transform, &Pos, &Rot)>) {
-    for (mut transform, pos, rot) in &mut bodies {
-        transform.translation = pos.extend(0.0);
-        transform.rotation = (*rot).into();
-    }
-}
-
-/// Copies positions from the physics world to bevy Transforms
-#[cfg(feature = "3d")]
-fn sync_transforms(mut bodies: Query<(&mut Transform, &Pos, &Rot)>) {
-    for (mut transform, pos, rot) in &mut bodies {
-        transform.translation = pos.0;
-        transform.rotation = rot.0;
     }
 }
 

--- a/src/steps/sync.rs
+++ b/src/steps/sync.rs
@@ -1,0 +1,31 @@
+use crate::{prelude::*, XpbdSchedule};
+use bevy::prelude::*;
+
+/// Synchronizes changes from the physics world to Bevy `Transform`s
+pub struct SyncPlugin;
+
+impl Plugin for SyncPlugin {
+    fn build(&self, app: &mut bevy::prelude::App) {
+        app.get_schedule_mut(XpbdSchedule)
+            .expect("add xpbd schedule first")
+            .add_system(sync_transforms.in_set(PhysicsSet::Sync));
+    }
+}
+
+/// Copies positions from the physics world to bevy Transforms
+#[cfg(feature = "2d")]
+fn sync_transforms(mut bodies: Query<(&mut Transform, &Pos, &Rot)>) {
+    for (mut transform, pos, rot) in &mut bodies {
+        transform.translation = pos.extend(0.0);
+        transform.rotation = (*rot).into();
+    }
+}
+
+/// Copies positions from the physics world to bevy Transforms
+#[cfg(feature = "3d")]
+fn sync_transforms(mut bodies: Query<(&mut Transform, &Pos, &Rot)>) {
+    for (mut transform, pos, rot) in &mut bodies {
+        transform.translation = pos.0;
+        transform.rotation = rot.0;
+    }
+}


### PR DESCRIPTION
This gets rid of an unnecessary 1 frame delay, where we'd always see the physics frame 1 frame behind their position in the physics world.

Also, when pausing, we'd previously never see the latest state.