### PR TITLE
Improved APIs for bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ fn setup(
             ..default()
         },
         RigidBodyBundle::new_static(),
-        ColliderBundle::new(&Shape::cuboid(4.0, 0.001, 4.0), 1.0),
+        ColliderBundle::new(&Shape::cuboid(4.0, 0.001, 4.0)),
     ));
     // Cube
     commands.spawn((
@@ -61,7 +61,7 @@ fn setup(
         RigidBodyBundle::new_dynamic()
             .with_pos(Vec3::Y * 4.0)
             .with_ang_vel(Vec3::new(2.5, 3.4, 1.6)),
-        ColliderBundle::new(&Shape::cuboid(0.5, 0.5, 0.5), 1.0),
+        ColliderBundle::new(&Shape::cuboid(0.5, 0.5, 0.5)),
     ));
     // Light
     commands.spawn(PointLightBundle {

--- a/crates/bevy_xpbd_2d/examples/chain2d.rs
+++ b/crates/bevy_xpbd_2d/examples/chain2d.rs
@@ -88,7 +88,7 @@ fn create_chain(
             .insert(
                 RigidBodyBundle::new_dynamic()
                     .with_pos(Vec2::Y * -(node_size + node_dist) * i as f32)
-                    .with_mass_props_from_shape(&Shape::ball(node_size * 0.5), 1.0),
+                    .with_computed_mass_props(&Shape::ball(node_size * 0.5), 1.0),
             )
             .id();
 

--- a/crates/bevy_xpbd_2d/examples/fixed_joint_2d.rs
+++ b/crates/bevy_xpbd_2d/examples/fixed_joint_2d.rs
@@ -51,7 +51,7 @@ fn setup(
         .insert(
             RigidBodyBundle::new_dynamic()
                 .with_pos(Vec2::X * 1.5)
-                .with_mass_props_from_shape(&Shape::cuboid(0.5, 0.5), 1.0),
+                .with_computed_mass_props(&Shape::cuboid(0.5, 0.5), 1.0),
         )
         .id();
 

--- a/crates/bevy_xpbd_2d/examples/move_marbles.rs
+++ b/crates/bevy_xpbd_2d/examples/move_marbles.rs
@@ -51,7 +51,7 @@ fn setup(
             ..default()
         },
         RigidBodyBundle::new_static().with_pos(Vec2::new(0.0, -7.5)),
-        ColliderBundle::new(&Shape::cuboid(10.0, 0.5), 1.0),
+        ColliderBundle::new(&Shape::cuboid(10.0, 0.5)),
     ));
 
     let _ceiling = commands.spawn((
@@ -62,7 +62,7 @@ fn setup(
             ..default()
         },
         RigidBodyBundle::new_static().with_pos(Vec2::new(0.0, 7.5)),
-        ColliderBundle::new(&Shape::cuboid(10.0, 0.5), 1.0),
+        ColliderBundle::new(&Shape::cuboid(10.0, 0.5)),
     ));
 
     let _left_wall = commands.spawn((
@@ -73,7 +73,7 @@ fn setup(
             ..default()
         },
         RigidBodyBundle::new_static().with_pos(Vec2::new(-9.5, 0.0)),
-        ColliderBundle::new(&Shape::cuboid(0.5, 10.0), 1.0),
+        ColliderBundle::new(&Shape::cuboid(0.5, 10.0)),
     ));
 
     let _right_wall = commands.spawn((
@@ -84,7 +84,7 @@ fn setup(
             ..default()
         },
         RigidBodyBundle::new_static().with_pos(Vec2::new(9.5, 0.0)),
-        ColliderBundle::new(&Shape::cuboid(0.5, 10.0), 1.0),
+        ColliderBundle::new(&Shape::cuboid(0.5, 10.0)),
     ));
 
     let radius = 0.15;
@@ -107,7 +107,7 @@ fn setup(
                     ..default()
                 },
                 RigidBodyBundle::new_dynamic().with_pos(pos),
-                ColliderBundle::new(&Shape::ball(radius), 1.0),
+                ColliderBundle::new(&Shape::ball(radius)),
                 Player,
                 MoveAcceleration(0.5),
                 MaxVelocity(Vec2::new(30.0, 30.0)),

--- a/crates/bevy_xpbd_2d/examples/prismatic_joint_2d.rs
+++ b/crates/bevy_xpbd_2d/examples/prismatic_joint_2d.rs
@@ -51,7 +51,7 @@ fn setup(
         .insert(
             RigidBodyBundle::new_dynamic()
                 .with_pos(Vec2::X * 1.5)
-                .with_mass_props_from_shape(&Shape::cuboid(0.5, 0.5), 1.0),
+                .with_computed_mass_props(&Shape::cuboid(0.5, 0.5), 1.0),
         )
         .id();
 

--- a/crates/bevy_xpbd_2d/examples/revolute_joint_2d.rs
+++ b/crates/bevy_xpbd_2d/examples/revolute_joint_2d.rs
@@ -51,7 +51,7 @@ fn setup(
         .insert(
             RigidBodyBundle::new_dynamic()
                 .with_pos(Vec2::Y * -3.0)
-                .with_mass_props_from_shape(&Shape::cuboid(0.5, 0.5), 1.0),
+                .with_computed_mass_props(&Shape::cuboid(0.5, 0.5), 1.0),
         )
         .id();
 

--- a/crates/bevy_xpbd_3d/examples/chain3d.rs
+++ b/crates/bevy_xpbd_3d/examples/chain3d.rs
@@ -42,10 +42,11 @@ fn setup(
             ..default()
         })
         .insert(RigidBodyBundle::new_static().with_pos(Vec3::new(0.0, -18.0, 0.0)))
-        .insert(ColliderBundle::new(
-            &Shape::cuboid(floor_size.x * 0.5, floor_size.y * 0.5, floor_size.z * 0.5),
-            1.0,
-        ));
+        .insert(ColliderBundle::new(&Shape::cuboid(
+            floor_size.x * 0.5,
+            floor_size.y * 0.5,
+            floor_size.z * 0.5,
+        )));
 
     // Rope
     create_chain(

--- a/crates/bevy_xpbd_3d/examples/chain3d.rs
+++ b/crates/bevy_xpbd_3d/examples/chain3d.rs
@@ -144,7 +144,7 @@ fn create_chain(
             .insert(
                 RigidBodyBundle::new_dynamic()
                     .with_pos(start_pos + delta_pos * i as f32)
-                    .with_mass_props_from_shape(&Shape::ball(node_size * 0.5), 1.0),
+                    .with_computed_mass_props(&Shape::ball(node_size * 0.5), 1.0),
             )
             .id();
 

--- a/crates/bevy_xpbd_3d/examples/cubes.rs
+++ b/crates/bevy_xpbd_3d/examples/cubes.rs
@@ -37,10 +37,11 @@ fn setup(
             ..default()
         })
         .insert(RigidBodyBundle::new_static().with_pos(Vec3::new(0.0, -1.0, 0.0)))
-        .insert(ColliderBundle::new(
-            &Shape::cuboid(floor_size.x * 0.5, floor_size.y * 0.5, floor_size.z * 0.5),
-            1.0,
-        ));
+        .insert(ColliderBundle::new(&Shape::cuboid(
+            floor_size.x * 0.5,
+            floor_size.y * 0.5,
+            floor_size.z * 0.5,
+        )));
 
     let radius = 1.0;
     let count_x = 4;
@@ -65,10 +66,7 @@ fn setup(
                         ..default()
                     })
                     .insert(RigidBodyBundle::new_dynamic().with_pos(pos + Vec3::Y * 5.0))
-                    .insert(ColliderBundle::new(
-                        &Shape::cuboid(radius, radius, radius),
-                        1.0,
-                    ))
+                    .insert(ColliderBundle::new(&Shape::cuboid(radius, radius, radius)))
                     .insert(Player)
                     .insert(MoveAcceleration(0.1))
                     .insert(MaxLinearVelocity(Vec3::new(30.0, 30.0, 30.0)));

--- a/crates/bevy_xpbd_3d/examples/cubes_f64.rs
+++ b/crates/bevy_xpbd_3d/examples/cubes_f64.rs
@@ -37,10 +37,11 @@ fn setup(
             ..default()
         })
         .insert(RigidBodyBundle::new_static().with_pos(DVec3::new(0.0, -1.0, 0.0)))
-        .insert(ColliderBundle::new(
-            &Shape::cuboid(floor_size.x * 0.5, floor_size.y * 0.5, floor_size.z * 0.5),
-            1.0,
-        ));
+        .insert(ColliderBundle::new(&Shape::cuboid(
+            floor_size.x * 0.5,
+            floor_size.y * 0.5,
+            floor_size.z * 0.5,
+        )));
 
     let radius = 1.0;
     let count_x = 4;
@@ -65,10 +66,7 @@ fn setup(
                         ..default()
                     })
                     .insert(RigidBodyBundle::new_dynamic().with_pos(pos + DVec3::Y * 5.0))
-                    .insert(ColliderBundle::new(
-                        &Shape::cuboid(radius, radius, radius),
-                        1.0,
-                    ))
+                    .insert(ColliderBundle::new(&Shape::cuboid(radius, radius, radius)))
                     .insert(Player)
                     .insert(MoveAcceleration(0.1))
                     .insert(MaxLinearVelocity(DVec3::new(30.0, 30.0, 30.0)));

--- a/crates/bevy_xpbd_3d/examples/fixed_joint_3d.rs
+++ b/crates/bevy_xpbd_3d/examples/fixed_joint_3d.rs
@@ -50,7 +50,7 @@ fn setup(
         .insert(
             RigidBodyBundle::new_dynamic()
                 .with_pos(Vec3::X * 1.5)
-                .with_mass_props_from_shape(&Shape::cuboid(0.5, 0.5, 0.5), 1.0),
+                .with_computed_mass_props(&Shape::cuboid(0.5, 0.5, 0.5), 1.0),
         )
         .id();
 

--- a/crates/bevy_xpbd_3d/examples/prismatic_joint_3d.rs
+++ b/crates/bevy_xpbd_3d/examples/prismatic_joint_3d.rs
@@ -50,7 +50,7 @@ fn setup(
         .insert(
             RigidBodyBundle::new_dynamic()
                 .with_pos(Vec3::X * 1.5)
-                .with_mass_props_from_shape(&Shape::cuboid(0.5, 0.5, 0.5), 1.0),
+                .with_computed_mass_props(&Shape::cuboid(0.5, 0.5, 0.5), 1.0),
         )
         .id();
 

--- a/crates/bevy_xpbd_3d/examples/revolute_joint_3d.rs
+++ b/crates/bevy_xpbd_3d/examples/revolute_joint_3d.rs
@@ -50,7 +50,7 @@ fn setup(
         .insert(
             RigidBodyBundle::new_dynamic()
                 .with_pos(Vec3::Y * -3.0)
-                .with_mass_props_from_shape(&Shape::cuboid(0.5, 0.5, 0.5), 1.0),
+                .with_computed_mass_props(&Shape::cuboid(0.5, 0.5, 0.5), 1.0),
         )
         .id();
 

--- a/crates/bevy_xpbd_3d/examples/rolling_balls.rs
+++ b/crates/bevy_xpbd_3d/examples/rolling_balls.rs
@@ -44,10 +44,11 @@ fn setup(
             ..default()
         })
         .insert(RigidBodyBundle::new_static().with_pos(Vec3::new(0.0, -5.0, 0.0)))
-        .insert(ColliderBundle::new(
-            &Shape::cuboid(floor_size.x * 0.5, floor_size.y * 0.5, floor_size.z * 0.5),
-            1.0,
-        ));
+        .insert(ColliderBundle::new(&Shape::cuboid(
+            floor_size.x * 0.5,
+            floor_size.y * 0.5,
+            floor_size.z * 0.5,
+        )));
 
     let radius = 0.5;
     let count_x = 1;
@@ -73,7 +74,7 @@ fn setup(
                         ..default()
                     })
                     .insert(RigidBodyBundle::new_dynamic().with_pos(pos))
-                    .insert(ColliderBundle::new(&Shape::ball(radius), 1.0))
+                    .insert(ColliderBundle::new(&Shape::ball(radius)))
                     .insert(Player)
                     .insert(RollAcceleration(Vec3::splat(0.5)))
                     .insert(MaxAngularVelocity(Vec3::new(30.0, 30.0, 30.0)));

--- a/src/bundles.rs
+++ b/src/bundles.rs
@@ -24,7 +24,7 @@ use bevy::prelude::*;
 ///         .with_rot(Quat::from_rotation_x(2.1))
 ///         .with_lin_vel(Vec3::new(0.0, 4.5, 0.0))
 ///         .with_ang_vel(Vec3::new(2.5, 3.4, 1.6))
-///         .with_mass_props_from_shape(&Shape::cuboid(0.5, 0.5, 0.5), 1.0),
+///         .with_computed_mass_props(&Shape::cuboid(0.5, 0.5, 0.5), 1.0),
 /// );
 /// ```
 #[derive(Bundle, Default)]
@@ -156,7 +156,7 @@ impl RigidBodyBundle {
     /// Sets the mass properties of a rigid body by computing the [`ColliderMassProperties`] that a given [`ColliderShape`] would have with a given density.
     ///
     /// For the affected mass properties, see [`Mass`], [`InvMass`], [`Inertia`], [`InvInertia`] and [`LocalCom`].
-    pub fn with_mass_props_from_shape(self, shape: &Shape, density: Scalar) -> Self {
+    pub fn with_computed_mass_props(self, shape: &Shape, density: Scalar) -> Self {
         let ColliderMassProperties {
             mass,
             inv_mass,

--- a/src/bundles.rs
+++ b/src/bundles.rs
@@ -188,16 +188,22 @@ pub struct ColliderBundle {
 }
 
 impl ColliderBundle {
-    /// Creates a new [`ColliderBundle`] from a given [`Shape`] and density.
-    pub fn new(shape: &Shape, density: Scalar) -> Self {
-        let aabb = ColliderAabb::from_shape(shape);
-        let mass_props = ColliderMassProperties::from_shape_and_density(shape, density);
-
+    /// Creates a new [`ColliderBundle`] from a given [`Shape`] with a default density of 1.
+    pub fn new(shape: &Shape) -> Self {
         Self {
             collider_shape: ColliderShape(shape.to_owned()),
-            collider_aabb: aabb,
-            mass_props,
+            collider_aabb: ColliderAabb::from_shape(shape),
+            mass_props: ColliderMassProperties::from_shape_and_density(shape, 1.0),
             prev_mass_props: PrevColliderMassProperties(ColliderMassProperties::ZERO),
+        }
+    }
+    /// Sets the collider's mass properties computed from a given density.
+    pub fn with_density(self, density: Scalar) -> Self {
+        let shape = &self.collider_shape;
+        Self {
+            mass_props: ColliderMassProperties::from_shape_and_density(shape, density),
+            prev_mass_props: PrevColliderMassProperties(self.mass_props),
+            ..self
         }
     }
 }

--- a/src/bundles.rs
+++ b/src/bundles.rs
@@ -107,6 +107,52 @@ impl RigidBodyBundle {
         Self { ang_vel, ..self }
     }
 
+    /// Sets the restitution of a rigid body. See [`Restitution`].
+    pub fn with_restitution(self, restitution: impl Into<Restitution>) -> Self {
+        let restitution = restitution.into();
+        Self {
+            restitution,
+            ..self
+        }
+    }
+
+    /// Sets the friction of a rigid body. See [`Friction`].
+    pub fn with_friction(self, friction: impl Into<Friction>) -> Self {
+        let friction = friction.into();
+        Self { friction, ..self }
+    }
+
+    /// Sets the mass of a rigid body. See [`Mass`].
+    pub fn with_mass(self, mass: impl Into<Mass>) -> Self {
+        let mass = mass.into();
+        let inv_mass = InvMass(1.0 / mass.0);
+        Self {
+            mass,
+            inv_mass,
+            ..self
+        }
+    }
+
+    /// Sets the moment of inertia of a rigid body. See [`Inertia`].
+    pub fn with_inertia(self, inertia: impl Into<Inertia>) -> Self {
+        let inertia = inertia.into();
+        let inv_inertia = inertia.inverse();
+        Self {
+            inertia,
+            inv_inertia,
+            ..self
+        }
+    }
+
+    /// Sets the local center of mass of a rigid body. See [`LocalCom`].
+    pub fn with_local_center_of_mass(self, local_center_of_mass: impl Into<LocalCom>) -> Self {
+        let local_center_of_mass = local_center_of_mass.into();
+        Self {
+            local_center_of_mass,
+            ..self
+        }
+    }
+
     /// Sets the mass properties of a rigid body by computing the [`ColliderMassProperties`] that a given [`ColliderShape`] would have with a given density.
     ///
     /// For the affected mass properties, see [`Mass`], [`InvMass`], [`Inertia`], [`InvInertia`] and [`LocalCom`].

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -275,6 +275,15 @@ impl Default for Restitution {
     }
 }
 
+impl From<Scalar> for Restitution {
+    fn from(coefficient: Scalar) -> Self {
+        Self {
+            coefficient,
+            ..default()
+        }
+    }
+}
+
 /// Friction prevents relative tangential movement at contact points.
 ///
 /// For surfaces that are at rest relative to each other, static friction is used. Once it is overcome, the bodies start sliding relative to each other, and dynamic friction is applied instead.
@@ -347,6 +356,16 @@ impl Default for Friction {
             dynamic_coefficient: 0.3,
             static_coefficient: 0.3,
             combine_rule: CoefficientCombine::default(),
+        }
+    }
+}
+
+impl From<Scalar> for Friction {
+    fn from(coefficient: Scalar) -> Self {
+        Self {
+            dynamic_coefficient: coefficient,
+            static_coefficient: coefficient,
+            ..default()
         }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -45,10 +45,11 @@ fn setup_cubes_simulation(mut commands: Commands) {
     let floor_size = Vector::new(80.0, 1.0, 80.0);
     commands.spawn((
         RigidBodyBundle::new_static().with_pos(Vector::new(0.0, -1.0, 0.0)),
-        ColliderBundle::new(
-            &Shape::cuboid(floor_size.x * 0.5, floor_size.y * 0.5, floor_size.z * 0.5),
-            1.0,
-        ),
+        ColliderBundle::new(&Shape::cuboid(
+            floor_size.x * 0.5,
+            floor_size.y * 0.5,
+            floor_size.z * 0.5,
+        )),
     ));
 
     let radius = 1.0;
@@ -66,7 +67,7 @@ fn setup_cubes_simulation(mut commands: Commands) {
                 commands.spawn((
                     SpatialBundle::default(),
                     RigidBodyBundle::new_dynamic().with_pos(pos + Vector::Y * 5.0),
-                    ColliderBundle::new(&Shape::cuboid(radius, radius, radius), 1.0),
+                    ColliderBundle::new(&Shape::cuboid(radius, radius, radius)),
                     Id(next_id),
                 ));
                 next_id += 1;


### PR DESCRIPTION
This mainly adds more builder methods for `RigidBodyBundle`. Restitution and friction now also implement `From<Scalar>`, so you can do things like `.with_friction(0.5)` instead of having to pass the entire struct to the method.

`ColliderBundle::new()` now only takes a collider shape, and a default density of 1 is used. To specify the density manually, you can use `.with_density()`.