### PR TITLE
Use opt-level 1 in debug mode for ~100x faster examples and tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
 [workspace]
 members = [ "crates/bevy_xpbd_2d", "crates/bevy_xpbd_3d" ]
 resolver = "2"
+
+[profile.dev]
+opt-level = 1 # Use slightly better optimization, so examples work


### PR DESCRIPTION
Makes compilation slightly slower, but execution of examples tests much faster

Makes cubes_simulation_is_deterministic run in ~2 seconds instead of ~2 minutes.

Helps #18 