### PR TITLE
Make timestep configurable and add a variable timestep

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,8 +48,6 @@ use bevy::{
 use parry::math::Isometry;
 use prelude::*;
 
-pub const DELTA_TIME: Scalar = 1.0 / 60.0;
-
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
 struct FixedUpdateSet;
 
@@ -67,9 +65,11 @@ pub struct XpbdSubstepSchedule;
 impl Plugin for XpbdPlugin {
     fn build(&self, app: &mut App) {
         // Init resources and register component types
-        app.init_resource::<NumSubsteps>()
-            .init_resource::<NumPosIters>()
+        app.init_resource::<PhysicsTimestep>()
+            .init_resource::<DeltaTime>()
             .init_resource::<SubDeltaTime>()
+            .init_resource::<NumSubsteps>()
+            .init_resource::<NumPosIters>()
             .init_resource::<XpbdLoop>()
             .init_resource::<Gravity>()
             .register_type::<RigidBody>()
@@ -221,25 +221,31 @@ fn run_physics_schedule(world: &mut World) {
         .remove_resource::<XpbdLoop>()
         .expect("no xpbd loop resource");
 
+    #[cfg(feature = "f32")]
+    let delta_seconds = world.resource::<Time>().delta_seconds();
+    #[cfg(feature = "f64")]
+    let delta_seconds = world.resource::<Time>().delta_seconds_f64();
+
+    let time_step = *world.resource::<PhysicsTimestep>();
+
+    // Update `DeltaTime` according to the `PhysicsTimestep` configuration
+    let dt = match time_step {
+        PhysicsTimestep::Fixed(fixed_delta_seconds) => fixed_delta_seconds,
+        PhysicsTimestep::Variable { max_dt } => delta_seconds.min(max_dt),
+    };
+    world.resource_mut::<DeltaTime>().0 = dt;
+
     if xpbd_loop.paused {
-        xpbd_loop.accumulator += DELTA_TIME * xpbd_loop.queued_steps as Scalar;
+        xpbd_loop.accumulator += dt * xpbd_loop.queued_steps as Scalar;
         xpbd_loop.queued_steps = 0;
     } else {
-        let time = world.resource::<Time>();
-
-        #[cfg(feature = "f32")]
-        let delta_time = time.delta_seconds();
-
-        #[cfg(feature = "f64")]
-        let delta_time = time.delta_seconds_f64();
-
-        xpbd_loop.accumulator += delta_time;
+        xpbd_loop.accumulator += delta_seconds;
     }
 
-    while xpbd_loop.accumulator >= DELTA_TIME {
+    while xpbd_loop.accumulator >= dt && dt != 0.0 {
         debug!("running physics schedule");
         world.run_schedule(XpbdSchedule);
-        xpbd_loop.accumulator -= DELTA_TIME;
+        xpbd_loop.accumulator -= dt;
     }
 
     world.insert_resource(xpbd_loop);
@@ -247,6 +253,12 @@ fn run_physics_schedule(world: &mut World) {
 
 fn run_substep_schedule(world: &mut World) {
     let NumSubsteps(substeps) = *world.resource::<NumSubsteps>();
+    let dt = world.resource::<DeltaTime>().0;
+
+    // Update `SubDeltaTime`
+    let mut sub_delta_time = world.resource_mut::<SubDeltaTime>();
+    sub_delta_time.0 = dt / substeps as Scalar;
+
     for i in 0..substeps {
         debug!("running substep schedule: {i}");
         world.run_schedule(XpbdSubstepSchedule);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,6 +235,7 @@ fn run_physics_schedule(world: &mut World) {
     };
     world.resource_mut::<DeltaTime>().0 = dt;
 
+    // Add time to the accumulator
     if xpbd_loop.paused {
         xpbd_loop.accumulator += dt * xpbd_loop.queued_steps as Scalar;
         xpbd_loop.queued_steps = 0;
@@ -242,6 +243,8 @@ fn run_physics_schedule(world: &mut World) {
         xpbd_loop.accumulator += delta_seconds;
     }
 
+    // Step the simulation until the accumulator has been consumed.
+    // Note that a small remainder may be passed on to the next run of the physics schedule.
     while xpbd_loop.accumulator >= dt && dt > 0.0 {
         debug!("running physics schedule");
         world.run_schedule(XpbdSchedule);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,7 +242,7 @@ fn run_physics_schedule(world: &mut World) {
         xpbd_loop.accumulator += delta_seconds;
     }
 
-    while xpbd_loop.accumulator >= dt && dt != 0.0 {
+    while xpbd_loop.accumulator >= dt && dt > 0.0 {
         debug!("running physics schedule");
         world.run_schedule(XpbdSchedule);
         xpbd_loop.accumulator -= dt;

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -1,6 +1,34 @@
 use bevy::prelude::Resource;
 
-use crate::{Scalar, Vector, DELTA_TIME};
+use crate::{Scalar, Vector};
+
+/// Configures how many times per second the physics simulation is run.
+#[derive(Resource, Clone, Copy, Debug, PartialEq)]
+pub enum PhysicsTimestep {
+    /// **Fixed timestep**: the physics simulation will be advanced by a fixed value `dt` for every `dt` seconds passed since the previous physics frame. This allows consistent behavior across different machines and framerates.
+    Fixed(Scalar),
+    /// **Variable timestep**: the physics simulation will be advanced by `Time::delta_seconds().min(max_dt)` seconds at each Bevy tick.
+    Variable {
+        /// The maximum amount of time the physics simulation can be advanced at each Bevy tick. This makes sure that the simulation doesn't break when the delta time is large.
+        ///
+        /// A good default is `1.0 / 60.0` (60 Hz)
+        max_dt: Scalar,
+    },
+}
+
+impl Default for PhysicsTimestep {
+    fn default() -> Self {
+        Self::Fixed(1.0 / 60.0)
+    }
+}
+
+/// How much time the previous physics frame took. The timestep can be configured with the [`PhysicsTimestep`] resource.
+#[derive(Resource, Default)]
+pub(crate) struct DeltaTime(pub Scalar);
+
+/// How much time the previous physics substep took. This depends on the [`DeltaTime`] and [`NumSubsteps`] resources.
+#[derive(Resource, Default)]
+pub(crate) struct SubDeltaTime(pub Scalar);
 
 /// Number of substeps used in XPBD simulation
 #[derive(Resource, Clone, Copy)]
@@ -19,16 +47,6 @@ pub struct NumPosIters(pub u32);
 impl Default for NumPosIters {
     fn default() -> Self {
         Self(4)
-    }
-}
-
-/// Substep delta time
-#[derive(Resource)]
-pub(crate) struct SubDeltaTime(pub Scalar);
-
-impl Default for SubDeltaTime {
-    fn default() -> Self {
-        Self(DELTA_TIME / NumSubsteps::default().0 as Scalar)
     }
 }
 


### PR DESCRIPTION
Closes #5

This makes the physics timestep configurable by introducing the `PhysicsTimestep` enum resource that configures how the value of the new `DeltaTime` resource is computed at each physics frame. Previously the timestep was just hardcoded at `1.0 / 60.0` (which is still the default).

`PhysicsTimestep` currently looks like this:

```rs
pub enum PhysicsTimestep {
    Fixed(Scalar),
    Variable {
        max_dt: Scalar, // Required to make sure objects don't teleport around due to large delta time
    },
}
```

In the future, it could be interesting to also make time scale configurable to allow slowing down and speeding up time.