### PR TITLE
Update to Bevy 0.10.1

### DIFF
--- a/crates/bevy_xpbd_2d/Cargo.toml
+++ b/crates/bevy_xpbd_2d/Cargo.toml
@@ -18,8 +18,8 @@ path = "../../src/lib.rs"
 required-features = [ "2d" ]
 
 [dependencies]
-bevy = { version = "0.10", default-features = false }
-bevy_prototype_debug_lines = { version = "0.10", optional = true }
+bevy = { version = "0.10.1", default-features = false }
+bevy_prototype_debug_lines = { version = "0.10.1", optional = true }
 parry2d = { version = "0.13.1", optional = true }
 parry2d-f64 = { version = "0.13.1", optional = true }
 nalgebra = { version = "0.32.2", features = [ "convert-glam023" ] }

--- a/crates/bevy_xpbd_3d/Cargo.toml
+++ b/crates/bevy_xpbd_3d/Cargo.toml
@@ -18,8 +18,8 @@ path = "../../src/lib.rs"
 required-features = [ "3d" ]
 
 [dependencies]
-bevy = { version = "0.10", default-features = false }
-bevy_prototype_debug_lines = { version = "0.10", optional = true, features = [ "3d" ] }
+bevy = { version = "0.10.1", default-features = false }
+bevy_prototype_debug_lines = { version = "0.10.1", optional = true, features = [ "3d" ] }
 parry3d = { version = "0.13.1", optional = true }
 parry3d-f64 = { version = "0.13.1", optional = true }
 nalgebra = { version = "0.32.2", features = [ "convert-glam023" ] }

--- a/crates/examples_common_2d/Cargo.toml
+++ b/crates/examples_common_2d/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.10", default-features = false, features = [
+bevy = { version = "0.10.1", default-features = false, features = [
+    "bevy_core_pipeline",
     "bevy_pbr", # todo use sprites instead
     "bevy_winit",
     "x11", # github actions runners don't have libxkbcommon installed, so can't use wayland

--- a/crates/examples_common_3d/Cargo.toml
+++ b/crates/examples_common_3d/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.10", default-features = false, features = [
+bevy = { version = "0.10.1", default-features = false, features = [
+    "bevy_core_pipeline",
     "bevy_pbr",
     "bevy_winit",
     "x11", # github actions runners don't have libxkbcommon installed, so can't use wayland


### PR DESCRIPTION
Updates dependencies to Bevy 0.10.1. This was already done implicitly, but now the patch version is set explicitly to avoid future problems.

It seems like in 0.10.1, the `bevy_core_pipeline` feature is no longer set by the `bevy_pbr` feature, so it must be set explicitly as well.