### PR TITLE
More/better builder methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,6 +866,7 @@ dependencies = [
  "bevy",
  "bevy_prototype_debug_lines",
  "console_error_panic_hook",
+ "derive_more",
  "examples_common_2d",
  "nalgebra",
  "parry2d",
@@ -879,6 +880,7 @@ dependencies = [
  "bevy",
  "bevy_prototype_debug_lines",
  "console_error_panic_hook",
+ "derive_more",
  "examples_common_3d",
  "nalgebra",
  "parry3d",
@@ -1065,6 +1067,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58baae561b85ca19b3122a9ddd35c8ec40c3bcd14fe89921824eae73f7baffbf"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1142,6 +1150,19 @@ dependencies = [
  "bitflags",
  "libloading",
  "winapi",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
 ]
 
 [[package]]
@@ -2353,6 +2374,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "safe_arch"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2375,6 +2405,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,11 +863,13 @@ dependencies = [
 name = "bevy_xpbd_2d"
 version = "0.1.0"
 dependencies = [
+ "approx",
  "bevy",
  "bevy_prototype_debug_lines",
  "console_error_panic_hook",
  "derive_more",
  "examples_common_2d",
+ "glam",
  "nalgebra",
  "parry2d",
  "web-sys",
@@ -877,11 +879,13 @@ dependencies = [
 name = "bevy_xpbd_3d"
 version = "0.1.0"
 dependencies = [
+ "approx",
  "bevy",
  "bevy_prototype_debug_lines",
  "console_error_panic_hook",
  "derive_more",
  "examples_common_3d",
+ "glam",
  "nalgebra",
  "parry3d",
  "web-sys",
@@ -1452,6 +1456,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e4afd9ad95555081e109fe1d21f2a30c691b5f0919c67dfa690a2e1eb6bd51c"
 dependencies = [
+ "approx",
  "bytemuck",
  "serde",
 ]

--- a/crates/bevy_xpbd_2d/Cargo.toml
+++ b/crates/bevy_xpbd_2d/Cargo.toml
@@ -20,6 +20,7 @@ parry2d = { version = "0.13.1", features = [ "simd-stable" ] }
 nalgebra = { version = "0.32.2", features = [ "convert-glam023" ] }
 console_error_panic_hook = "0.1.7"
 web-sys = "0.3.59"
+derive_more = "0.99"
 
 [dev-dependencies]
 examples_common_2d = { path = "../examples_common_2d" }

--- a/crates/bevy_xpbd_2d/Cargo.toml
+++ b/crates/bevy_xpbd_2d/Cargo.toml
@@ -24,3 +24,5 @@ derive_more = "0.99"
 
 [dev-dependencies]
 examples_common_2d = { path = "../examples_common_2d" }
+approx = "0.5"
+glam = { version = "0.23", features = [ "approx" ] }

--- a/crates/bevy_xpbd_3d/Cargo.toml
+++ b/crates/bevy_xpbd_3d/Cargo.toml
@@ -20,6 +20,7 @@ parry3d = { version = "0.13.1" }
 nalgebra = { version = "0.32.2", features = [ "convert-glam023" ] }
 console_error_panic_hook = "0.1"
 web-sys = "0.3.59"
+derive_more = "0.99"
 
 [dev-dependencies]
 examples_common_3d = { path = "../examples_common_3d" }

--- a/crates/bevy_xpbd_3d/Cargo.toml
+++ b/crates/bevy_xpbd_3d/Cargo.toml
@@ -24,3 +24,5 @@ derive_more = "0.99"
 
 [dev-dependencies]
 examples_common_3d = { path = "../examples_common_3d" }
+approx = "0.5"
+glam = { version = "0.23", features = [ "approx" ] }

--- a/src/bundles.rs
+++ b/src/bundles.rs
@@ -124,3 +124,40 @@ impl ColliderBundle {
         );
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::prelude::*;
+    use approx::assert_relative_eq;
+    use bevy::prelude::*;
+
+    #[cfg(feature = "2d")]
+    #[test]
+    fn body_builder_accepts_vec_2d() {
+        let body = RigidBodyBundle::new_dynamic()
+            .with_ang_vel(1.)
+            .with_lin_vel(Vec2::new(2., 3.))
+            .with_pos(Vec2::new(4., 5.))
+            .with_rot(Rot::from_radians(0.123));
+
+        assert_relative_eq!(body.ang_vel.0, 1.);
+        assert_relative_eq!(body.lin_vel.0, Vec2::new(2., 3.));
+        assert_relative_eq!(body.pos.0, Vec2::new(4., 5.));
+        assert_relative_eq!(body.rot.as_radians(), 0.123);
+    }
+
+    #[cfg(feature = "3d")]
+    #[test]
+    fn body_builder_accepts_vec_3d() {
+        let body = RigidBodyBundle::new_dynamic()
+            .with_ang_vel(Vec3::X)
+            .with_lin_vel(Vec3::new(2., 3., 4.))
+            .with_pos(Vec3::new(5., 6., 7.))
+            .with_rot(Quat::from_axis_angle(Vec3::X, 0.123));
+
+        assert_relative_eq!(body.ang_vel.0, Vec3::X);
+        assert_relative_eq!(body.lin_vel.0, Vec3::new(2., 3., 4.));
+        assert_relative_eq!(body.pos.0, Vec3::new(5., 6., 7.));
+        assert_relative_eq!(body.rot.0, Quat::from_axis_angle(Vec3::X, 0.123));
+    }
+}

--- a/src/bundles.rs
+++ b/src/bundles.rs
@@ -1,4 +1,4 @@
-use crate::{components::*, Vector};
+use crate::components::*;
 
 use bevy::prelude::*;
 
@@ -53,24 +53,24 @@ impl RigidBodyBundle {
         }
     }
 
-    pub fn with_pos(self, pos: Vector) -> Self {
-        Self {
-            pos: Pos(pos),
-            ..self
-        }
+    pub fn with_pos(self, pos: impl Into<Pos>) -> Self {
+        let pos = pos.into();
+        Self { pos, ..self }
     }
 
-    #[cfg(feature = "2d")]
-    pub fn with_rot(self, rot: Rot) -> Self {
+    pub fn with_rot(self, rot: impl Into<Rot>) -> Self {
+        let rot = rot.into();
         Self { rot, ..self }
     }
 
-    #[cfg(feature = "3d")]
-    pub fn with_rot(self, quat: Quat) -> Self {
-        Self {
-            rot: Rot(quat),
-            ..self
-        }
+    pub fn with_lin_vel(self, lin_vel: impl Into<LinVel>) -> Self {
+        let lin_vel = lin_vel.into();
+        Self { lin_vel, ..self }
+    }
+
+    pub fn with_ang_vel(self, ang_vel: impl Into<AngVel>) -> Self {
+        let ang_vel = ang_vel.into();
+        Self { ang_vel, ..self }
     }
 
     /// Computes the mass properties that a [`Collider`] would have with a given density, and adds those to the body.

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -4,6 +4,7 @@ pub use rotation::*;
 
 use crate::Vector;
 use bevy::{ecs::query::WorldQuery, prelude::*};
+use derive_more::From;
 use parry::{bounding_volume::Aabb, shape::SharedShape};
 use std::ops::{AddAssign, SubAssign};
 
@@ -111,15 +112,15 @@ impl Default for RigidBody {
     }
 }
 
-#[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq)]
+#[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[reflect(Component)]
 pub struct Pos(pub Vector);
 
-#[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq)]
+#[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[reflect(Component)]
 pub struct PrevPos(pub Vector);
 
-#[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq)]
+#[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[reflect(Component)]
 pub struct LinVel(pub Vector);
 
@@ -128,12 +129,12 @@ pub struct LinVel(pub Vector);
 pub struct PreSolveLinVel(pub Vector);
 
 #[cfg(feature = "2d")]
-#[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq)]
+#[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[reflect(Component)]
 pub struct AngVel(pub f32);
 
 #[cfg(feature = "3d")]
-#[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq)]
+#[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[reflect(Component)]
 pub struct AngVel(pub Vec3);
 

--- a/src/components/rotation.rs
+++ b/src/components/rotation.rs
@@ -16,7 +16,7 @@ pub struct Rot {
 }
 
 #[cfg(feature = "3d")]
-#[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut)]
+#[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, derive_more::From)]
 #[reflect(Component)]
 pub struct Rot(pub Quat);
 


### PR DESCRIPTION
This allows the builder methods to take anything that can be converted into the type of their respective fields. So if we implemented `From<nalgebra::Point2<f32>> for Pos` for instance, then we could pass points directly into `with_pos`.

Also adds missing builder methods for `lin_vel` and `ang_vel`.