### PR TITLE
Add `CoefficientCombine` rule for `Restitution` and `Friction`

### DIFF
--- a/crates/bevy_xpbd_2d/examples/move_marbles.rs
+++ b/crates/bevy_xpbd_2d/examples/move_marbles.rs
@@ -106,10 +106,7 @@ fn setup(
                     },
                     ..default()
                 },
-                RigidBodyBundle {
-                    restitution: Restitution(0.3),
-                    ..RigidBodyBundle::new_dynamic().with_pos(pos)
-                },
+                RigidBodyBundle::new_dynamic().with_pos(pos),
                 ColliderBundle::new(&Shape::ball(radius), 1.0),
                 Player,
                 MoveAcceleration(0.5),

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -209,7 +209,7 @@ impl From<Vec3> for ExternalTorque {
 /// When combine rules clash with each other, the following priority order is used: `Max > Multiply > Min > Average`.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub enum CoefficientCombine {
-    // The discriminants allow `PartialEq` and `Eq` to work automatically
+    // The discriminants allow priority ordering to work automatically via comparison methods
     #[default]
     Average = 1,
     Min = 2,

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -567,3 +567,37 @@ impl Default for ColliderAabb {
         ColliderAabb(Aabb::new_invalid())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::prelude::*;
+
+    #[test]
+    fn coefficient_combine_works() {
+        let r1 = Restitution::new(0.3).with_combine_rule(CoefficientCombine::Average);
+
+        // (0.3 + 0.7) / 2.0 == 0.5
+        assert_eq!(
+            r1.combine(Restitution::new(0.7).with_combine_rule(CoefficientCombine::Average)),
+            Restitution::new(0.5).with_combine_rule(CoefficientCombine::Average)
+        );
+
+        // 0.3.min(0.7) == 0.3
+        assert_eq!(
+            r1.combine(Restitution::new(0.7).with_combine_rule(CoefficientCombine::Min)),
+            Restitution::new(0.3).with_combine_rule(CoefficientCombine::Min)
+        );
+
+        // 0.3 * 0.7 == 0.21
+        assert_eq!(
+            r1.combine(Restitution::new(0.7).with_combine_rule(CoefficientCombine::Multiply)),
+            Restitution::new(0.21).with_combine_rule(CoefficientCombine::Multiply)
+        );
+
+        // 0.3.max(0.7) == 0.7
+        assert_eq!(
+            r1.combine(Restitution::new(0.7).with_combine_rule(CoefficientCombine::Max)),
+            Restitution::new(0.7).with_combine_rule(CoefficientCombine::Max)
+        );
+    }
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -204,46 +204,141 @@ impl From<Vec3> for ExternalTorque {
     }
 }
 
+/// Determines how coefficients are combined. The default is `Average`.
+///
+/// When combine rules clash with each other, the following priority order is used: `Max > Multiply > Min > Average`.
+#[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub enum CoefficientCombine {
+    // The discriminants allow `PartialEq` and `Eq` to work automatically
+    #[default]
+    Average = 1,
+    Min = 2,
+    Multiply = 3,
+    Max = 4,
+}
+
 /// 0.0: perfectly inelastic\
 /// 1.0: perfectly elastic\
 /// 2.0: kinetic energy is doubled
-#[derive(Reflect, Clone, Copy, Component, Debug, From)]
+#[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, PartialOrd)]
 #[reflect(Component)]
-pub struct Restitution(pub Scalar);
+pub struct Restitution {
+    pub coefficient: Scalar,
+    pub combine_rule: CoefficientCombine,
+}
+
+impl Restitution {
+    pub const ZERO: Self = Self {
+        coefficient: 0.0,
+        combine_rule: CoefficientCombine::Average,
+    };
+
+    /// Creates a new `Restitution` component with the given restitution coefficient.
+    pub fn new(coefficient: Scalar) -> Self {
+        Self {
+            coefficient,
+            ..default()
+        }
+    }
+
+    pub fn with_combine_rule(&self, combine_rule: CoefficientCombine) -> Self {
+        Self {
+            combine_rule,
+            ..*self
+        }
+    }
+
+    /// Combines the properties of two `Restitution` components.
+    pub fn combine(&self, other: Self) -> Self {
+        // Choose rule with higher priority
+        let rule = self.combine_rule.max(other.combine_rule);
+
+        Self {
+            coefficient: match rule {
+                CoefficientCombine::Average => (self.coefficient + other.coefficient) * 0.5,
+                CoefficientCombine::Min => self.coefficient.min(other.coefficient),
+                CoefficientCombine::Multiply => self.coefficient * other.coefficient,
+                CoefficientCombine::Max => self.coefficient.max(other.coefficient),
+            },
+            combine_rule: rule,
+        }
+    }
+}
 
 impl Default for Restitution {
     fn default() -> Self {
-        Self(0.3)
+        Self {
+            coefficient: 0.3,
+            combine_rule: CoefficientCombine::default(),
+        }
     }
 }
 
 /// 0.0: no friction at all, the body slides infinitely\
 /// 1.0: high friction\
-#[derive(Reflect, Clone, Copy, Component, Debug)]
+#[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, PartialOrd)]
 #[reflect(Component)]
 pub struct Friction {
     pub dynamic_coefficient: Scalar,
     pub static_coefficient: Scalar,
+    pub combine_rule: CoefficientCombine,
 }
 
 impl Friction {
     pub const ZERO: Self = Self {
         dynamic_coefficient: 0.0,
         static_coefficient: 0.0,
+        combine_rule: CoefficientCombine::Average,
     };
 
-    /// Creates a new Friction component with the same dynamic and static friction coefficients.
-    fn new(friction_coefficient: Scalar) -> Self {
+    /// Creates a new `Friction` component with the same dynamic and static friction coefficients.
+    pub fn new(friction_coefficient: Scalar) -> Self {
         Self {
             dynamic_coefficient: friction_coefficient,
             static_coefficient: friction_coefficient,
+            ..default()
+        }
+    }
+
+    pub fn with_combine_rule(&self, combine_rule: CoefficientCombine) -> Self {
+        Self {
+            combine_rule,
+            ..*self
+        }
+    }
+
+    /// Combines the properties of two `Friction` components.
+    pub fn combine(&self, other: Self) -> Self {
+        // Choose rule with higher priority
+        let rule = self.combine_rule.max(other.combine_rule);
+        let (dynamic1, dynamic2) = (self.dynamic_coefficient, other.dynamic_coefficient);
+        let (static1, static2) = (self.static_coefficient, other.static_coefficient);
+
+        Self {
+            dynamic_coefficient: match rule {
+                CoefficientCombine::Average => (dynamic1 + dynamic2) * 0.5,
+                CoefficientCombine::Min => dynamic1.min(dynamic2),
+                CoefficientCombine::Multiply => dynamic1 * dynamic2,
+                CoefficientCombine::Max => dynamic1.max(dynamic2),
+            },
+            static_coefficient: match rule {
+                CoefficientCombine::Average => (static1 + static2) * 0.5,
+                CoefficientCombine::Min => static1.min(static2),
+                CoefficientCombine::Multiply => static1 * static2,
+                CoefficientCombine::Max => static1.max(static2),
+            },
+            combine_rule: rule,
         }
     }
 }
 
 impl Default for Friction {
     fn default() -> Self {
-        Self::new(0.3)
+        Self {
+            dynamic_coefficient: 0.3,
+            static_coefficient: 0.3,
+            combine_rule: CoefficientCombine::default(),
+        }
     }
 }
 

--- a/src/constraints/penetration.rs
+++ b/src/constraints/penetration.rs
@@ -108,13 +108,11 @@ impl PenetrationConstraint {
             sub_dt,
         );
 
-        let static_friction_coefficient =
-            (body1.friction.static_coefficient + body2.friction.static_coefficient) * 0.5;
-
         let lagrange_n = self.normal_lagrange;
         let lagrange_t = self.tangential_lagrange + delta_lagrange_t;
+        let coefficient = body1.friction.combine(*body2.friction).static_coefficient;
 
-        if lagrange_t > static_friction_coefficient * lagrange_n {
+        if lagrange_t > coefficient * lagrange_n {
             let prev_p1 = body1.prev_pos.0 - body1.local_com.0
                 + body1.prev_rot.rotate(self.collision_data.local_r1);
             let prev_p2 = body2.prev_pos.0 - body2.local_com.0

--- a/src/steps/solver.rs
+++ b/src/steps/solver.rs
@@ -261,8 +261,7 @@ fn solve_vel(
             // Compute dynamic friction
             let friction_impulse = get_dynamic_friction(
                 tangent_vel,
-                body1.friction,
-                body2.friction,
+                body1.friction.combine(*body2.friction).dynamic_coefficient,
                 constraint.normal_lagrange,
                 sub_dt.0,
             );
@@ -272,8 +271,7 @@ fn solve_vel(
                 normal,
                 normal_vel,
                 pre_solve_normal_vel,
-                body1.restitution,
-                body2.restitution,
+                body1.restitution.combine(*body2.restitution).coefficient,
                 gravity.0,
                 sub_dt.0,
             );

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,8 +19,7 @@ pub(crate) fn get_rotated_inertia_tensor(inertia_tensor: Matrix3, rot: Quaternio
 /// Calculates velocity correction caused by dynamic friction.
 pub(crate) fn get_dynamic_friction(
     tangent_vel: Vector,
-    friction1: &Friction,
-    friction2: &Friction,
+    coefficient: Scalar,
     normal_lagrange: Scalar,
     sub_dt: Scalar,
 ) -> Vector {
@@ -32,15 +31,11 @@ pub(crate) fn get_dynamic_friction(
         return Vector::ZERO;
     }
 
-    // Average of the bodies' dynamic friction coefficients
-    let dynamic_friction_coefficient =
-        (friction1.dynamic_coefficient + friction2.dynamic_coefficient) * 0.5;
-
     let normal_force = normal_lagrange / sub_dt.powi(2);
 
     // Velocity update caused by dynamic friction, never exceeds the magnitude of the tangential velocity itself
     -tangent_vel / tangent_vel_magnitude
-        * (sub_dt * dynamic_friction_coefficient * normal_force.abs()).min(tangent_vel_magnitude)
+        * (sub_dt * coefficient * normal_force.abs()).min(tangent_vel_magnitude)
 }
 
 /// Calculates velocity correction caused by restitution.
@@ -48,17 +43,14 @@ pub(crate) fn get_restitution(
     normal: Vector,
     normal_vel: Scalar,
     pre_solve_normal_vel: Scalar,
-    restitution1: &Restitution,
-    restitution2: &Restitution,
+    mut coefficient: Scalar,
     gravity: Vector,
     sub_dt: Scalar,
 ) -> Vector {
-    let mut restitution_coefficient = (restitution1.0 + restitution2.0) * 0.5;
-
     // If normal velocity is small enough, use restitution of 0 to avoid jittering
     if normal_vel.abs() <= 2.0 * gravity.length() * sub_dt {
-        restitution_coefficient = 0.0;
+        coefficient = 0.0;
     }
 
-    normal * (-normal_vel + (-restitution_coefficient * pre_solve_normal_vel).min(0.0))
+    normal * (-normal_vel + (-coefficient * pre_solve_normal_vel).min(0.0))
 }


### PR DESCRIPTION
This adds a `CoefficientCombine` enum with the `Average`, `Min`, `Multiply` and `Max` variants, where `Average` has the lowest priority, and `Max` has the highest priority (in case of conflicting combine rules). The default is still `Average` like before.

I would have also added something like `Custom(fn(a: Scalar, b: Scalar) -> Scalar)`, but it would cause issues with `Copy` and `Reflect`, so I left it out.

I also added a couple builder methods and a test for the combine rules.

Combining two `Restitution` components:

```rs
let restitution1 = Restitution::new(0.3).with_combine_rule(CoefficientCombine::Average);
let restitution2 = Restitution::new(0.7).with_combine_rule(CoefficientCombine::Multiply);
let result = Restitution::new(0.21).with_combine_rule(CoefficientCombine::Multiply);

assert_eq!(restitution1.combine(restitution2), result);
```

Friction works similarly, but the same combine rule is currently used for both static and dynamic friction.