### PR TITLE
Add `Sensor` component for colliders

### DIFF
--- a/src/components/collider.rs
+++ b/src/components/collider.rs
@@ -246,6 +246,11 @@ fn extract_mesh_vertices_indices(mesh: &Mesh) -> Option<VerticesIndices> {
     Some((vtx, idx))
 }
 
+/// Marks a [`Collider`] as a sensor collider. Sensor colliders send collision events but
+/// don't cause a collision response. This is often used to detect when something enters or leaves an area.
+#[derive(Reflect, Clone, Component, Debug, Default, PartialEq, Eq)]
+pub struct Sensor;
+
 /// The Axis-Aligned Bounding Box of a collider.
 #[derive(Clone, Copy, Component, Deref, DerefMut, PartialEq)]
 pub struct ColliderAabb(pub Aabb);


### PR DESCRIPTION
Adds a `Sensor` component for creating colliders that generate collision events but don't cause a collision response.

## Example

```rust
commands.spawn((Collider::ball(0.5), Sensor));
```