### PR TITLE
Add ergonomic rigid body and collider initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ fn setup(
             material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
             ..default()
         },
-        RigidBodyBundle::new_static(),
-        ColliderBundle::new(&Shape::cuboid(4.0, 0.001, 4.0)),
+        RigidBody::Static,
+        ColliderShape(&Shape::cuboid(4.0, 0.001, 4.0)),
     ));
     // Cube
     commands.spawn((
@@ -58,10 +58,10 @@ fn setup(
             material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
             ..default()
         },
-        RigidBodyBundle::new_dynamic()
-            .with_pos(Vec3::Y * 4.0)
-            .with_ang_vel(Vec3::new(2.5, 3.4, 1.6)),
-        ColliderBundle::new(&Shape::cuboid(0.5, 0.5, 0.5)),
+        RigidBody::Dynamic,
+        Pos(Vec3::Y * 4.0),
+        AngVel(Vec3::new(2.5, 3.4, 1.6)),
+        ColliderShape(&Shape::cuboid(0.5, 0.5, 0.5)),
     ));
     // Light
     commands.spawn(PointLightBundle {

--- a/src/components/rotation.rs
+++ b/src/components/rotation.rs
@@ -202,6 +202,14 @@ impl From<Rot> for Quaternion {
     }
 }
 
+#[cfg(feature = "2d")]
+impl From<Quaternion> for Rot {
+    fn from(quat: Quat) -> Self {
+        let angle = quat.to_euler(EulerRot::XYZ).2;
+        Rot::from_radians(angle)
+    }
+}
+
 #[cfg(feature = "3d")]
 impl From<Rot> for Matrix3x1<Scalar> {
     fn from(rot: Rot) -> Self {

--- a/src/plugins/prepare.rs
+++ b/src/plugins/prepare.rs
@@ -8,11 +8,196 @@ pub struct PreparePlugin;
 
 impl Plugin for PreparePlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
+        app.configure_set(ComponentInitSet.in_set(PhysicsSet::Prepare));
+
         app.get_schedule_mut(PhysicsSchedule)
             .expect("add PhysicsSchedule first")
             .add_systems(
-                (update_aabb, update_mass_props.after(update_aabb)).in_set(PhysicsSet::Prepare),
+                (init_rigid_bodies, init_mass_props, init_colliders).in_set(ComponentInitSet),
+            )
+            .add_systems(
+                (update_aabb, update_mass_props)
+                    .chain()
+                    .after(ComponentInitSet)
+                    .in_set(PhysicsSet::Prepare),
             );
+    }
+}
+
+#[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct ComponentInitSet;
+
+type RigidBodyComponents = (
+    Entity,
+    // Use transform as default position and rotation if no components for them found
+    Option<&'static mut Transform>,
+    Option<&'static Pos>,
+    Option<&'static Rot>,
+    Option<&'static LinVel>,
+    Option<&'static AngVel>,
+    Option<&'static ExternalForce>,
+    Option<&'static ExternalTorque>,
+    Option<&'static Restitution>,
+    Option<&'static Friction>,
+    Option<&'static TimeSleeping>,
+);
+
+fn init_rigid_bodies(
+    mut commands: Commands,
+    mut bodies: Query<RigidBodyComponents, Added<RigidBody>>,
+) {
+    for (
+        entity,
+        mut transform,
+        pos,
+        rot,
+        lin_vel,
+        ang_vel,
+        force,
+        torque,
+        restitution,
+        friction,
+        time_sleeping,
+    ) in &mut bodies
+    {
+        let mut body = commands.entity(entity);
+
+        if let Some(pos) = pos {
+            body.insert(PrevPos(pos.0));
+
+            if let Some(ref mut transform) = transform {
+                #[cfg(feature = "2d")]
+                {
+                    transform.translation = pos.extend(0.0).as_vec3_f32();
+                }
+                #[cfg(feature = "3d")]
+                {
+                    transform.translation = pos.as_vec3_f32();
+                }
+            }
+        } else {
+            let translation;
+            #[cfg(feature = "2d")]
+            {
+                translation = transform.as_ref().map_or(Vector::ZERO, |t| {
+                    Vector::new(t.translation.x as Scalar, t.translation.y as Scalar)
+                });
+            }
+            #[cfg(feature = "3d")]
+            {
+                translation = transform.as_ref().map_or(Vector::ZERO, |t| {
+                    Vector::new(
+                        t.translation.x as Scalar,
+                        t.translation.y as Scalar,
+                        t.translation.z as Scalar,
+                    )
+                });
+            }
+
+            body.insert(Pos(translation));
+            body.insert(PrevPos(translation));
+        }
+
+        if let Some(rot) = rot {
+            body.insert(PrevRot(*rot));
+
+            if let Some(mut transform) = transform {
+                let q: Quaternion = (*rot).into();
+                transform.rotation = q.as_quat_f32();
+            }
+        } else {
+            let rotation = transform.map_or(Rot::default(), |t| t.rotation.into());
+            body.insert(rotation);
+            body.insert(PrevRot(rotation));
+        }
+
+        if lin_vel.is_none() {
+            body.insert(LinVel::default());
+        }
+        body.insert(PreSolveLinVel::default());
+        if ang_vel.is_none() {
+            body.insert(AngVel::default());
+        }
+        body.insert(PreSolveAngVel::default());
+        if force.is_none() {
+            body.insert(ExternalForce::default());
+        }
+        if torque.is_none() {
+            body.insert(ExternalTorque::default());
+        }
+        if restitution.is_none() {
+            body.insert(Restitution::default());
+        }
+        if friction.is_none() {
+            body.insert(Friction::default());
+        }
+        if time_sleeping.is_none() {
+            body.insert(TimeSleeping::default());
+        }
+    }
+}
+
+type MassPropComponents = (
+    Entity,
+    Option<&'static Mass>,
+    Option<&'static InvMass>,
+    Option<&'static Inertia>,
+    Option<&'static InvInertia>,
+    Option<&'static LocalCom>,
+);
+type MassPropComponentsQueryFilter = Or<(Added<RigidBody>, Added<ColliderShape>)>;
+
+fn init_mass_props(
+    mut commands: Commands,
+    mass_props: Query<MassPropComponents, MassPropComponentsQueryFilter>,
+) {
+    for (entity, mass, inv_mass, inertia, inv_inertia, local_com) in &mass_props {
+        let mut body = commands.entity(entity);
+
+        if mass.is_none() {
+            body.insert(Mass::default());
+            body.insert(InvMass::default());
+        }
+        if inv_mass.is_none() {
+            body.insert(InvMass(1.0 / mass.cloned().unwrap_or_default().0));
+        }
+        if inertia.is_none() {
+            body.insert(Inertia::default());
+            body.insert(InvInertia::default());
+        }
+        if inv_inertia.is_none() {
+            body.insert(inertia.cloned().unwrap_or_default().inverse());
+        }
+        if local_com.is_none() {
+            body.insert(LocalCom::default());
+        }
+    }
+}
+
+type ColliderComponents = (
+    Entity,
+    &'static ColliderShape,
+    Option<&'static ColliderAabb>,
+    Option<&'static ColliderMassProperties>,
+    Option<&'static PrevColliderMassProperties>,
+);
+
+fn init_colliders(
+    mut commands: Commands,
+    colliders: Query<ColliderComponents, Added<ColliderShape>>,
+) {
+    for (entity, shape, aabb, mass_props, prev_mass_props) in &colliders {
+        let mut collider = commands.entity(entity);
+
+        if aabb.is_none() {
+            collider.insert(ColliderAabb::from_shape(shape));
+        }
+        if mass_props.is_none() {
+            collider.insert(ColliderMassProperties::from_shape_and_density(shape, 1.0));
+        }
+        if prev_mass_props.is_none() {
+            collider.insert(PrevColliderMassProperties(ColliderMassProperties::ZERO));
+        }
     }
 }
 


### PR DESCRIPTION
Currently, rigid bodies are created using the various methods in `RigidBodyBundle`. This PR makes it possible to just add a `RigidBody` component, and missing components will be automatically added. This is very similar to the way `bevy_rapier` and the discontinued `heron` handle body instancing.

This is (in my opinion) more ergonomic than using bundles, and it also allows things like setting `Pos` and `Rot` to use `Transform` for default values. Many people might also expect adding a `RigidBody` to be enough, and initializing the missing components helps prevent these issues.

I also implemented this for colliders, so adding a `ColliderShape` instead of a `ColliderBundle` is enough.

## Example

Previously:

```rust
commands.spawn((
    RigidBodyBundle::new_dynamic()
        .with_pos(Vec3::Y * 2.0)
        .with_lin_vel(Vec3::X * 5.0),
    ColliderBundle::new(&Shape::ball(0.5)),
));
```

Now:

```rust
commands.spawn((
    RigidBody::Dynamic,
    Pos(Vec3::Y * 2.0),
    LinVel(Vec3::X * 5.0),
    ColliderShape(&Shape::ball(0.5)),
));
```

If `Pos` or `Rot` aren't specified, they will get their default values from the entity's `Transform` if it has one.

I'm also implementing nicer collider's, so instead of `ColliderShape(&Shape::ball(0.5))` you can just use `Collider::ball(0.5)`. This is on the `collider-ergonomics` branch and will have a PR soon.

## Todo

- [ ] Remove the bundles?
- [ ] Update examples