### PR TITLE
Rename names to be more readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ fn setup(
             ..default()
         },
         RigidBody::Dynamic,
-        Pos(Vec3::Y * 4.0),
-        AngVel(Vec3::new(2.5, 3.4, 1.6)),
+        Position(Vec3::Y * 4.0),
+        AngularVelocity(Vec3::new(2.5, 3.4, 1.6)),
         Collider::cuboid(1.0, 1.0, 1.0),
     ));
     // Light

--- a/crates/bevy_xpbd_2d/examples/chain2d.rs
+++ b/crates/bevy_xpbd_2d/examples/chain2d.rs
@@ -80,8 +80,8 @@ fn create_chain(
                     ..default()
                 },
                 RigidBody::Dynamic,
-                Pos(Vec2::Y * -(node_size + node_dist) * i as f32),
-                MassPropsBundle::new_computed(&Collider::ball(node_size * 0.5), 1.0),
+                Position(Vec2::Y * -(node_size + node_dist) * i as f32),
+                MassPropertiesBundle::new_computed(&Collider::ball(node_size * 0.5), 1.0),
             ))
             .id();
 
@@ -119,7 +119,7 @@ fn mouse_position(
 fn follow_mouse(
     mouse_pos: Res<MouseWorldPos>,
     buttons: Res<Input<MouseButton>>,
-    mut query: Query<&mut Pos, With<FollowMouse>>,
+    mut query: Query<&mut Position, With<FollowMouse>>,
 ) {
     for mut pos in &mut query {
         if buttons.pressed(MouseButton::Left) {
@@ -135,8 +135,8 @@ fn main() {
     App::new()
         .insert_resource(ClearColor(Color::BLACK))
         .insert_resource(Msaa::Sample4)
-        .insert_resource(NumSubsteps(15))
-        .insert_resource(NumPosIters(6))
+        .insert_resource(SubstepCount(15))
+        .insert_resource(IterationCount(6))
         .init_resource::<MouseWorldPos>()
         .add_plugins(DefaultPlugins)
         .add_plugin(XpbdExamplePlugin)

--- a/crates/bevy_xpbd_2d/examples/fixed_joint_2d.rs
+++ b/crates/bevy_xpbd_2d/examples/fixed_joint_2d.rs
@@ -42,8 +42,8 @@ fn setup(
                 ..default()
             },
             RigidBody::Dynamic,
-            Pos(Vec2::X * 1.5),
-            MassPropsBundle::new_computed(&Collider::cuboid(1.0, 1.0), 1.0),
+            Position(Vec2::X * 1.5),
+            MassPropertiesBundle::new_computed(&Collider::cuboid(1.0, 1.0), 1.0),
         ))
         .id();
 
@@ -62,7 +62,7 @@ fn setup(
 
 fn player_movement(
     keyboard_input: Res<Input<KeyCode>>,
-    mut query: Query<(&mut LinVel, &mut AngVel, &MoveSpeed), With<Player>>,
+    mut query: Query<(&mut LinearVelocity, &mut AngularVelocity, &MoveSpeed), With<Player>>,
 ) {
     for (mut lin_vel, mut ang_vel, move_speed) in &mut query {
         lin_vel.0 *= 0.95;
@@ -95,7 +95,7 @@ fn main() {
     App::new()
         .insert_resource(ClearColor(Color::rgb(0.0, 0.0, 0.1)))
         .insert_resource(Msaa::Sample4)
-        .insert_resource(NumSubsteps(50))
+        .insert_resource(SubstepCount(50))
         .add_plugins(DefaultPlugins)
         .add_plugin(XpbdExamplePlugin)
         .add_startup_system(setup)

--- a/crates/bevy_xpbd_2d/examples/move_marbles.rs
+++ b/crates/bevy_xpbd_2d/examples/move_marbles.rs
@@ -51,7 +51,7 @@ fn setup(
             ..default()
         },
         RigidBody::Static,
-        Pos(Vec2::NEG_Y * 7.5),
+        Position(Vec2::NEG_Y * 7.5),
         Collider::cuboid(20.0, 1.0),
     ));
 
@@ -63,7 +63,7 @@ fn setup(
             ..default()
         },
         RigidBody::Static,
-        Pos(Vec2::Y * 7.5),
+        Position(Vec2::Y * 7.5),
         Collider::cuboid(20.0, 1.0),
     ));
 
@@ -75,7 +75,7 @@ fn setup(
             ..default()
         },
         RigidBody::Static,
-        Pos(Vec2::NEG_X * 9.5),
+        Position(Vec2::NEG_X * 9.5),
         Collider::cuboid(1.0, 20.0),
     ));
 
@@ -87,7 +87,7 @@ fn setup(
             ..default()
         },
         RigidBody::Static,
-        Pos(Vec2::X * 9.5),
+        Position(Vec2::X * 9.5),
         Collider::cuboid(1.0, 20.0),
     ));
 
@@ -107,7 +107,7 @@ fn setup(
                     ..default()
                 },
                 RigidBody::Dynamic,
-                Pos(pos),
+                Position(pos),
                 Collider::ball(radius),
                 Player,
                 MoveAcceleration(0.5),
@@ -144,7 +144,7 @@ fn handle_input(keyboard_input: Res<Input<KeyCode>>, mut ev_movement: EventWrite
 
 fn player_movement(
     mut ev_movement: EventReader<MovementEvent>,
-    mut query: Query<(&mut LinVel, &MaxVelocity, &MoveAcceleration), With<Player>>,
+    mut query: Query<(&mut LinearVelocity, &MaxVelocity, &MoveAcceleration), With<Player>>,
 ) {
     for ev in ev_movement.iter() {
         for (mut vel, max_vel, move_acceleration) in &mut query {
@@ -166,7 +166,7 @@ fn main() {
     App::new()
         .insert_resource(ClearColor(Color::BLACK))
         .insert_resource(Msaa::Sample4)
-        .insert_resource(NumSubsteps(6))
+        .insert_resource(SubstepCount(6))
         .add_plugins(DefaultPlugins)
         .add_plugin(XpbdExamplePlugin)
         .add_event::<MovementEvent>()

--- a/crates/bevy_xpbd_2d/examples/prismatic_joint_2d.rs
+++ b/crates/bevy_xpbd_2d/examples/prismatic_joint_2d.rs
@@ -42,8 +42,8 @@ fn setup(
                 ..default()
             },
             RigidBody::Dynamic,
-            Pos(Vec2::X * 1.5),
-            MassPropsBundle::new_computed(&Collider::cuboid(1.0, 1.0), 1.0),
+            Position(Vec2::X * 1.5),
+            MassPropertiesBundle::new_computed(&Collider::cuboid(1.0, 1.0), 1.0),
         ))
         .id();
 
@@ -67,7 +67,7 @@ fn setup(
 
 fn player_movement(
     keyboard_input: Res<Input<KeyCode>>,
-    mut query: Query<(&mut LinVel, &MoveSpeed), With<Player>>,
+    mut query: Query<(&mut LinearVelocity, &MoveSpeed), With<Player>>,
 ) {
     for (mut vel, move_speed) in &mut query {
         vel.0 *= 0.95;
@@ -93,7 +93,7 @@ fn main() {
     App::new()
         .insert_resource(ClearColor(Color::rgb(0.0, 0.0, 0.1)))
         .insert_resource(Msaa::Sample4)
-        .insert_resource(NumSubsteps(50))
+        .insert_resource(SubstepCount(50))
         .add_plugins(DefaultPlugins)
         .add_plugin(XpbdExamplePlugin)
         .add_startup_system(setup)

--- a/crates/bevy_xpbd_2d/examples/revolute_joint_2d.rs
+++ b/crates/bevy_xpbd_2d/examples/revolute_joint_2d.rs
@@ -42,8 +42,8 @@ fn setup(
                 ..default()
             },
             RigidBody::Dynamic,
-            Pos(Vec2::NEG_Y * 3.0),
-            MassPropsBundle::new_computed(&Collider::cuboid(1.0, 1.0), 1.0),
+            Position(Vec2::NEG_Y * 3.0),
+            MassPropertiesBundle::new_computed(&Collider::cuboid(1.0, 1.0), 1.0),
         ))
         .id();
 
@@ -67,7 +67,7 @@ fn setup(
 
 fn player_movement(
     keyboard_input: Res<Input<KeyCode>>,
-    mut query: Query<(&mut LinVel, &MoveSpeed), With<Player>>,
+    mut query: Query<(&mut LinearVelocity, &MoveSpeed), With<Player>>,
 ) {
     for (mut vel, move_speed) in &mut query {
         vel.0 *= 0.95;
@@ -93,7 +93,7 @@ fn main() {
     App::new()
         .insert_resource(ClearColor(Color::rgb(0.0, 0.0, 0.1)))
         .insert_resource(Msaa::Sample4)
-        .insert_resource(NumSubsteps(50))
+        .insert_resource(SubstepCount(50))
         .add_plugins(DefaultPlugins)
         .add_plugin(XpbdExamplePlugin)
         .add_startup_system(setup)

--- a/crates/bevy_xpbd_3d/examples/chain3d.rs
+++ b/crates/bevy_xpbd_3d/examples/chain3d.rs
@@ -42,7 +42,7 @@ fn setup(
             ..default()
         },
         RigidBody::Static,
-        Pos(Vec3::NEG_Y * 18.0),
+        Position(Vec3::NEG_Y * 18.0),
         Collider::cuboid(floor_size.x, floor_size.y, floor_size.z),
     ));
 
@@ -117,7 +117,7 @@ fn create_chain(
                 ..default()
             },
             RigidBody::Kinematic,
-            Pos(start_pos),
+            Position(start_pos),
             Player,
             MoveSpeed(0.3),
         ))
@@ -134,8 +134,8 @@ fn create_chain(
                     ..default()
                 },
                 RigidBody::Dynamic,
-                Pos(start_pos + delta_pos * i as f32),
-                MassPropsBundle::new_computed(&Collider::ball(node_size * 0.5), 1.0),
+                Position(start_pos + delta_pos * i as f32),
+                MassPropertiesBundle::new_computed(&Collider::ball(node_size * 0.5), 1.0),
             ))
             .id();
 
@@ -151,7 +151,7 @@ fn create_chain(
 
 fn player_movement(
     keyboard_input: Res<Input<KeyCode>>,
-    mut query: Query<(&mut LinVel, &MoveSpeed), With<Player>>,
+    mut query: Query<(&mut LinearVelocity, &MoveSpeed), With<Player>>,
 ) {
     for (mut vel, move_speed) in &mut query {
         vel.0 *= 0.95;
@@ -183,7 +183,7 @@ fn main() {
     App::new()
         .insert_resource(ClearColor(Color::rgb(0.0, 0.0, 0.1)))
         .insert_resource(Msaa::Sample4)
-        .insert_resource(NumSubsteps(50))
+        .insert_resource(SubstepCount(50))
         .add_plugins(DefaultPlugins)
         .add_plugin(XpbdExamplePlugin)
         .add_startup_system(setup)

--- a/crates/bevy_xpbd_3d/examples/cubes.rs
+++ b/crates/bevy_xpbd_3d/examples/cubes.rs
@@ -37,7 +37,7 @@ fn setup(
             ..default()
         },
         RigidBody::Static,
-        Pos(Vec3::NEG_Y),
+        Position(Vec3::NEG_Y),
         Collider::cuboid(floor_size.x, floor_size.y, floor_size.z),
     ));
 
@@ -61,7 +61,7 @@ fn setup(
                         ..default()
                     },
                     RigidBody::Dynamic,
-                    Pos(pos + Vec3::Y * 5.0),
+                    Position(pos + Vec3::Y * 5.0),
                     Collider::cuboid(radius * 2.0, radius * 2.0, radius * 2.0),
                     Player,
                     MoveAcceleration(0.1),
@@ -100,7 +100,7 @@ fn setup(
 
 fn player_movement(
     keyboard_input: Res<Input<KeyCode>>,
-    mut query: Query<(&mut LinVel, &MaxLinearVelocity, &MoveAcceleration), With<Player>>,
+    mut query: Query<(&mut LinearVelocity, &MaxLinearVelocity, &MoveAcceleration), With<Player>>,
 ) {
     for (mut lin_vel, max_vel, move_acceleration) in &mut query {
         if keyboard_input.pressed(KeyCode::Up) {

--- a/crates/bevy_xpbd_3d/examples/cubes_f64.rs
+++ b/crates/bevy_xpbd_3d/examples/cubes_f64.rs
@@ -37,7 +37,7 @@ fn setup(
             ..default()
         },
         RigidBody::Static,
-        Pos(DVec3::NEG_Y),
+        Position(DVec3::NEG_Y),
         Collider::cuboid(floor_size.x, floor_size.y, floor_size.z),
     ));
 
@@ -61,7 +61,7 @@ fn setup(
                         ..default()
                     },
                     RigidBody::Dynamic,
-                    Pos(pos + DVec3::Y * 5.0),
+                    Position(pos + DVec3::Y * 5.0),
                     Collider::cuboid(radius * 2.0, radius * 2.0, radius * 2.0),
                     Player,
                     MoveAcceleration(0.1),
@@ -100,7 +100,7 @@ fn setup(
 
 fn player_movement(
     keyboard_input: Res<Input<KeyCode>>,
-    mut query: Query<(&mut LinVel, &MaxLinearVelocity, &MoveAcceleration), With<Player>>,
+    mut query: Query<(&mut LinearVelocity, &MaxLinearVelocity, &MoveAcceleration), With<Player>>,
 ) {
     for (mut lin_vel, max_vel, move_acceleration) in &mut query {
         if keyboard_input.pressed(KeyCode::Up) {

--- a/crates/bevy_xpbd_3d/examples/custom_broad_phase.rs
+++ b/crates/bevy_xpbd_3d/examples/custom_broad_phase.rs
@@ -44,8 +44,8 @@ fn setup(
             ..default()
         },
         RigidBody::Dynamic,
-        Pos(Vec3::Y * 4.0),
-        AngVel(Vec3::new(2.5, 3.4, 1.6)),
+        Position(Vec3::Y * 4.0),
+        AngularVelocity(Vec3::new(2.5, 3.4, 1.6)),
         Collider::cuboid(1.0, 1.0, 1.0),
     ));
     // Light

--- a/crates/bevy_xpbd_3d/examples/custom_constraint.rs
+++ b/crates/bevy_xpbd_3d/examples/custom_constraint.rs
@@ -14,8 +14,7 @@ fn main() {
         .get_schedule_mut(SubstepSchedule)
         .expect("add SubstepSchedule first");
     substeps.add_system(
-        solve_constraint::<CustomDistanceConstraint, 2>
-            .in_set(SubsteppingSet::SolveUserConstraints),
+        solve_constraint::<CustomDistanceConstraint, 2>.in_set(SubstepSet::SolveUserConstraints),
     );
 
     // Run the app
@@ -101,8 +100,8 @@ fn setup(
         .spawn((
             cube_mesh,
             RigidBody::Dynamic,
-            Pos(Vec3::new(3.0, 3.5, 0.0)),
-            MassPropsBundle::new_computed(&Collider::cuboid(1.0, 1.0, 1.0), 1.0),
+            Position(Vec3::new(3.0, 3.5, 0.0)),
+            MassPropertiesBundle::new_computed(&Collider::cuboid(1.0, 1.0, 1.0), 1.0),
         ))
         .id();
 

--- a/crates/bevy_xpbd_3d/examples/custom_constraint.rs
+++ b/crates/bevy_xpbd_3d/examples/custom_constraint.rs
@@ -47,7 +47,7 @@ impl XpbdConstraint<2> for CustomDistanceConstraint {
         let [r1, r2] = [Vector::ZERO, Vector::ZERO];
 
         // Compute the positional difference
-        let delta_x = body1.pos.0 - body2.pos.0;
+        let delta_x = body1.position.0 - body2.position.0;
 
         // The current separation distance
         let length = delta_x.length();

--- a/crates/bevy_xpbd_3d/examples/fixed_joint_3d.rs
+++ b/crates/bevy_xpbd_3d/examples/fixed_joint_3d.rs
@@ -41,8 +41,8 @@ fn setup(
                 ..default()
             },
             RigidBody::Dynamic,
-            Pos(Vec3::X * 1.5),
-            MassPropsBundle::new_computed(&Collider::cuboid(1.0, 1.0, 1.0), 1.0),
+            Position(Vec3::X * 1.5),
+            MassPropertiesBundle::new_computed(&Collider::cuboid(1.0, 1.0, 1.0), 1.0),
         ))
         .id();
 
@@ -76,7 +76,7 @@ fn setup(
 
 fn player_movement(
     keyboard_input: Res<Input<KeyCode>>,
-    mut query: Query<(&mut LinVel, &mut AngVel, &MoveSpeed), With<Player>>,
+    mut query: Query<(&mut LinearVelocity, &mut AngularVelocity, &MoveSpeed), With<Player>>,
 ) {
     for (mut lin_vel, mut ang_vel, move_speed) in &mut query {
         lin_vel.0 *= 0.95;
@@ -115,7 +115,7 @@ fn main() {
     App::new()
         .insert_resource(ClearColor(Color::rgb(0.0, 0.0, 0.1)))
         .insert_resource(Msaa::Sample4)
-        .insert_resource(NumSubsteps(50))
+        .insert_resource(SubstepCount(50))
         .add_plugins(DefaultPlugins)
         .add_plugin(XpbdExamplePlugin)
         .add_startup_system(setup)

--- a/crates/bevy_xpbd_3d/examples/prismatic_joint_3d.rs
+++ b/crates/bevy_xpbd_3d/examples/prismatic_joint_3d.rs
@@ -41,8 +41,8 @@ fn setup(
                 ..default()
             },
             RigidBody::Dynamic,
-            Pos(Vec3::X * 1.5),
-            MassPropsBundle::new_computed(&Collider::cuboid(1.0, 1.0, 1.0), 1.0),
+            Position(Vec3::X * 1.5),
+            MassPropertiesBundle::new_computed(&Collider::cuboid(1.0, 1.0, 1.0), 1.0),
         ))
         .id();
 
@@ -81,7 +81,7 @@ fn setup(
 
 fn player_movement(
     keyboard_input: Res<Input<KeyCode>>,
-    mut query: Query<(&mut LinVel, &MoveSpeed), With<Player>>,
+    mut query: Query<(&mut LinearVelocity, &MoveSpeed), With<Player>>,
 ) {
     for (mut vel, move_speed) in &mut query {
         vel.0 *= 0.95;
@@ -113,7 +113,7 @@ fn main() {
     App::new()
         .insert_resource(ClearColor(Color::rgb(0.0, 0.0, 0.1)))
         .insert_resource(Msaa::Sample4)
-        .insert_resource(NumSubsteps(50))
+        .insert_resource(SubstepCount(50))
         .add_plugins(DefaultPlugins)
         .add_plugin(XpbdExamplePlugin)
         .add_startup_system(setup)

--- a/crates/bevy_xpbd_3d/examples/revolute_joint_3d.rs
+++ b/crates/bevy_xpbd_3d/examples/revolute_joint_3d.rs
@@ -41,8 +41,8 @@ fn setup(
                 ..default()
             },
             RigidBody::Dynamic,
-            Pos(Vec3::NEG_Y * 3.0),
-            MassPropsBundle::new_computed(&Collider::cuboid(1.0, 1.0, 1.0), 1.0),
+            Position(Vec3::NEG_Y * 3.0),
+            MassPropertiesBundle::new_computed(&Collider::cuboid(1.0, 1.0, 1.0), 1.0),
         ))
         .id();
 
@@ -83,7 +83,7 @@ fn setup(
 
 fn player_movement(
     keyboard_input: Res<Input<KeyCode>>,
-    mut query: Query<(&mut LinVel, &MoveSpeed), With<Player>>,
+    mut query: Query<(&mut LinearVelocity, &MoveSpeed), With<Player>>,
 ) {
     for (mut vel, move_speed) in &mut query {
         vel.0 *= 0.95;
@@ -115,7 +115,7 @@ fn main() {
     App::new()
         .insert_resource(ClearColor(Color::rgb(0.0, 0.0, 0.1)))
         .insert_resource(Msaa::Sample4)
-        .insert_resource(NumSubsteps(50))
+        .insert_resource(SubstepCount(50))
         .add_plugins(DefaultPlugins)
         .add_plugin(XpbdExamplePlugin)
         .add_startup_system(setup)

--- a/crates/bevy_xpbd_3d/examples/rolling_balls.rs
+++ b/crates/bevy_xpbd_3d/examples/rolling_balls.rs
@@ -44,7 +44,7 @@ fn setup(
             ..default()
         },
         RigidBody::Static,
-        Pos(Vec3::NEG_Y * 5.0),
+        Position(Vec3::NEG_Y * 5.0),
         Collider::cuboid(floor_size.x, floor_size.y, floor_size.z),
     ));
 
@@ -68,7 +68,7 @@ fn setup(
                         ..default()
                     },
                     RigidBody::Dynamic,
-                    Pos(pos),
+                    Position(pos),
                     Collider::ball(radius),
                     Player,
                     RollAcceleration(Vec3::splat(0.5)),
@@ -107,7 +107,7 @@ fn setup(
 
 fn player_movement(
     keyboard_input: Res<Input<KeyCode>>,
-    mut query: Query<(&mut AngVel, &MaxAngularVelocity, &RollAcceleration), With<Player>>,
+    mut query: Query<(&mut AngularVelocity, &MaxAngularVelocity, &RollAcceleration), With<Player>>,
 ) {
     for (mut ang_vel, max_ang_vel, move_acceleration) in &mut query {
         if keyboard_input.pressed(KeyCode::Up) {
@@ -133,7 +133,7 @@ fn main() {
     App::new()
         .insert_resource(ClearColor(Color::BLACK))
         .insert_resource(Msaa::Sample4)
-        .insert_resource(NumSubsteps(6))
+        .insert_resource(SubstepCount(6))
         .add_plugins(DefaultPlugins)
         .add_plugin(XpbdExamplePlugin)
         .add_startup_system(setup)

--- a/src/collision.rs
+++ b/src/collision.rs
@@ -46,8 +46,8 @@ pub(crate) fn compute_contact(
     pos2: Vector,
     local_com1: Vector,
     local_com2: Vector,
-    rot1: &Rot,
-    rot2: &Rot,
+    rot1: &Rotation,
+    rot2: &Rotation,
     shape1: &SharedShape,
     shape2: &SharedShape,
 ) -> Option<Contact> {
@@ -64,8 +64,8 @@ pub(crate) fn compute_contact(
         return Some(Contact {
             entity1: ent1,
             entity2: ent2,
-            local_r1: rot1.inv().rotate(world_r1),
-            local_r2: rot2.inv().rotate(world_r2),
+            local_r1: rot1.inverse().rotate(world_r1),
+            local_r2: rot2.inverse().rotate(world_r2),
             world_r1,
             world_r2,
             normal: contact.normal1.into(),

--- a/src/components/collider.rs
+++ b/src/components/collider.rs
@@ -35,7 +35,13 @@ impl Collider {
     ///
     /// If you want to create a compound shape from a 3D triangle mesh or 2D polyline, consider using the
     /// [`Collider::convex_decomposition`](#method.convex_decomposition) method.
-    pub fn compound(shapes: Vec<(impl Into<Pos>, impl Into<Rot>, impl Into<Collider>)>) -> Self {
+    pub fn compound(
+        shapes: Vec<(
+            impl Into<Position>,
+            impl Into<Rotation>,
+            impl Into<Collider>,
+        )>,
+    ) -> Self {
         let shapes = shapes
             .into_iter()
             .map(|(p, r, c)| {

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -2,13 +2,13 @@
 
 mod collider;
 mod layers;
-mod mass_props;
+mod mass_properties;
 mod rotation;
 mod world_queries;
 
 pub use collider::*;
 pub use layers::*;
-pub use mass_props::*;
+pub use mass_properties::*;
 pub use rotation::*;
 pub use world_queries::*;
 
@@ -22,7 +22,7 @@ use derive_more::From;
 pub enum RigidBody {
     /// Dynamic bodies are bodies that are affected by forces, velocity and collisions.
     ///
-    /// You should generally move dynamic bodies by modifying the [`ExternalForce`], [`LinVel`] or [`AngVel`] components. Directly changing the [`Pos`] or [`Rot`] works as well, but it may cause unwanted behaviour if the body happens to teleport into the colliders of other bodies.
+    /// You should generally move dynamic bodies by modifying the [`ExternalForce`], [`LinearVelocity`] or [`AngularVelocity`] components. Directly changing the [`Position`] or [`Rotation`] works as well, but it may cause unwanted behaviour if the body happens to teleport into the colliders of other bodies.
     #[default]
     Dynamic,
 
@@ -35,7 +35,7 @@ pub enum RigidBody {
 
     /// Kinematic bodies are bodies that are not affected by any external forces or collisions. They will realistically affect colliding dynamic bodies, but not other kinematic bodies.
     ///
-    /// Unlike static bodies, the [`Pos`], [`LinVel`] and [`AngVel`] components will move kinematic bodies as expected. These components will never be altered by the physics engine, so you can kinematic bodies freely.
+    /// Unlike static bodies, the [`Position`], [`LinearVelocity`] and [`AngularVelocity`] components will move kinematic bodies as expected. These components will never be altered by the physics engine, so you can kinematic bodies freely.
     Kinematic,
 }
 
@@ -88,17 +88,17 @@ pub struct SleepingDisabled;
 /// The position of a body.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[reflect(Component)]
-pub struct Pos(pub Vector);
+pub struct Position(pub Vector);
 
 #[cfg(all(feature = "2d", feature = "f64"))]
-impl From<Vec2> for Pos {
+impl From<Vec2> for Position {
     fn from(value: Vec2) -> Self {
         value.as_dvec2().into()
     }
 }
 
 #[cfg(all(feature = "3d", feature = "f64"))]
-impl From<Vec3> for Pos {
+impl From<Vec3> for Position {
     fn from(value: Vec3) -> Self {
         value.as_dvec3().into()
     }
@@ -107,26 +107,26 @@ impl From<Vec3> for Pos {
 /// The previous position of a body.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[reflect(Component)]
-pub struct PrevPos(pub Vector);
+pub struct PreviousPosition(pub Vector);
 
 /// The linear velocity of a body.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[reflect(Component)]
-pub struct LinVel(pub Vector);
+pub struct LinearVelocity(pub Vector);
 
-impl LinVel {
-    pub const ZERO: LinVel = LinVel(Vector::ZERO);
+impl LinearVelocity {
+    pub const ZERO: LinearVelocity = LinearVelocity(Vector::ZERO);
 }
 
 #[cfg(all(feature = "2d", feature = "f64"))]
-impl From<Vec2> for LinVel {
+impl From<Vec2> for LinearVelocity {
     fn from(value: Vec2) -> Self {
         value.as_dvec2().into()
     }
 }
 
 #[cfg(all(feature = "3d", feature = "f64"))]
-impl From<Vec3> for LinVel {
+impl From<Vec3> for LinearVelocity {
     fn from(value: Vec3) -> Self {
         value.as_dvec3().into()
     }
@@ -135,29 +135,29 @@ impl From<Vec3> for LinVel {
 /// The linear velocity of a body before the velocity solve is performed.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[reflect(Component)]
-pub struct PreSolveLinVel(pub Vector);
+pub struct PreSolveLinearVelocity(pub Vector);
 
 /// The angular velocity of a body in radians. Positive values will result in counter-clockwise rotation.
 #[cfg(feature = "2d")]
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[reflect(Component)]
-pub struct AngVel(pub Scalar);
+pub struct AngularVelocity(pub Scalar);
 
 /// The angular velocity of a body in radians.
 #[cfg(feature = "3d")]
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[reflect(Component)]
-pub struct AngVel(pub Vector);
+pub struct AngularVelocity(pub Vector);
 
-impl AngVel {
+impl AngularVelocity {
     #[cfg(feature = "2d")]
-    pub const ZERO: AngVel = AngVel(0.0);
+    pub const ZERO: AngularVelocity = AngularVelocity(0.0);
     #[cfg(feature = "3d")]
-    pub const ZERO: AngVel = AngVel(Vector::ZERO);
+    pub const ZERO: AngularVelocity = AngularVelocity(Vector::ZERO);
 }
 
 #[cfg(all(feature = "3d", feature = "f64"))]
-impl From<Vec3> for AngVel {
+impl From<Vec3> for AngularVelocity {
     fn from(value: Vec3) -> Self {
         value.as_dvec3().into()
     }
@@ -167,13 +167,13 @@ impl From<Vec3> for AngVel {
 #[cfg(feature = "2d")]
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[reflect(Component)]
-pub struct PreSolveAngVel(pub Scalar);
+pub struct PreSolveAngularVelocity(pub Scalar);
 
 /// The angular velocity of a body in radians before the velocity solve is performed.
 #[cfg(feature = "3d")]
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[reflect(Component)]
-pub struct PreSolveAngVel(pub Vector);
+pub struct PreSolveAngularVelocity(pub Vector);
 
 /// An external force applied to a body during the integration step. It persists during the simulation, so it must be cleared manually.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]

--- a/src/components/rotation.rs
+++ b/src/components/rotation.rs
@@ -15,7 +15,7 @@ use crate::prelude::*;
 #[cfg(feature = "2d")]
 #[derive(Reflect, Clone, Copy, Component, Debug)]
 #[reflect(Component)]
-pub struct Rot {
+pub struct Rotation {
     pub cos: Scalar,
     pub sin: Scalar,
 }
@@ -24,9 +24,9 @@ pub struct Rot {
 #[cfg(feature = "3d")]
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut)]
 #[reflect(Component)]
-pub struct Rot(pub Quaternion);
+pub struct Rotation(pub Quaternion);
 
-impl Rot {
+impl Rotation {
     /// Rotates the rotation by a 3D vector.
     #[cfg(feature = "2d")]
     pub fn rotate_vec3(&self, vec: crate::Vector3) -> crate::Vector3 {
@@ -44,7 +44,7 @@ impl Rot {
 }
 
 #[cfg(feature = "2d")]
-impl Rot {
+impl Rotation {
     pub const ZERO: Self = Self { cos: 1.0, sin: 0.0 };
 
     /// Returns the cosine of the rotation in radians.
@@ -57,7 +57,7 @@ impl Rot {
         self.sin
     }
 
-    /// Creates a [`Rot`] from radians.
+    /// Creates a [`Rotation`] from radians.
     pub fn from_radians(radians: Scalar) -> Self {
         Self {
             cos: radians.cos(),
@@ -65,7 +65,7 @@ impl Rot {
         }
     }
 
-    /// Creates a [`Rot`] from degrees.
+    /// Creates a [`Rotation`] from degrees.
     pub fn from_degrees(degrees: Scalar) -> Self {
         Self::from_radians(degrees.to_radians())
     }
@@ -89,7 +89,7 @@ impl Rot {
     }
 
     /// Inverts the rotation.
-    pub fn inv(&self) -> Self {
+    pub fn inverse(&self) -> Self {
         Self {
             cos: self.cos,
             sin: -self.sin,
@@ -106,27 +106,27 @@ impl Rot {
 }
 
 #[cfg(feature = "3d")]
-impl Rot {
+impl Rotation {
     /// Rotates the rotation by a given vector,
     pub fn rotate(&self, vec: Vector) -> Vector {
         self.0 * vec
     }
 
     /// Inverts the rotation.
-    pub fn inv(&self) -> Self {
-        Self(self.inverse())
+    pub fn inverse(&self) -> Self {
+        Self(self.0.inverse())
     }
 }
 
 #[cfg(feature = "2d")]
-impl Default for Rot {
+impl Default for Rotation {
     fn default() -> Self {
         Self::ZERO
     }
 }
 
 #[cfg(feature = "2d")]
-impl Add<Self> for Rot {
+impl Add<Self> for Rotation {
     type Output = Self;
     fn add(self, rhs: Self) -> Self::Output {
         self.mul(rhs)
@@ -134,51 +134,51 @@ impl Add<Self> for Rot {
 }
 
 #[cfg(feature = "3d")]
-impl Add<Self> for Rot {
+impl Add<Self> for Rotation {
     type Output = Self;
     fn add(self, rhs: Self) -> Self::Output {
-        Rot(self.0 + rhs.0)
+        Rotation(self.0 + rhs.0)
     }
 }
 
-impl AddAssign<Self> for Rot {
+impl AddAssign<Self> for Rotation {
     fn add_assign(&mut self, rhs: Self) {
         *self = *self + rhs;
     }
 }
 
 #[cfg(feature = "2d")]
-impl Sub<Self> for Rot {
+impl Sub<Self> for Rotation {
     type Output = Self;
     fn sub(self, rhs: Self) -> Self::Output {
-        self.mul(rhs.inv())
+        self.mul(rhs.inverse())
     }
 }
 
 #[cfg(feature = "3d")]
-impl Sub<Self> for Rot {
+impl Sub<Self> for Rotation {
     type Output = Self;
     fn sub(self, rhs: Self) -> Self::Output {
-        Rot(self.0 - rhs.0)
+        Rotation(self.0 - rhs.0)
     }
 }
 
-impl SubAssign<Self> for Rot {
+impl SubAssign<Self> for Rotation {
     fn sub_assign(&mut self, rhs: Self) {
         *self = *self - rhs;
     }
 }
 
 #[cfg(feature = "2d")]
-impl From<Rot> for Scalar {
-    fn from(rot: Rot) -> Self {
+impl From<Rotation> for Scalar {
+    fn from(rot: Rotation) -> Self {
         rot.as_radians()
     }
 }
 
 #[cfg(feature = "2d")]
-impl From<Rot> for Quaternion {
-    fn from(rot: Rot) -> Self {
+impl From<Rotation> for Quaternion {
+    fn from(rot: Rotation) -> Self {
         if rot.cos() < 0.0 {
             let t = 1.0 - rot.cos();
             let d = 1.0 / (t * 2.0).sqrt();
@@ -196,14 +196,14 @@ impl From<Rot> for Quaternion {
 }
 
 #[cfg(feature = "3d")]
-impl From<Rot> for Quaternion {
-    fn from(rot: Rot) -> Self {
+impl From<Rotation> for Quaternion {
+    fn from(rot: Rotation) -> Self {
         rot.0
     }
 }
 
 #[cfg(feature = "2d")]
-impl From<Quat> for Rot {
+impl From<Quat> for Rotation {
     fn from(quat: Quat) -> Self {
         let angle = quat.to_euler(EulerRot::XYZ).2;
         Self::from_radians(angle as Scalar)
@@ -211,7 +211,7 @@ impl From<Quat> for Rot {
 }
 
 #[cfg(feature = "2d")]
-impl From<DQuat> for Rot {
+impl From<DQuat> for Rotation {
     fn from(quat: DQuat) -> Self {
         let angle = quat.to_euler(EulerRot::XYZ).2;
         Self::from_radians(angle as Scalar)
@@ -219,7 +219,7 @@ impl From<DQuat> for Rot {
 }
 
 #[cfg(feature = "3d")]
-impl From<Quat> for Rot {
+impl From<Quat> for Rotation {
     fn from(quat: Quat) -> Self {
         Self(Quaternion::from_xyzw(
             quat.x as Scalar,
@@ -231,7 +231,7 @@ impl From<Quat> for Rot {
 }
 
 #[cfg(feature = "3d")]
-impl From<DQuat> for Rot {
+impl From<DQuat> for Rotation {
     fn from(quat: DQuat) -> Self {
         Self(Quaternion::from_xyzw(
             quat.x as Scalar,
@@ -243,13 +243,13 @@ impl From<DQuat> for Rot {
 }
 
 #[cfg(feature = "3d")]
-impl From<Rot> for Matrix3x1<Scalar> {
-    fn from(rot: Rot) -> Self {
+impl From<Rotation> for Matrix3x1<Scalar> {
+    fn from(rot: Rotation) -> Self {
         Matrix3x1::new(rot.x, rot.y, rot.z)
     }
 }
 
-/// The previous rotation of a body. See [`Rot`].
+/// The previous rotation of a body. See [`Rotation`].
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut)]
 #[reflect(Component)]
-pub struct PrevRot(pub Rot);
+pub struct PreviousRotation(pub Rotation);

--- a/src/components/world_queries.rs
+++ b/src/components/world_queries.rs
@@ -8,14 +8,14 @@ use std::ops::{AddAssign, SubAssign};
 pub struct RigidBodyQuery {
     pub entity: Entity,
     pub rb: &'static mut RigidBody,
-    pub pos: &'static mut Position,
-    pub rot: &'static mut Rotation,
-    pub prev_pos: &'static mut PreviousPosition,
-    pub prev_rot: &'static mut PreviousRotation,
-    pub lin_vel: &'static mut LinearVelocity,
-    pub pre_solve_lin_vel: &'static mut PreSolveLinearVelocity,
-    pub ang_vel: &'static mut AngularVelocity,
-    pub pre_solve_ang_vel: &'static mut PreSolveAngularVelocity,
+    pub position: &'static mut Position,
+    pub rotation: &'static mut Rotation,
+    pub previous_position: &'static mut PreviousPosition,
+    pub previous_rotation: &'static mut PreviousRotation,
+    pub linear_velocity: &'static mut LinearVelocity,
+    pub pre_solve_linear_velocity: &'static mut PreSolveLinearVelocity,
+    pub angular_velocity: &'static mut AngularVelocity,
+    pub pre_solve_angular_velocity: &'static mut PreSolveAngularVelocity,
     pub mass: &'static mut Mass,
     pub inverse_mass: &'static mut InverseMass,
     pub inertia: &'static mut Inertia,
@@ -35,13 +35,13 @@ impl<'w> RigidBodyQueryItem<'w> {
     // Computes the world-space inverse inertia tensor.
     #[cfg(feature = "3d")]
     pub fn world_inv_inertia(&self) -> InverseInertia {
-        self.inverse_inertia.rotated(&self.rot)
+        self.inverse_inertia.rotated(&self.rotation)
     }
 }
 
 #[derive(WorldQuery)]
 #[world_query(mutable)]
-pub(crate) struct MassPropsQuery {
+pub(crate) struct MassPropertiesQuery {
     pub mass: &'static mut Mass,
     pub inverse_mass: &'static mut InverseMass,
     pub inertia: &'static mut Inertia,
@@ -58,7 +58,7 @@ pub(crate) struct ColliderQuery {
     pub previous_mass_properties: &'static mut PreviousColliderMassProperties,
 }
 
-impl<'w> AddAssign<ColliderMassProperties> for MassPropsQueryItem<'w> {
+impl<'w> AddAssign<ColliderMassProperties> for MassPropertiesQueryItem<'w> {
     fn add_assign(&mut self, rhs: ColliderMassProperties) {
         self.mass.0 += rhs.mass.0;
         self.inverse_mass.0 = 1.0 / self.mass.0;
@@ -68,7 +68,7 @@ impl<'w> AddAssign<ColliderMassProperties> for MassPropsQueryItem<'w> {
     }
 }
 
-impl<'w> SubAssign<ColliderMassProperties> for MassPropsQueryItem<'w> {
+impl<'w> SubAssign<ColliderMassProperties> for MassPropertiesQueryItem<'w> {
     fn sub_assign(&mut self, rhs: ColliderMassProperties) {
         self.mass.0 -= rhs.mass.0;
         self.inverse_mass.0 = 1.0 / self.mass.0;

--- a/src/components/world_queries.rs
+++ b/src/components/world_queries.rs
@@ -8,19 +8,19 @@ use std::ops::{AddAssign, SubAssign};
 pub struct RigidBodyQuery {
     pub entity: Entity,
     pub rb: &'static mut RigidBody,
-    pub pos: &'static mut Pos,
-    pub rot: &'static mut Rot,
-    pub prev_pos: &'static mut PrevPos,
-    pub prev_rot: &'static mut PrevRot,
-    pub lin_vel: &'static mut LinVel,
-    pub pre_solve_lin_vel: &'static mut PreSolveLinVel,
-    pub ang_vel: &'static mut AngVel,
-    pub pre_solve_ang_vel: &'static mut PreSolveAngVel,
+    pub pos: &'static mut Position,
+    pub rot: &'static mut Rotation,
+    pub prev_pos: &'static mut PreviousPosition,
+    pub prev_rot: &'static mut PreviousRotation,
+    pub lin_vel: &'static mut LinearVelocity,
+    pub pre_solve_lin_vel: &'static mut PreSolveLinearVelocity,
+    pub ang_vel: &'static mut AngularVelocity,
+    pub pre_solve_ang_vel: &'static mut PreSolveAngularVelocity,
     pub mass: &'static mut Mass,
-    pub inv_mass: &'static mut InvMass,
+    pub inverse_mass: &'static mut InverseMass,
     pub inertia: &'static mut Inertia,
-    pub inv_inertia: &'static mut InvInertia,
-    pub local_com: &'static mut LocalCom,
+    pub inverse_inertia: &'static mut InverseInertia,
+    pub center_of_mass: &'static mut CenterOfMass,
     pub friction: &'static mut Friction,
     pub restitution: &'static mut Restitution,
 }
@@ -28,14 +28,14 @@ pub struct RigidBodyQuery {
 impl<'w> RigidBodyQueryItem<'w> {
     /// Computes the world-space inverse inertia (does nothing in 2D).
     #[cfg(feature = "2d")]
-    pub(crate) fn world_inv_inertia(&self) -> InvInertia {
-        *self.inv_inertia
+    pub(crate) fn world_inv_inertia(&self) -> InverseInertia {
+        *self.inverse_inertia
     }
 
     // Computes the world-space inverse inertia tensor.
     #[cfg(feature = "3d")]
-    pub fn world_inv_inertia(&self) -> InvInertia {
-        self.inv_inertia.rotated(&self.rot)
+    pub fn world_inv_inertia(&self) -> InverseInertia {
+        self.inverse_inertia.rotated(&self.rot)
     }
 }
 
@@ -43,10 +43,10 @@ impl<'w> RigidBodyQueryItem<'w> {
 #[world_query(mutable)]
 pub(crate) struct MassPropsQuery {
     pub mass: &'static mut Mass,
-    pub inv_mass: &'static mut InvMass,
+    pub inverse_mass: &'static mut InverseMass,
     pub inertia: &'static mut Inertia,
-    pub inv_inertia: &'static mut InvInertia,
-    pub local_com: &'static mut LocalCom,
+    pub inverse_inertia: &'static mut InverseInertia,
+    pub center_of_mass: &'static mut CenterOfMass,
 }
 
 #[derive(WorldQuery)]
@@ -54,26 +54,26 @@ pub(crate) struct MassPropsQuery {
 pub(crate) struct ColliderQuery {
     pub collider: &'static mut Collider,
     pub aabb: &'static mut ColliderAabb,
-    pub mass_props: &'static mut ColliderMassProperties,
-    pub prev_mass_props: &'static mut PrevColliderMassProperties,
+    pub mass_properties: &'static mut ColliderMassProperties,
+    pub previous_mass_properties: &'static mut PreviousColliderMassProperties,
 }
 
 impl<'w> AddAssign<ColliderMassProperties> for MassPropsQueryItem<'w> {
     fn add_assign(&mut self, rhs: ColliderMassProperties) {
         self.mass.0 += rhs.mass.0;
-        self.inv_mass.0 = 1.0 / self.mass.0;
+        self.inverse_mass.0 = 1.0 / self.mass.0;
         self.inertia.0 += rhs.inertia.0;
-        self.inv_inertia.0 = self.inertia.inverse().0;
-        self.local_com.0 += rhs.local_center_of_mass.0;
+        self.inverse_inertia.0 = self.inertia.inverse().0;
+        self.center_of_mass.0 += rhs.center_of_mass.0;
     }
 }
 
 impl<'w> SubAssign<ColliderMassProperties> for MassPropsQueryItem<'w> {
     fn sub_assign(&mut self, rhs: ColliderMassProperties) {
         self.mass.0 -= rhs.mass.0;
-        self.inv_mass.0 = 1.0 / self.mass.0;
+        self.inverse_mass.0 = 1.0 / self.mass.0;
         self.inertia.0 -= rhs.inertia.0;
-        self.inv_inertia.0 = self.inertia.inverse().0;
-        self.local_com.0 -= rhs.local_center_of_mass.0;
+        self.inverse_inertia.0 = self.inertia.inverse().0;
+        self.center_of_mass.0 -= rhs.center_of_mass.0;
     }
 }

--- a/src/constraints/angular_constraint.rs
+++ b/src/constraints/angular_constraint.rs
@@ -25,18 +25,18 @@ pub trait AngularConstraint: XpbdConstraint<2> {
         // `axis.z` is 1 or -1 and it controls if the body should rotate counterclockwise or clockwise
         let p = -delta_lagrange * axis.z;
 
-        let rot1 = *body1.rot;
-        let rot2 = *body2.rot;
+        let rot1 = *body1.rotation;
+        let rot2 = *body2.rotation;
 
         let inv_inertia1 = body1.world_inv_inertia().0;
         let inv_inertia2 = body2.world_inv_inertia().0;
 
         // Apply rotational updates
         if body1.rb.is_dynamic() {
-            *body1.rot += Self::get_delta_rot(rot1, inv_inertia1, p);
+            *body1.rotation += Self::get_delta_rot(rot1, inv_inertia1, p);
         }
         if body2.rb.is_dynamic() {
-            *body2.rot -= Self::get_delta_rot(rot2, inv_inertia2, p);
+            *body2.rotation -= Self::get_delta_rot(rot2, inv_inertia2, p);
         }
 
         p
@@ -60,18 +60,18 @@ pub trait AngularConstraint: XpbdConstraint<2> {
         // Compute angular impulse
         let p = -delta_lagrange * axis;
 
-        let rot1 = *body1.rot;
-        let rot2 = *body2.rot;
+        let rot1 = *body1.rotation;
+        let rot2 = *body2.rotation;
 
         let inv_inertia1 = body1.world_inv_inertia().0;
         let inv_inertia2 = body2.world_inv_inertia().0;
 
         // Apply rotational updates
         if body1.rb.is_dynamic() {
-            *body1.rot += Self::get_delta_rot(rot1, inv_inertia1, p);
+            *body1.rotation += Self::get_delta_rot(rot1, inv_inertia1, p);
         }
         if body2.rb.is_dynamic() {
-            *body2.rot -= Self::get_delta_rot(rot2, inv_inertia2, p);
+            *body2.rotation -= Self::get_delta_rot(rot2, inv_inertia2, p);
         }
 
         p

--- a/src/constraints/angular_constraint.rs
+++ b/src/constraints/angular_constraint.rs
@@ -80,7 +80,7 @@ pub trait AngularConstraint: XpbdConstraint<2> {
     #[cfg(feature = "2d")]
     fn compute_generalized_inverse_mass(&self, body: &RigidBodyQueryItem, axis: Vector3) -> Scalar {
         if body.rb.is_dynamic() {
-            axis.dot(body.inv_inertia.0 * axis)
+            axis.dot(body.inverse_inertia.0 * axis)
         } else {
             // Static and kinematic bodies are a special case, where 0.0 can be thought of as infinite mass.
             0.0
@@ -98,15 +98,15 @@ pub trait AngularConstraint: XpbdConstraint<2> {
     }
 
     #[cfg(feature = "2d")]
-    fn get_delta_rot(_rot: Rot, inv_inertia: Scalar, p: Scalar) -> Rot {
+    fn get_delta_rot(_rot: Rotation, inverse_inertia: Scalar, p: Scalar) -> Rotation {
         // Equation 8/9 but in 2D
-        Rot::from_radians(inv_inertia * p)
+        Rotation::from_radians(inverse_inertia * p)
     }
 
     #[cfg(feature = "3d")]
-    fn get_delta_rot(rot: Rot, inv_inertia: Matrix3, p: Vector) -> Rot {
+    fn get_delta_rot(rot: Rotation, inverse_inertia: Matrix3, p: Vector) -> Rotation {
         // Equation 8/9
-        Rot(Quaternion::from_vec4(0.5 * (inv_inertia * p).extend(0.0)) * rot.0)
+        Rotation(Quaternion::from_vec4(0.5 * (inverse_inertia * p).extend(0.0)) * rot.0)
     }
 
     /// Computes the torque acting along the constraint using the equation tau = lambda * n / h^2

--- a/src/constraints/joints/fixed.rs
+++ b/src/constraints/joints/fixed.rs
@@ -131,13 +131,13 @@ impl Joint for FixedJoint {
 
 impl FixedJoint {
     #[cfg(feature = "2d")]
-    fn get_delta_q(&self, rot1: &Rot, rot2: &Rot) -> Vector3 {
-        rot1.mul(rot2.inv()).as_radians() * Vector3::Z
+    fn get_delta_q(&self, rot1: &Rotation, rot2: &Rotation) -> Vector3 {
+        rot1.mul(rot2.inverse()).as_radians() * Vector3::Z
     }
 
     #[cfg(feature = "3d")]
-    fn get_delta_q(&self, rot1: &Rot, rot2: &Rot) -> Vector {
-        2.0 * (rot1.0 * rot2.inverse()).xyz()
+    fn get_delta_q(&self, rot1: &Rotation, rot2: &Rotation) -> Vector {
+        2.0 * (rot1.0 * rot2.inverse().0).xyz()
     }
 }
 

--- a/src/constraints/joints/fixed.rs
+++ b/src/constraints/joints/fixed.rs
@@ -18,11 +18,11 @@ pub struct FixedJoint {
     /// Attachment point on the second body.
     pub local_anchor2: Vector,
     /// Linear damping applied by the joint.
-    pub damping_lin: Scalar,
+    pub damping_linear: Scalar,
     /// Angular damping applied by the joint.
-    pub damping_ang: Scalar,
+    pub damping_angular: Scalar,
     /// Lagrange multiplier for the positional correction.
-    pub pos_lagrange: Scalar,
+    pub position_lagrange: Scalar,
     /// Lagrange multiplier for the angular correction caused by the alignment of the bodies.
     pub align_lagrange: Scalar,
     /// The joint's compliance, the inverse of stiffness, has the unit meters / Newton.
@@ -39,7 +39,7 @@ impl XpbdConstraint<2> for FixedJoint {
     }
 
     fn clear_lagrange_multipliers(&mut self) {
-        self.pos_lagrange = 0.0;
+        self.position_lagrange = 0.0;
         self.align_lagrange = 0.0;
     }
 
@@ -48,13 +48,13 @@ impl XpbdConstraint<2> for FixedJoint {
         let compliance = self.compliance;
 
         // Align orientation
-        let dq = self.get_delta_q(&body1.rot, &body2.rot);
+        let dq = self.get_delta_q(&body1.rotation, &body2.rotation);
         let mut lagrange = self.align_lagrange;
         self.align_torque = self.align_orientation(body1, body2, dq, &mut lagrange, compliance, dt);
         self.align_lagrange = lagrange;
 
         // Align position of local attachment points
-        let mut lagrange = self.pos_lagrange;
+        let mut lagrange = self.position_lagrange;
         self.force = self.align_position(
             body1,
             body2,
@@ -64,7 +64,7 @@ impl XpbdConstraint<2> for FixedJoint {
             compliance,
             dt,
         );
-        self.pos_lagrange = lagrange;
+        self.position_lagrange = lagrange;
     }
 }
 
@@ -75,9 +75,9 @@ impl Joint for FixedJoint {
             entity2,
             local_anchor1: Vector::ZERO,
             local_anchor2: Vector::ZERO,
-            damping_lin: 1.0,
-            damping_ang: 1.0,
-            pos_lagrange: 0.0,
+            damping_linear: 1.0,
+            damping_angular: 1.0,
+            position_lagrange: 0.0,
             align_lagrange: 0.0,
             compliance: 0.0,
             force: Vector::ZERO,
@@ -108,24 +108,24 @@ impl Joint for FixedJoint {
 
     fn with_lin_vel_damping(self, damping: Scalar) -> Self {
         Self {
-            damping_lin: damping,
+            damping_linear: damping,
             ..self
         }
     }
 
     fn with_ang_vel_damping(self, damping: Scalar) -> Self {
         Self {
-            damping_ang: damping,
+            damping_angular: damping,
             ..self
         }
     }
 
-    fn damping_lin(&self) -> Scalar {
-        self.damping_lin
+    fn damping_linear(&self) -> Scalar {
+        self.damping_linear
     }
 
-    fn damping_ang(&self) -> Scalar {
-        self.damping_ang
+    fn damping_angular(&self) -> Scalar {
+        self.damping_angular
     }
 }
 

--- a/src/constraints/joints/mod.rs
+++ b/src/constraints/joints/mod.rs
@@ -34,10 +34,10 @@ pub trait Joint: Component + PositionConstraint + AngularConstraint {
     fn with_ang_vel_damping(self, damping: Scalar) -> Self;
 
     /// Returns the linear velocity damping of the joint.
-    fn damping_lin(&self) -> Scalar;
+    fn damping_linear(&self) -> Scalar;
 
     /// Returns the angular velocity damping of the joint.
-    fn damping_ang(&self) -> Scalar;
+    fn damping_angular(&self) -> Scalar;
 
     /// Applies a positional correction that aligns the positions of the local attachment points `r1` and `r2`.
     ///
@@ -53,11 +53,11 @@ pub trait Joint: Component + PositionConstraint + AngularConstraint {
         compliance: Scalar,
         dt: Scalar,
     ) -> Vector {
-        let world_r1 = body1.rot.rotate(r1);
-        let world_r2 = body2.rot.rotate(r2);
+        let world_r1 = body1.rotation.rotate(r1);
+        let world_r2 = body2.rotation.rotate(r2);
 
         let delta_x = DistanceLimit::new(0.0, 0.0)
-            .compute_correction(body1.pos.0 + world_r1, body2.pos.0 + world_r2);
+            .compute_correction(body1.position.0 + world_r1, body2.position.0 + world_r2);
         let magnitude = delta_x.length();
 
         if magnitude <= Scalar::EPSILON {

--- a/src/constraints/joints/prismatic.rs
+++ b/src/constraints/joints/prismatic.rs
@@ -21,11 +21,11 @@ pub struct PrismaticJoint {
     /// The extents of the allowed relative translation along the free axis.
     pub free_axis_limits: Option<DistanceLimit>,
     /// Linear damping applied by the joint.
-    pub damping_lin: Scalar,
+    pub damping_linear: Scalar,
     /// Angular damping applied by the joint.
-    pub damping_ang: Scalar,
+    pub damping_angular: Scalar,
     /// Lagrange multiplier for the positional correction.
-    pub pos_lagrange: Scalar,
+    pub position_lagrange: Scalar,
     /// Lagrange multiplier for the angular correction caused by the alignment of the bodies.
     pub align_lagrange: Scalar,
     /// The joint's compliance, the inverse of stiffness, has the unit meters / Newton.
@@ -42,7 +42,7 @@ impl XpbdConstraint<2> for PrismaticJoint {
     }
 
     fn clear_lagrange_multipliers(&mut self) {
-        self.pos_lagrange = 0.0;
+        self.position_lagrange = 0.0;
         self.align_lagrange = 0.0;
     }
 
@@ -51,7 +51,7 @@ impl XpbdConstraint<2> for PrismaticJoint {
         let compliance = self.compliance;
 
         // Align orientations
-        let dq = self.get_delta_q(&body1.rot, &body2.rot);
+        let dq = self.get_delta_q(&body1.rotation, &body2.rotation);
         let mut lagrange = self.align_lagrange;
         self.align_torque = self.align_orientation(body1, body2, dq, &mut lagrange, compliance, dt);
         self.align_lagrange = lagrange;
@@ -70,9 +70,9 @@ impl Joint for PrismaticJoint {
             local_anchor2: Vector::ZERO,
             free_axis: Vector::X,
             free_axis_limits: None,
-            damping_lin: 1.0,
-            damping_ang: 1.0,
-            pos_lagrange: 0.0,
+            damping_linear: 1.0,
+            damping_angular: 1.0,
+            position_lagrange: 0.0,
             align_lagrange: 0.0,
             compliance: 0.0,
             force: Vector::ZERO,
@@ -103,24 +103,24 @@ impl Joint for PrismaticJoint {
 
     fn with_lin_vel_damping(self, damping: Scalar) -> Self {
         Self {
-            damping_lin: damping,
+            damping_linear: damping,
             ..self
         }
     }
 
     fn with_ang_vel_damping(self, damping: Scalar) -> Self {
         Self {
-            damping_ang: damping,
+            damping_angular: damping,
             ..self
         }
     }
 
-    fn damping_lin(&self) -> Scalar {
-        self.damping_lin
+    fn damping_linear(&self) -> Scalar {
+        self.damping_linear
     }
 
-    fn damping_ang(&self) -> Scalar {
-        self.damping_ang
+    fn damping_angular(&self) -> Scalar {
+        self.damping_angular
     }
 }
 
@@ -134,16 +134,16 @@ impl PrismaticJoint {
         body2: &mut RigidBodyQueryItem,
         dt: Scalar,
     ) -> Vector {
-        let world_r1 = body1.rot.rotate(self.local_anchor1);
-        let world_r2 = body2.rot.rotate(self.local_anchor2);
+        let world_r1 = body1.rotation.rotate(self.local_anchor1);
+        let world_r2 = body2.rotation.rotate(self.local_anchor2);
 
         let mut delta_x = Vector::ZERO;
 
-        let axis1 = body1.rot.rotate(self.free_axis);
+        let axis1 = body1.rotation.rotate(self.free_axis);
         if let Some(limits) = self.free_axis_limits {
             delta_x += limits.compute_correction_along_axis(
-                body1.pos.0 + world_r1,
-                body2.pos.0 + world_r2,
+                body1.position.0 + world_r1,
+                body2.position.0 + world_r2,
                 axis1,
             );
         }
@@ -154,8 +154,8 @@ impl PrismaticJoint {
         {
             let axis2 = Vector::new(axis1.y, -axis1.x);
             delta_x += zero_distance_limit.compute_correction_along_axis(
-                body1.pos.0 + world_r1,
-                body2.pos.0 + world_r2,
+                body1.position.0 + world_r1,
+                body2.position.0 + world_r2,
                 axis2,
             );
         }
@@ -165,13 +165,13 @@ impl PrismaticJoint {
             let axis3 = axis1.cross(axis2);
 
             delta_x += zero_distance_limit.compute_correction_along_axis(
-                body1.pos.0 + world_r1,
-                body2.pos.0 + world_r2,
+                body1.position.0 + world_r1,
+                body2.position.0 + world_r2,
                 axis2,
             );
             delta_x += zero_distance_limit.compute_correction_along_axis(
-                body1.pos.0 + world_r1,
-                body2.pos.0 + world_r2,
+                body1.position.0 + world_r1,
+                body2.position.0 + world_r2,
                 axis3,
             );
         }
@@ -194,20 +194,20 @@ impl PrismaticJoint {
 
         // Compute Lagrange multiplier update
         let delta_lagrange = self.compute_lagrange_update(
-            self.pos_lagrange,
+            self.position_lagrange,
             magnitude,
             &gradients,
             &w,
             self.compliance,
             dt,
         );
-        self.pos_lagrange += delta_lagrange;
+        self.position_lagrange += delta_lagrange;
 
         // Apply positional correction to align the positions of the bodies
         self.apply_positional_correction(body1, body2, delta_lagrange, dir, world_r1, world_r2);
 
         // Return constraint force
-        self.compute_force(self.pos_lagrange, dir, dt)
+        self.compute_force(self.position_lagrange, dir, dt)
     }
 
     /// Sets the joint's free axis. Relative translations are allowed along this free axis.

--- a/src/constraints/joints/prismatic.rs
+++ b/src/constraints/joints/prismatic.rs
@@ -227,13 +227,13 @@ impl PrismaticJoint {
     }
 
     #[cfg(feature = "2d")]
-    fn get_delta_q(&self, rot1: &Rot, rot2: &Rot) -> Vector3 {
-        rot1.mul(rot2.inv()).as_radians() * Vector3::Z
+    fn get_delta_q(&self, rot1: &Rotation, rot2: &Rotation) -> Vector3 {
+        rot1.mul(rot2.inverse()).as_radians() * Vector3::Z
     }
 
     #[cfg(feature = "3d")]
-    fn get_delta_q(&self, rot1: &Rot, rot2: &Rot) -> Vector {
-        2.0 * (rot1.0 * rot2.inverse()).xyz()
+    fn get_delta_q(&self, rot1: &Rotation, rot2: &Rotation) -> Vector {
+        2.0 * (rot1.0 * rot2.inverse().0).xyz()
     }
 }
 

--- a/src/constraints/joints/revolute.rs
+++ b/src/constraints/joints/revolute.rs
@@ -27,11 +27,11 @@ pub struct RevoluteJoint {
     /// The extents of the allowed relative rotation of the bodies around the `aligned_axis`.
     pub angle_limit: Option<AngleLimit>,
     /// Linear damping applied by the joint.
-    pub damping_lin: Scalar,
+    pub damping_linear: Scalar,
     /// Angular damping applied by the joint.
-    pub damping_ang: Scalar,
+    pub damping_angular: Scalar,
     /// Lagrange multiplier for the positional correction.
-    pub pos_lagrange: Scalar,
+    pub position_lagrange: Scalar,
     /// Lagrange multiplier for the angular correction caused by the alignment of the bodies.
     pub align_lagrange: Scalar,
     /// Lagrange multiplier for the angular correction caused by the angle limits.
@@ -52,7 +52,7 @@ impl XpbdConstraint<2> for RevoluteJoint {
     }
 
     fn clear_lagrange_multipliers(&mut self) {
-        self.pos_lagrange = 0.0;
+        self.position_lagrange = 0.0;
         self.align_lagrange = 0.0;
         self.angle_limit_lagrange = 0.0;
     }
@@ -62,13 +62,13 @@ impl XpbdConstraint<2> for RevoluteJoint {
         let compliance = self.compliance;
 
         // Constrain the relative rotation of the bodies, only allowing rotation around one free axis
-        let dq = self.get_delta_q(&body1.rot, &body2.rot);
+        let dq = self.get_delta_q(&body1.rotation, &body2.rotation);
         let mut lagrange = self.align_lagrange;
         self.align_torque = self.align_orientation(body1, body2, dq, &mut lagrange, compliance, dt);
         self.align_lagrange = lagrange;
 
         // Align positions
-        let mut lagrange = self.pos_lagrange;
+        let mut lagrange = self.position_lagrange;
         self.force = self.align_position(
             body1,
             body2,
@@ -78,7 +78,7 @@ impl XpbdConstraint<2> for RevoluteJoint {
             compliance,
             dt,
         );
-        self.pos_lagrange = lagrange;
+        self.position_lagrange = lagrange;
 
         // Apply angle limits when rotating around the free axis
         self.angle_limit_torque = self.apply_angle_limits(body1, body2, dt);
@@ -94,9 +94,9 @@ impl Joint for RevoluteJoint {
             local_anchor2: Vector::ZERO,
             aligned_axis: Vector3::Z,
             angle_limit: None,
-            damping_lin: 1.0,
-            damping_ang: 1.0,
-            pos_lagrange: 0.0,
+            damping_linear: 1.0,
+            damping_angular: 1.0,
+            position_lagrange: 0.0,
             align_lagrange: 0.0,
             angle_limit_lagrange: 0.0,
             compliance: 0.0,
@@ -132,24 +132,24 @@ impl Joint for RevoluteJoint {
 
     fn with_lin_vel_damping(self, damping: Scalar) -> Self {
         Self {
-            damping_lin: damping,
+            damping_linear: damping,
             ..self
         }
     }
 
     fn with_ang_vel_damping(self, damping: Scalar) -> Self {
         Self {
-            damping_ang: damping,
+            damping_angular: damping,
             ..self
         }
     }
 
-    fn damping_lin(&self) -> Scalar {
-        self.damping_lin
+    fn damping_linear(&self) -> Scalar {
+        self.damping_linear
     }
 
-    fn damping_ang(&self) -> Scalar {
-        self.damping_ang
+    fn damping_angular(&self) -> Scalar {
+        self.damping_angular
     }
 }
 
@@ -191,8 +191,8 @@ impl RevoluteJoint {
                 self.aligned_axis.x,
                 self.aligned_axis.y,
             );
-            let a1 = body1.rot.rotate_vec3(limit_axis);
-            let a2 = body2.rot.rotate_vec3(limit_axis);
+            let a1 = body1.rotation.rotate_vec3(limit_axis);
+            let a2 = body2.rotation.rotate_vec3(limit_axis);
             let n = a1.cross(a2).normalize();
 
             if let Some(dq) = angle_limit.compute_correction(n, a1, a2, PI) {

--- a/src/constraints/joints/revolute.rs
+++ b/src/constraints/joints/revolute.rs
@@ -171,7 +171,7 @@ impl RevoluteJoint {
         }
     }
 
-    fn get_delta_q(&self, rot1: &Rot, rot2: &Rot) -> Vector3 {
+    fn get_delta_q(&self, rot1: &Rotation, rot2: &Rotation) -> Vector3 {
         let a1 = rot1.rotate_vec3(self.aligned_axis);
         let a2 = rot2.rotate_vec3(self.aligned_axis);
         a1.cross(a2)

--- a/src/constraints/joints/spherical.rs
+++ b/src/constraints/joints/spherical.rs
@@ -25,11 +25,11 @@ pub struct SphericalJoint {
     /// The extents of the allowed relative rotation of the bodies around the `twist_axis`.
     pub twist_limit: Option<AngleLimit>,
     /// Linear damping applied by the joint.
-    pub damping_lin: Scalar,
+    pub damping_linear: Scalar,
     /// Angular damping applied by the joint.
-    pub damping_ang: Scalar,
+    pub damping_angular: Scalar,
     /// Lagrange multiplier for the positional correction.
-    pub pos_lagrange: Scalar,
+    pub position_lagrange: Scalar,
     /// Lagrange multiplier for the angular correction caused by the swing limits.
     pub swing_lagrange: Scalar,
     /// Lagrange multiplier for the angular correction caused by the twist limits.
@@ -50,7 +50,7 @@ impl XpbdConstraint<2> for SphericalJoint {
     }
 
     fn clear_lagrange_multipliers(&mut self) {
-        self.pos_lagrange = 0.0;
+        self.position_lagrange = 0.0;
         self.swing_lagrange = 0.0;
         self.twist_lagrange = 0.0;
     }
@@ -60,7 +60,7 @@ impl XpbdConstraint<2> for SphericalJoint {
         let compliance = self.compliance;
 
         // Align positions
-        let mut lagrange = self.pos_lagrange;
+        let mut lagrange = self.position_lagrange;
         self.force = self.align_position(
             body1,
             body2,
@@ -70,7 +70,7 @@ impl XpbdConstraint<2> for SphericalJoint {
             compliance,
             dt,
         );
-        self.pos_lagrange = lagrange;
+        self.position_lagrange = lagrange;
 
         // Apply swing limits
         self.swing_torque = self.apply_swing_limits(body1, body2, dt);
@@ -91,9 +91,9 @@ impl Joint for SphericalJoint {
             twist_axis: Vector3::Y,
             swing_limit: None,
             twist_limit: None,
-            damping_lin: 1.0,
-            damping_ang: 1.0,
-            pos_lagrange: 0.0,
+            damping_linear: 1.0,
+            damping_angular: 1.0,
+            position_lagrange: 0.0,
             swing_lagrange: 0.0,
             twist_lagrange: 0.0,
             compliance: 0.0,
@@ -129,24 +129,24 @@ impl Joint for SphericalJoint {
 
     fn with_lin_vel_damping(self, damping: Scalar) -> Self {
         Self {
-            damping_lin: damping,
+            damping_linear: damping,
             ..self
         }
     }
 
     fn with_ang_vel_damping(self, damping: Scalar) -> Self {
         Self {
-            damping_ang: damping,
+            damping_angular: damping,
             ..self
         }
     }
 
-    fn damping_lin(&self) -> Scalar {
-        self.damping_lin
+    fn damping_linear(&self) -> Scalar {
+        self.damping_linear
     }
 
-    fn damping_ang(&self) -> Scalar {
-        self.damping_ang
+    fn damping_angular(&self) -> Scalar {
+        self.damping_angular
     }
 }
 
@@ -176,8 +176,8 @@ impl SphericalJoint {
         dt: Scalar,
     ) -> Torque {
         if let Some(joint_limit) = self.swing_limit {
-            let a1 = body1.rot.rotate_vec3(self.swing_axis);
-            let a2 = body2.rot.rotate_vec3(self.swing_axis);
+            let a1 = body1.rotation.rotate_vec3(self.swing_axis);
+            let a2 = body2.rotation.rotate_vec3(self.swing_axis);
 
             let n = a1.cross(a2);
             let n_magnitude = n.length();
@@ -207,11 +207,11 @@ impl SphericalJoint {
         dt: Scalar,
     ) -> Torque {
         if let Some(joint_limit) = self.twist_limit {
-            let a1 = body1.rot.rotate_vec3(self.swing_axis);
-            let a2 = body2.rot.rotate_vec3(self.swing_axis);
+            let a1 = body1.rotation.rotate_vec3(self.swing_axis);
+            let a2 = body2.rotation.rotate_vec3(self.swing_axis);
 
-            let b1 = body1.rot.rotate_vec3(self.twist_axis);
-            let b2 = body2.rot.rotate_vec3(self.twist_axis);
+            let b1 = body1.rotation.rotate_vec3(self.twist_axis);
+            let b2 = body2.rotation.rotate_vec3(self.twist_axis);
 
             let n = a1 + a2;
             let n_magnitude = n.length();

--- a/src/constraints/penetration.rs
+++ b/src/constraints/penetration.rs
@@ -73,8 +73,8 @@ impl PenetrationConstraint {
         let r2 = self.contact.world_r2;
 
         // Compute contact positions at the current state
-        let p1 = body1.pos.0 - body1.local_com.0 + body1.rot.rotate(self.contact.local_r1);
-        let p2 = body2.pos.0 - body2.local_com.0 + body2.rot.rotate(self.contact.local_r2);
+        let p1 = body1.pos.0 - body1.center_of_mass.0 + body1.rot.rotate(self.contact.local_r1);
+        let p2 = body2.pos.0 - body2.center_of_mass.0 + body2.rot.rotate(self.contact.local_r2);
 
         // Compute penetration depth
         let penetration = (p1 - p2).dot(normal);
@@ -119,12 +119,12 @@ impl PenetrationConstraint {
         let r2 = self.contact.world_r2;
 
         // Compute contact positions at the current state and before substep integration
-        let p1 = body1.pos.0 - body1.local_com.0 + body1.rot.rotate(self.contact.local_r1);
-        let p2 = body2.pos.0 - body2.local_com.0 + body2.rot.rotate(self.contact.local_r2);
-        let prev_p1 =
-            body1.prev_pos.0 - body1.local_com.0 + body1.prev_rot.rotate(self.contact.local_r1);
-        let prev_p2 =
-            body2.prev_pos.0 - body2.local_com.0 + body2.prev_rot.rotate(self.contact.local_r2);
+        let p1 = body1.pos.0 - body1.center_of_mass.0 + body1.rot.rotate(self.contact.local_r1);
+        let p2 = body2.pos.0 - body2.center_of_mass.0 + body2.rot.rotate(self.contact.local_r2);
+        let prev_p1 = body1.prev_pos.0 - body1.center_of_mass.0
+            + body1.prev_rot.rotate(self.contact.local_r1);
+        let prev_p2 = body2.prev_pos.0 - body2.center_of_mass.0
+            + body2.prev_rot.rotate(self.contact.local_r2);
 
         // Compute relative motion of the contact points and get the tangential component
         let delta_p = (p1 - prev_p1) - (p2 - prev_p2);

--- a/src/constraints/penetration.rs
+++ b/src/constraints/penetration.rs
@@ -73,8 +73,10 @@ impl PenetrationConstraint {
         let r2 = self.contact.world_r2;
 
         // Compute contact positions at the current state
-        let p1 = body1.pos.0 - body1.center_of_mass.0 + body1.rot.rotate(self.contact.local_r1);
-        let p2 = body2.pos.0 - body2.center_of_mass.0 + body2.rot.rotate(self.contact.local_r2);
+        let p1 = body1.position.0 - body1.center_of_mass.0
+            + body1.rotation.rotate(self.contact.local_r1);
+        let p2 = body2.position.0 - body2.center_of_mass.0
+            + body2.rotation.rotate(self.contact.local_r2);
 
         // Compute penetration depth
         let penetration = (p1 - p2).dot(normal);
@@ -119,12 +121,14 @@ impl PenetrationConstraint {
         let r2 = self.contact.world_r2;
 
         // Compute contact positions at the current state and before substep integration
-        let p1 = body1.pos.0 - body1.center_of_mass.0 + body1.rot.rotate(self.contact.local_r1);
-        let p2 = body2.pos.0 - body2.center_of_mass.0 + body2.rot.rotate(self.contact.local_r2);
-        let prev_p1 = body1.prev_pos.0 - body1.center_of_mass.0
-            + body1.prev_rot.rotate(self.contact.local_r1);
-        let prev_p2 = body2.prev_pos.0 - body2.center_of_mass.0
-            + body2.prev_rot.rotate(self.contact.local_r2);
+        let p1 = body1.position.0 - body1.center_of_mass.0
+            + body1.rotation.rotate(self.contact.local_r1);
+        let p2 = body2.position.0 - body2.center_of_mass.0
+            + body2.rotation.rotate(self.contact.local_r2);
+        let prev_p1 = body1.previous_position.0 - body1.center_of_mass.0
+            + body1.previous_rotation.rotate(self.contact.local_r1);
+        let prev_p2 = body2.previous_position.0 - body2.center_of_mass.0
+            + body2.previous_rotation.rotate(self.contact.local_r2);
 
         // Compute relative motion of the contact points and get the tangential component
         let delta_p = (p1 - prev_p1) - (p2 - prev_p2);

--- a/src/constraints/position_constraint.rs
+++ b/src/constraints/position_constraint.rs
@@ -23,20 +23,20 @@ pub trait PositionConstraint: XpbdConstraint<2> {
 
         // Compute positional impulse
         let p = delta_lagrange * direction;
-        let rot1 = *body1.rot;
-        let rot2 = *body2.rot;
+        let rot1 = *body1.rotation;
+        let rot2 = *body2.rotation;
 
         let inv_inertia1 = body1.world_inv_inertia().0;
         let inv_inertia2 = body2.world_inv_inertia().0;
 
         // Apply positional and rotational updates
         if body1.rb.is_dynamic() {
-            body1.pos.0 += p * body1.inverse_mass.0;
-            *body1.rot += Self::get_delta_rot(rot1, inv_inertia1, r1, p);
+            body1.position.0 += p * body1.inverse_mass.0;
+            *body1.rotation += Self::get_delta_rot(rot1, inv_inertia1, r1, p);
         }
         if body2.rb.is_dynamic() {
-            body2.pos.0 -= p * body2.inverse_mass.0;
-            *body2.rot -= Self::get_delta_rot(rot2, inv_inertia2, r2, p);
+            body2.position.0 -= p * body2.inverse_mass.0;
+            *body2.rotation -= Self::get_delta_rot(rot2, inv_inertia2, r2, p);
         }
 
         p

--- a/src/constraints/position_constraint.rs
+++ b/src/constraints/position_constraint.rs
@@ -31,11 +31,11 @@ pub trait PositionConstraint: XpbdConstraint<2> {
 
         // Apply positional and rotational updates
         if body1.rb.is_dynamic() {
-            body1.pos.0 += p * body1.inv_mass.0;
+            body1.pos.0 += p * body1.inverse_mass.0;
             *body1.rot += Self::get_delta_rot(rot1, inv_inertia1, r1, p);
         }
         if body2.rb.is_dynamic() {
-            body2.pos.0 -= p * body2.inv_mass.0;
+            body2.pos.0 -= p * body2.inverse_mass.0;
             *body2.rot -= Self::get_delta_rot(rot2, inv_inertia2, r2, p);
         }
 
@@ -50,7 +50,7 @@ pub trait PositionConstraint: XpbdConstraint<2> {
         n: Vector,
     ) -> Scalar {
         if body.rb.is_dynamic() {
-            body.inv_mass.0 + body.inv_inertia.0 * r.perp_dot(n).powi(2)
+            body.inverse_mass.0 + body.inverse_inertia.0 * r.perp_dot(n).powi(2)
         } else {
             // Static and kinematic bodies are a special case, where 0.0 can be thought of as infinite mass.
             0.0
@@ -65,13 +65,13 @@ pub trait PositionConstraint: XpbdConstraint<2> {
         n: Vector,
     ) -> Scalar {
         if body.rb.is_dynamic() {
-            let inv_inertia = body.world_inv_inertia().0;
+            let inverse_inertia = body.world_inv_inertia().0;
 
             let r_cross_n = r.cross(n); // Compute the cross product only once
 
             // The line below is equivalent to Eq (2) because the component-wise multiplication of a transposed vector and another vector is equal to the dot product of the two vectors.
             // a^T * b = a • b
-            body.inv_mass.0 + r_cross_n.dot(inv_inertia * r_cross_n)
+            body.inverse_mass.0 + r_cross_n.dot(inverse_inertia * r_cross_n)
         } else {
             // Static and kinematic bodies are a special case, where 0.0 can be thought of as infinite mass.
             0.0
@@ -79,15 +79,15 @@ pub trait PositionConstraint: XpbdConstraint<2> {
     }
 
     #[cfg(feature = "2d")]
-    fn get_delta_rot(_rot: Rot, inv_inertia: Scalar, r: Vector, p: Vector) -> Rot {
+    fn get_delta_rot(_rot: Rotation, inverse_inertia: Scalar, r: Vector, p: Vector) -> Rotation {
         // Equation 8/9 but in 2D
-        Rot::from_radians(inv_inertia * r.perp_dot(p))
+        Rotation::from_radians(inverse_inertia * r.perp_dot(p))
     }
 
     #[cfg(feature = "3d")]
-    fn get_delta_rot(rot: Rot, inv_inertia: Matrix3, r: Vector, p: Vector) -> Rot {
+    fn get_delta_rot(rot: Rotation, inverse_inertia: Matrix3, r: Vector, p: Vector) -> Rotation {
         // Equation 8/9
-        Rot(Quaternion::from_vec4(0.5 * (inv_inertia * r.cross(p)).extend(0.0)) * rot.0)
+        Rotation(Quaternion::from_vec4(0.5 * (inverse_inertia * r.cross(p)).extend(0.0)) * rot.0)
     }
 
     /// Computes the force acting along the constraint using the equation f = lambda * n / h^2

--- a/src/plugins/integrator.rs
+++ b/src/plugins/integrator.rs
@@ -10,15 +10,15 @@ impl Plugin for IntegratorPlugin {
     fn build(&self, app: &mut App) {
         app.get_schedule_mut(SubstepSchedule)
             .expect("add SubstepSchedule first")
-            .add_systems((integrate_pos, integrate_rot).in_set(SubsteppingSet::Integrate));
+            .add_systems((integrate_pos, integrate_rot).in_set(SubstepSet::Integrate));
     }
 }
 
 type PosIntegrationComponents = (
     &'static RigidBody,
-    &'static mut Pos,
-    &'static mut PrevPos,
-    &'static mut LinVel,
+    &'static mut Position,
+    &'static mut PreviousPosition,
+    &'static mut LinearVelocity,
     &'static ExternalForce,
     &'static Mass,
 );
@@ -49,12 +49,12 @@ fn integrate_pos(
 
 type RotIntegrationComponents = (
     &'static RigidBody,
-    &'static mut Rot,
-    &'static mut PrevRot,
-    &'static mut AngVel,
+    &'static mut Rotation,
+    &'static mut PreviousRotation,
+    &'static mut AngularVelocity,
     &'static ExternalTorque,
     &'static Inertia,
-    &'static InvInertia,
+    &'static InverseInertia,
 );
 
 /// Explicitly integrates the rotations and angular velocities of bodies taking only external torque into account. This acts as a prediction for the next rotations of the bodies.
@@ -63,7 +63,7 @@ fn integrate_rot(
     mut bodies: Query<RotIntegrationComponents, Without<Sleeping>>,
     sub_dt: Res<SubDeltaTime>,
 ) {
-    for (rb, mut rot, mut prev_rot, mut ang_vel, external_torque, _inertia, inv_inertia) in
+    for (rb, mut rot, mut prev_rot, mut ang_vel, external_torque, _inertia, inverse_inertia) in
         &mut bodies
     {
         prev_rot.0 = *rot;
@@ -74,10 +74,10 @@ fn integrate_rot(
 
         // Apply external torque
         if rb.is_dynamic() {
-            ang_vel.0 += sub_dt.0 * inv_inertia.0 * external_torque.0;
+            ang_vel.0 += sub_dt.0 * inverse_inertia.0 * external_torque.0;
         }
 
-        *rot += Rot::from_radians(sub_dt.0 * ang_vel.0);
+        *rot += Rotation::from_radians(sub_dt.0 * ang_vel.0);
     }
 }
 
@@ -87,7 +87,7 @@ fn integrate_rot(
     mut bodies: Query<RotIntegrationComponents, Without<Sleeping>>,
     sub_dt: Res<SubDeltaTime>,
 ) {
-    for (rb, mut rot, mut prev_rot, mut ang_vel, external_torque, inertia, inv_inertia) in
+    for (rb, mut rot, mut prev_rot, mut ang_vel, external_torque, inertia, inverse_inertia) in
         &mut bodies
     {
         prev_rot.0 = *rot;
@@ -99,7 +99,7 @@ fn integrate_rot(
         // Apply external torque
         if rb.is_dynamic() {
             let delta_ang_vel = sub_dt.0
-                * inv_inertia.rotated(&rot).0
+                * inverse_inertia.rotated(&rot).0
                 * (external_torque.0 - ang_vel.cross(inertia.rotated(&rot).0 * ang_vel.0));
             ang_vel.0 += delta_ang_vel;
         }

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -39,7 +39,7 @@ pub enum PhysicsSet {
     ///
     /// The broad phase speeds up collision detection, as the number of accurate collision checks is greatly reduced.
     BroadPhase,
-    /// Substepping is an inner loop inside a physics step. See [`SubsteppingSet`] and [`SubstepSchedule`].
+    /// Substepping is an inner loop inside a physics step. See [`SubstepSet`] and [`SubstepSchedule`].
     Substeps,
     /// The sleeping step controls when bodies are active. This improves performance and helps prevent jitter. See [`Sleeping`].
     Sleeping,
@@ -54,13 +54,13 @@ pub enum PhysicsSet {
 /// 3. Update velocities
 /// 4. Solve velocity constraints (dynamic friction and restitution)
 #[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum SubsteppingSet {
+pub enum SubstepSet {
     /// In the integration step, the position and velocity of each particle and body is explicitly integrated, taking only external forces like gravity (and forces applied by the user) into account.
     Integrate,
     /// The solver iterates through constraints and solves them.
     /// This step is also responsible for narrow phase collision detection, as it creates a [`PenetrationConstraint`] for each contact.
     ///
-    /// **Note**: If you want to create your own constraints, you should add them in [`SubsteppingSet::SolveUserConstraints`]
+    /// **Note**: If you want to create your own constraints, you should add them in [`SubstepSet::SolveUserConstraints`]
     /// to avoid system order ambiguities.
     SolveConstraints,
     /// The position solver iterates through custom constraints created by the user and solves them.

--- a/src/plugins/prepare.rs
+++ b/src/plugins/prepare.rs
@@ -258,7 +258,7 @@ fn update_aabb(
     }
 }
 
-type MassPropsChanged = Or<(
+type MassPropertiesChanged = Or<(
     Changed<Mass>,
     Changed<InverseMass>,
     Changed<Inertia>,
@@ -271,7 +271,7 @@ type MassPropsChanged = Or<(
 ///
 /// Also updates the collider's mass properties if the body has a collider.
 fn update_mass_properties(
-    mut bodies: Query<(MassPropsQuery, Option<ColliderQuery>), MassPropsChanged>,
+    mut bodies: Query<(MassPropertiesQuery, Option<ColliderQuery>), MassPropertiesChanged>,
 ) {
     for (mut mass_properties, collider) in &mut bodies {
         if mass_properties.mass.is_changed() && mass_properties.mass.0 >= Scalar::EPSILON {

--- a/src/plugins/setup.rs
+++ b/src/plugins/setup.rs
@@ -19,7 +19,7 @@ use crate::prelude::*;
 /// 4. [`PhysicsSet::Sleeping`],
 /// 5. [`PhysicsSet::Sync`],
 ///
-/// The [`SubstepSchedule`] handles physics substepping. It is run [`NumSubsteps`] times in [`PhysicsSet::Substeps`],
+/// The [`SubstepSchedule`] handles physics substepping. It is run [`SubstepCount`] times in [`PhysicsSet::Substeps`],
 /// and it typically handles things like collision detection and constraint solving.
 ///
 /// Substepping sets are added by the solver plugin if it is enabled. See [`SolverPlugin`] for more information.
@@ -31,8 +31,8 @@ impl Plugin for PhysicsSetupPlugin {
         app.init_resource::<PhysicsTimestep>()
             .init_resource::<DeltaTime>()
             .init_resource::<SubDeltaTime>()
-            .init_resource::<NumSubsteps>()
-            .init_resource::<NumPosIters>()
+            .init_resource::<SubstepCount>()
+            .init_resource::<IterationCount>()
             .init_resource::<BroadCollisionPairs>()
             .init_resource::<SleepingThreshold>()
             .init_resource::<DeactivationTime>()
@@ -41,8 +41,8 @@ impl Plugin for PhysicsSetupPlugin {
             .register_type::<PhysicsTimestep>()
             .register_type::<DeltaTime>()
             .register_type::<SubDeltaTime>()
-            .register_type::<NumSubsteps>()
-            .register_type::<NumPosIters>()
+            .register_type::<SubstepCount>()
+            .register_type::<IterationCount>()
             .register_type::<BroadCollisionPairs>()
             .register_type::<SleepingThreshold>()
             .register_type::<DeactivationTime>()
@@ -52,23 +52,23 @@ impl Plugin for PhysicsSetupPlugin {
             .register_type::<Sleeping>()
             .register_type::<SleepingDisabled>()
             .register_type::<TimeSleeping>()
-            .register_type::<Pos>()
-            .register_type::<Rot>()
-            .register_type::<PrevPos>()
-            .register_type::<PrevRot>()
-            .register_type::<LinVel>()
-            .register_type::<AngVel>()
-            .register_type::<PreSolveLinVel>()
-            .register_type::<PreSolveAngVel>()
+            .register_type::<Position>()
+            .register_type::<Rotation>()
+            .register_type::<PreviousPosition>()
+            .register_type::<PreviousRotation>()
+            .register_type::<LinearVelocity>()
+            .register_type::<AngularVelocity>()
+            .register_type::<PreSolveLinearVelocity>()
+            .register_type::<PreSolveAngularVelocity>()
             .register_type::<Restitution>()
             .register_type::<Friction>()
             .register_type::<ExternalForce>()
             .register_type::<ExternalTorque>()
             .register_type::<Mass>()
-            .register_type::<InvMass>()
+            .register_type::<InverseMass>()
             .register_type::<Inertia>()
-            .register_type::<InvInertia>()
-            .register_type::<LocalCom>()
+            .register_type::<InverseInertia>()
+            .register_type::<CenterOfMass>()
             .register_type::<CollidingEntities>();
 
         let mut physics_schedule = Schedule::default();
@@ -126,7 +126,7 @@ impl Plugin for PhysicsSetupPlugin {
 pub struct PhysicsSchedule;
 
 /// The substepping schedule. The number of substeps per physics step is
-/// configured through the [`NumSubsteps`] resource.
+/// configured through the [`SubstepCount`] resource.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, ScheduleLabel)]
 pub struct SubstepSchedule;
 
@@ -211,7 +211,7 @@ fn run_physics_schedule(world: &mut World) {
 
 /// Runs the [`SubstepSchedule`].
 fn run_substep_schedule(world: &mut World) {
-    let NumSubsteps(substeps) = *world.resource::<NumSubsteps>();
+    let SubstepCount(substeps) = *world.resource::<SubstepCount>();
     let dt = world.resource::<DeltaTime>().0;
 
     // Update `SubDeltaTime`

--- a/src/plugins/sleeping.rs
+++ b/src/plugins/sleeping.rs
@@ -25,8 +25,8 @@ impl Plugin for SleepingPlugin {
 type SleepingQueryComponents = (
     Entity,
     &'static RigidBody,
-    &'static mut LinVel,
-    &'static mut AngVel,
+    &'static mut LinearVelocity,
+    &'static mut AngularVelocity,
     &'static mut TimeSleeping,
 );
 
@@ -67,17 +67,17 @@ fn mark_sleeping_bodies(
         // If the body has been still for long enough, set it to sleep and reset velocities.
         if time_sleeping.0 > deactivation_time.0 {
             commands.entity(entity).insert(Sleeping);
-            *lin_vel = LinVel::ZERO;
-            *ang_vel = AngVel::ZERO;
+            *lin_vel = LinearVelocity::ZERO;
+            *ang_vel = AngularVelocity::ZERO;
         }
     }
 }
 
 type BodyWokeUpFilter = Or<(
-    Changed<Pos>,
-    Changed<Rot>,
-    Changed<LinVel>,
-    Changed<AngVel>,
+    Changed<Position>,
+    Changed<Rotation>,
+    Changed<LinearVelocity>,
+    Changed<AngularVelocity>,
     Changed<ExternalForce>,
     Changed<ExternalTorque>,
 )>;

--- a/src/plugins/sync.rs
+++ b/src/plugins/sync.rs
@@ -16,20 +16,20 @@ impl Plugin for SyncPlugin {
 
 type RigidBodyParentComponents = (
     &'static GlobalTransform,
-    Option<&'static Pos>,
-    Option<&'static Rot>,
+    Option<&'static Position>,
+    Option<&'static Rotation>,
 );
 
-/// Copies [`Pos`] and [`Rot`] values from the physics world to Bevy [`Transform`]s.
+/// Copies [`Position`] and [`Rotation`] values from the physics world to Bevy [`Transform`]s.
 #[cfg(feature = "2d")]
 fn sync_transforms(
-    mut bodies: Query<(&mut Transform, &Pos, &Rot, Option<&Parent>)>,
+    mut bodies: Query<(&mut Transform, &Position, &Rotation, Option<&Parent>)>,
     parents: Query<RigidBodyParentComponents, With<Children>>,
 ) {
     for (mut transform, pos, rot, parent) in &mut bodies {
         if let Some(parent) = parent {
             if let Ok((parent_transform, parent_pos, parent_rot)) = parents.get(**parent) {
-                // Compute the global transform of the parent using its Pos and Rot
+                // Compute the global transform of the parent using its Position and Rotation
                 let parent_transform = parent_transform.compute_transform();
                 let parent_pos = parent_pos.map_or(parent_transform.translation, |pos| {
                     pos.extend(0.0).as_vec3_f32()
@@ -60,19 +60,19 @@ fn sync_transforms(
     }
 }
 
-/// Copies [`Pos`] and [`Rot`] values from the physics world to Bevy's [`Transform`]s.
+/// Copies [`Position`] and [`Rotation`] values from the physics world to Bevy's [`Transform`]s.
 ///
 /// Nested rigid bodies move independently of each other, so the [`Transform`]s of child entities are updated
-/// based on their own and their parent's [`Pos`] and [`Rot`].
+/// based on their own and their parent's [`Position`] and [`Rotation`].
 #[cfg(feature = "3d")]
 fn sync_transforms(
-    mut bodies: Query<(&mut Transform, &Pos, &Rot, Option<&Parent>)>,
+    mut bodies: Query<(&mut Transform, &Position, &Rotation, Option<&Parent>)>,
     parents: Query<RigidBodyParentComponents, With<Children>>,
 ) {
     for (mut transform, pos, rot, parent) in &mut bodies {
         if let Some(parent) = parent {
             if let Ok((parent_transform, parent_pos, parent_rot)) = parents.get(**parent) {
-                // Compute the global transform of the parent using its Pos and Rot
+                // Compute the global transform of the parent using its Position and Rotation
                 let parent_transform = parent_transform.compute_transform();
                 let parent_pos =
                     parent_pos.map_or(parent_transform.translation, |pos| pos.as_vec3_f32());

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -30,7 +30,7 @@ impl Default for PhysicsTimestep {
 #[reflect(Resource)]
 pub struct DeltaTime(pub Scalar);
 
-/// How much time the previous physics substep took. This depends on the [`DeltaTime`] and [`NumSubsteps`] resources.
+/// How much time the previous physics substep took. This depends on the [`DeltaTime`] and [`SubstepCount`] resources.
 #[derive(Reflect, Resource, Default)]
 #[reflect(Resource)]
 pub struct SubDeltaTime(pub Scalar);
@@ -38,20 +38,20 @@ pub struct SubDeltaTime(pub Scalar);
 /// The number of substeps used in XPBD simulation. A higher number of substeps reduces the value of [`SubDeltaTime`], which results in a more accurate simulation at the cost of performance.
 #[derive(Reflect, Resource, Clone, Copy)]
 #[reflect(Resource)]
-pub struct NumSubsteps(pub u32);
+pub struct SubstepCount(pub u32);
 
-impl Default for NumSubsteps {
+impl Default for SubstepCount {
     fn default() -> Self {
         Self(8)
     }
 }
 
-/// The number of iterations used in the position solver. It is recommended to keep this low and to increase [`NumSubsteps`] instead, as substepping can provide better convergence, accuracy and energy conservation.
+/// The number of iterations used in the position solver. It is recommended to keep this low and to increase [`SubstepCount`] instead, as substepping can provide better convergence, accuracy and energy conservation.
 #[derive(Reflect, Resource)]
 #[reflect(Resource)]
-pub struct NumPosIters(pub u32);
+pub struct IterationCount(pub u32);
 
-impl Default for NumPosIters {
+impl Default for IterationCount {
     fn default() -> Self {
         Self(4)
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -45,7 +45,7 @@ fn setup_cubes_simulation(mut commands: Commands) {
     let floor_size = Vector::new(80.0, 1.0, 80.0);
     commands.spawn((
         RigidBody::Static,
-        Pos(Vector::NEG_Y),
+        Position(Vector::NEG_Y),
         Collider::cuboid(floor_size.x, floor_size.y, floor_size.z),
     ));
 
@@ -64,7 +64,7 @@ fn setup_cubes_simulation(mut commands: Commands) {
                 commands.spawn((
                     SpatialBundle::default(),
                     RigidBody::Dynamic,
-                    Pos(pos + Vector::Y * 5.0),
+                    Position(pos + Vector::Y * 5.0),
                     Collider::cuboid(radius * 2.0, radius * 2.0, radius * 2.0),
                     Id(next_id),
                 ));
@@ -97,7 +97,7 @@ fn body_with_velocity_moves() {
         commands.spawn((
             SpatialBundle::default(),
             RigidBody::Dynamic,
-            LinVel(Vector::X),
+            LinearVelocity(Vector::X),
         ));
     });
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,12 +3,12 @@
 use crate::prelude::*;
 
 #[cfg(feature = "2d")]
-pub(crate) fn make_isometry(pos: Vector, rot: &Rot) -> Isometry<Scalar> {
+pub(crate) fn make_isometry(pos: Vector, rot: &Rotation) -> Isometry<Scalar> {
     Isometry::<Scalar>::new(pos.into(), (*rot).into())
 }
 
 #[cfg(feature = "3d")]
-pub(crate) fn make_isometry(pos: Vector, rot: &Rot) -> Isometry<Scalar> {
+pub(crate) fn make_isometry(pos: Vector, rot: &Rotation) -> Isometry<Scalar> {
     Isometry::<Scalar>::new(pos.into(), rot.to_scaled_axis().into())
 }
 


### PR DESCRIPTION
This renames lots of names to be more readable, clear and consistent. Longer names are typically better than shortened names as long as they are clear and not too long (think Java).

## Changed names

- `Pos` → `Position`
- `Rot` → `Rotation`
- `PrevPos` → `PreviousPosition`
- `PrevRot` → `PreviousRotation`
- `LinVel` → `LinearVelocity`
- `AngVel` → `AngularVelocity`
- `PreSolveLinVel` → `PreSolveLinearVelocity`
- `PreSolveAngVel` → `PreSolveAngularVelocity`
- `InvMass` → `InverseMass`
- `InvInertia` → `InverseInertia`
- `LocalCom` → `CenterOfMass`
- `MassPropsBundle` → `MassPropertiesBundle`
- `PrevColliderMassProperties` → `PreviousColliderMassProperties`
- `NumSubsteps` → `SubstepCount`
- `NumPosIters` → `IterationCount`
- `SubsteppingSet` → `SubstepSet`
- `Rotation` method `.inv()` → `.inverse()`