### PR TITLE
Add `CollisionLayers`

### DIFF
--- a/crates/bevy_xpbd_2d/Cargo.toml
+++ b/crates/bevy_xpbd_2d/Cargo.toml
@@ -18,6 +18,7 @@ path = "../../src/lib.rs"
 required-features = [ "2d" ]
 
 [dependencies]
+bevy_xpbd_derive = { path = "../bevy_xpbd_derive" }
 bevy = { version = "0.10.1", default-features = false }
 bevy_prototype_debug_lines = { version = "0.10.1", optional = true }
 parry2d = { version = "0.13.1", optional = true }

--- a/crates/bevy_xpbd_3d/Cargo.toml
+++ b/crates/bevy_xpbd_3d/Cargo.toml
@@ -18,6 +18,7 @@ path = "../../src/lib.rs"
 required-features = [ "3d" ]
 
 [dependencies]
+bevy_xpbd_derive = { path = "../bevy_xpbd_derive" }
 bevy = { version = "0.10.1", default-features = false }
 bevy_prototype_debug_lines = { version = "0.10.1", optional = true, features = [ "3d" ] }
 parry3d = { version = "0.13.1", optional = true }

--- a/crates/bevy_xpbd_derive/Cargo.toml
+++ b/crates/bevy_xpbd_derive/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "bevy_xpbd_derive"
+version = "0.1.0"
+edition = "2021"
+description = "Provides derive implementations for Bevy XPBD"
+repository = "https://github.com/Jondolf/bevy_xpbd"
+license = "MIT OR Apache-2.0"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1.0"
+syn = "2.0"

--- a/crates/bevy_xpbd_derive/README.md
+++ b/crates/bevy_xpbd_derive/README.md
@@ -1,0 +1,1 @@
+This crate provides some derive implementation for Bevy XPBD.

--- a/crates/bevy_xpbd_derive/src/lib.rs
+++ b/crates/bevy_xpbd_derive/src/lib.rs
@@ -1,0 +1,58 @@
+//! Provides derive implementations for Bevy XPBD.
+
+use proc_macro::TokenStream;
+
+use quote::quote;
+use syn::{parse_macro_input, Data, DeriveInput};
+
+// Modified macro From the discontinued Heron,
+// see https://github.com/jcornaz/heron/blob/main/macros/src/lib.rs
+#[proc_macro_derive(PhysicsLayer)]
+pub fn derive_physics_layer(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let enum_ident = input.ident;
+
+    let variants = match &input.data {
+        Data::Enum(data) => &data.variants,
+        _ => panic!("Only enums can automatically derive PhysicsLayer"),
+    };
+
+    assert!(variants.len() <= 32, "Reached the maximum of 32 layers");
+
+    let to_bits = variants.iter().enumerate().map(|(index, variant)| {
+        let bits: u32 = 1 << index;
+        assert!(
+            variant.fields.is_empty(),
+            "Can only derive PhysicsLayer for enums without fields"
+        );
+        let ident = &variant.ident;
+        quote! { #enum_ident::#ident => #bits, }
+    });
+
+    let all_bits: u32 = if variants.len() == 32 {
+        0xffffffff
+    } else {
+        (1 << variants.len()) - 1
+    };
+
+    let expanded = quote! {
+        #[cfg(feature = "2d")]
+        use bevy_xpbd_2d::prelude::PhysicsLayer;
+        #[cfg(feature = "3d")]
+        use bevy_xpbd_3d::prelude::PhysicsLayer;
+
+        impl PhysicsLayer for #enum_ident {
+            fn all_bits() -> u32 {
+                #all_bits
+            }
+
+            fn to_bits(&self) -> u32 {
+                match self {
+                    #(#to_bits)*
+                }
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}

--- a/src/components/layers.rs
+++ b/src/components/layers.rs
@@ -47,9 +47,9 @@ impl<L: PhysicsLayer> PhysicsLayer for &L {
 ///
 /// ## Example
 ///
-/// ```
+/// ```ignore
 /// use bevy::prelude::*;
-/// use bevy_xpbd::prelude::*;
+/// use bevy_xpbd::prelude::*; // 2D or 3D
 ///
 /// #[derive(PhysicsLayer)]
 /// enum Layer {

--- a/src/components/layers.rs
+++ b/src/components/layers.rs
@@ -62,7 +62,7 @@ impl<L: PhysicsLayer> PhysicsLayer for &L {
 ///     commands.spawn((
 ///         Collider::ball(0.5),
 ///         // Player collides with enemies and the ground, but not with other players
-///         CollisionLayers::new(&[Layer::Player], &[Layer::Enemy, Layer::Ground])
+///         CollisionLayers::new([Layer::Player], [Layer::Enemy, Layer::Ground])
 ///     ));
 /// }
 /// ```

--- a/src/components/layers.rs
+++ b/src/components/layers.rs
@@ -1,0 +1,190 @@
+use bevy::prelude::*;
+
+/// A layer used for determining which entities should interact with each other.
+/// Physics layers are used heavily by [`CollisionLayers`].
+///
+/// This trait can be derived for enums with `#[derive(PhysicsLayer)]`.
+pub trait PhysicsLayer: Sized {
+    fn to_bits(&self) -> u32;
+    fn all_bits() -> u32;
+}
+
+impl<L: PhysicsLayer> PhysicsLayer for &L {
+    fn to_bits(&self) -> u32 {
+        L::to_bits(self)
+    }
+
+    fn all_bits() -> u32 {
+        L::all_bits()
+    }
+}
+
+/// Defines the collision layers of a collider using *groups* and *masks*.
+///
+/// **Groups** indicate what layers the collider is a part of.\
+/// **Masks** indicate what layers the collider can interact with.
+///
+/// Two colliders `A` and `B` can interact if and only if:
+///
+/// - The groups of `A` contain a layer that is also in the masks of `B`
+/// - The groups of `B` contain a layer that is also in the masks of `A`
+///
+/// Colliders without this component can be considered as having all groups and masks, and they can
+/// interact with everything that belongs on any layer.
+///
+/// ## Creating [`CollisionLayers`]
+///
+/// The easiest way to build a [`CollisionLayers`] configuration is to use the [`CollisionLayers::new()`](#method.new) method
+/// that takes in a list of groups and masks. Additional groups and masks can be added and removed by calling methods like
+/// [`with_groups`](#method.with_groups), [`with_masks`](#method.with_masks), [`without_groups`](#method.without_groups) and
+/// [`without_masks`](#method.without_masks).
+///
+/// These methods require the layers to implement [`PhysicsLayer`]. The easiest way to define the physics layers is to
+/// create an enum with `#[derive(PhysicsLayer)]`.
+///
+/// Internally, the groups and masks are represented as bitmasks, so you can also use [`CollisionLayers::from_bits()`](#method.from_bits)
+/// to create collision layers.
+///
+/// ## Example
+///
+/// ```
+/// use bevy::prelude::*;
+/// use bevy_xpbd::prelude::*;
+///
+/// #[derive(PhysicsLayer)]
+/// enum Layer {
+///     Player,
+///     Enemy,
+///     Ground,
+/// }
+///
+/// fn spawn(mut commands: Commands) {
+///     commands.spawn((
+///         Collider::ball(0.5),
+///         // Player collides with enemies and the ground, but not with other players
+///         CollisionLayers::new(&[Layer::Player], &[Layer::Enemy, Layer::Ground])
+///     ));
+/// }
+/// ```
+#[derive(Reflect, Clone, Copy, Component, Debug, PartialEq)]
+#[reflect(Component)]
+pub struct CollisionLayers {
+    groups: u32,
+    masks: u32,
+}
+
+impl CollisionLayers {
+    /// Creates a new [`CollisionLayers`] configuration with the given collision groups and masks.
+    pub fn new<L: PhysicsLayer>(
+        groups: impl IntoIterator<Item = L>,
+        masks: impl IntoIterator<Item = L>,
+    ) -> Self {
+        Self::none().with_groups(groups).with_masks(masks)
+    }
+
+    /// Contains all groups and masks.
+    pub fn all<L: PhysicsLayer>() -> Self {
+        Self::from_bits(L::all_bits(), L::all_bits())
+    }
+
+    /// Contains all groups but no masks.
+    pub fn all_groups<L: PhysicsLayer>() -> Self {
+        Self::from_bits(L::all_bits(), 0)
+    }
+
+    /// Contains all masks but no groups.
+    pub fn all_masks<L: PhysicsLayer>() -> Self {
+        Self::from_bits(0, L::all_bits())
+    }
+
+    /// Contains no masks or groups.
+    pub const fn none() -> Self {
+        Self::from_bits(0, 0)
+    }
+
+    /// Creates a new [`CollisionLayers`] using bits.
+    ///
+    /// There is one bit per group and mask, so there are a total of 32 layers.
+    /// For example, if an entity is a part of the layers `[0, 1, 3]` and can interact with the layers `[1, 2]`,
+    /// the groups in bits would be `0b01011` while the masks would be `0b00110`.
+    pub const fn from_bits(groups: u32, masks: u32) -> Self {
+        Self { groups, masks }
+    }
+
+    /// Returns true if an entity with this [`CollisionLayers`] configuration
+    /// can interact with an entity with the `other` [`CollisionLayers`] configuration.
+    pub fn interacts_with(self, other: Self) -> bool {
+        (self.groups & other.masks) != 0 && (other.groups & self.masks) != 0
+    }
+
+    /// Returns true if the given layer is contained in `groups`.
+    pub fn contains_group(self, layer: impl PhysicsLayer) -> bool {
+        (self.groups & layer.to_bits()) != 0
+    }
+
+    /// Adds the given layer into `groups`.
+    pub fn with_group(mut self, layer: impl PhysicsLayer) -> Self {
+        self.groups |= layer.to_bits();
+        self
+    }
+
+    /// Adds the given layers into `groups`.
+    pub fn with_groups(mut self, layers: impl IntoIterator<Item = impl PhysicsLayer>) -> Self {
+        for layer in layers.into_iter().map(|l| l.to_bits()) {
+            self.groups |= layer;
+        }
+
+        self
+    }
+
+    /// Removes the given layer from `groups`.
+    pub fn without_group(mut self, layer: impl PhysicsLayer) -> Self {
+        self.groups &= !layer.to_bits();
+        self
+    }
+
+    /// Returns true if the given layer is contained in `masks`.
+    pub fn contains_mask(self, layer: impl PhysicsLayer) -> bool {
+        (self.masks & layer.to_bits()) != 0
+    }
+
+    /// Adds the given layer into `masks`.
+    pub fn with_mask(mut self, layer: impl PhysicsLayer) -> Self {
+        self.masks |= layer.to_bits();
+        self
+    }
+
+    /// Adds the given layers in `masks`.
+    pub fn with_masks(mut self, layers: impl IntoIterator<Item = impl PhysicsLayer>) -> Self {
+        for layer in layers.into_iter().map(|l| l.to_bits()) {
+            self.masks |= layer;
+        }
+
+        self
+    }
+
+    /// Removes the given layer from `masks`.
+    pub fn without_mask(mut self, layer: impl PhysicsLayer) -> Self {
+        self.masks &= !layer.to_bits();
+        self
+    }
+
+    /// Returns the `groups` bitmask.
+    pub fn groups_bits(self) -> u32 {
+        self.groups
+    }
+
+    /// Returns the `masks` bitmask.
+    pub fn masks_bits(self) -> u32 {
+        self.masks
+    }
+}
+
+impl Default for CollisionLayers {
+    fn default() -> Self {
+        Self {
+            groups: 0xffff_ffff,
+            masks: 0xffff_ffff,
+        }
+    }
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,11 +1,13 @@
 //! Components used for rigid bodies, colliders and mass properties.
 
 mod collider;
+mod layers;
 mod mass_props;
 mod rotation;
 mod world_queries;
 
 pub use collider::*;
+pub use layers::*;
 pub use mass_props::*;
 pub use rotation::*;
 pub use world_queries::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ pub mod prelude {
         resources::*,
         *,
     };
+    pub use bevy_xpbd_derive::*;
 }
 pub use prelude::setup::{pause, resume};
 

--- a/src/plugins/solver.rs
+++ b/src/plugins/solver.rs
@@ -79,6 +79,7 @@ pub struct PenetrationConstraints(pub Vec<PenetrationConstraint>);
 
 /// Iterates through broad phase collision pairs, checks which ones are actually colliding, and uses [`PenetrationConstraint`]s to resolve the collisions.
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::type_complexity)]
 fn penetration_constraints(
     mut commands: Commands,
     mut bodies: Query<(
@@ -105,7 +106,7 @@ fn penetration_constraints(
         if let Ok([bundle1, bundle2]) = bodies.get_many_mut([*ent1, *ent2]) {
             let (mut body1, collider1, layers1, colliding_entities1, sleeping1) = bundle1;
             let (mut body2, collider2, layers2, colliding_entities2, sleeping2) = bundle2;
-          
+
             let layers1 = layers1.map_or(CollisionLayers::default(), |l| *l);
             let layers2 = layers2.map_or(CollisionLayers::default(), |l| *l);
 


### PR DESCRIPTION
This adds collision filtering in the form of a `CollisionLayers` component that contains collision groups and masks. The design and implementation is heavily inspired by the dicontinued [Heron](https://github.com/jcornaz/heron).

`CollisionLayers` has many methods where the layers must implement `PhysicsLayer`. There is now a `bevy_xpbd_derive` crate that provides a derive macro for this purpose. The macro is imported in the `bevy_xpbd::prelude`.

## Usage example

```rust
use bevy::prelude::*;
use bevy_xpbd::prelude::*;

#[derive(PhysicsLayer)]
enum Layer {
    Player,
    Enemy,
    Ground,
}

fn spawn(mut commands: Commands) {
    commands.spawn((
        Collider::ball(0.5),
        // Player collides with enemies and the ground, but not with other players
        CollisionLayers::new([Layer::Player], [Layer::Enemy, Layer::Ground])
    ));
}
```