### PR TITLE
Remove `Deref` and `DerefMut` from `AngularVelocity` in 2D

### DIFF
--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -139,7 +139,7 @@ pub struct PreSolveLinearVelocity(pub Vector);
 
 /// The angular velocity of a body in radians. Positive values will result in counter-clockwise rotation.
 #[cfg(feature = "2d")]
-#[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
+#[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, From)]
 #[reflect(Component)]
 pub struct AngularVelocity(pub Scalar);
 
@@ -165,7 +165,7 @@ impl From<Vec3> for AngularVelocity {
 
 /// The angular velocity of a body in radians before the velocity solve is performed. Positive values will result in counter-clockwise rotation.
 #[cfg(feature = "2d")]
-#[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
+#[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, From)]
 #[reflect(Component)]
 pub struct PreSolveAngularVelocity(pub Scalar);
 

--- a/src/plugins/integrator.rs
+++ b/src/plugins/integrator.rs
@@ -100,11 +100,11 @@ fn integrate_rot(
         if rb.is_dynamic() {
             let delta_ang_vel = sub_dt.0
                 * inverse_inertia.rotated(&rot).0
-                * (external_torque.0 - ang_vel.cross(inertia.rotated(&rot).0 * ang_vel.0));
+                * (external_torque.0 - ang_vel.0.cross(inertia.rotated(&rot).0 * ang_vel.0));
             ang_vel.0 += delta_ang_vel;
         }
 
-        let q = Quaternion::from_vec4(ang_vel.extend(0.0)) * rot.0;
+        let q = Quaternion::from_vec4(ang_vel.0.extend(0.0)) * rot.0;
         let (x, y, z, w) = (
             rot.x + sub_dt.0 * 0.5 * q.x,
             rot.y + sub_dt.0 * 0.5 * q.y,

--- a/src/plugins/prepare.rs
+++ b/src/plugins/prepare.rs
@@ -239,9 +239,9 @@ fn update_aabb(
         let lin_vel_len = lin_vel.map_or(0.0, |v| v.length());
 
         #[cfg(feature = "2d")]
-        let ang_vel_len = ang_vel.map_or(0.0, |v| v.abs());
+        let ang_vel_len = ang_vel.map_or(0.0, |v| v.0.abs());
         #[cfg(feature = "3d")]
-        let ang_vel_len = ang_vel.map_or(0.0, |v| v.length());
+        let ang_vel_len = ang_vel.map_or(0.0, |v| v.0.length());
 
         let computed_aabb = collider_query
             .collider

--- a/src/plugins/sleeping.rs
+++ b/src/plugins/sleeping.rs
@@ -48,9 +48,9 @@ fn mark_sleeping_bodies(
         let lin_vel_sq = lin_vel.length_squared();
 
         #[cfg(feature = "2d")]
-        let ang_vel_sq = ang_vel.powi(2);
+        let ang_vel_sq = ang_vel.0.powi(2);
         #[cfg(feature = "3d")]
-        let ang_vel_sq = ang_vel.dot(ang_vel.0);
+        let ang_vel_sq = ang_vel.0.dot(ang_vel.0);
 
         // Negative thresholds indicate that sleeping is disabled.
         let lin_sleeping_threshold_sq = sleep_threshold.linear * sleep_threshold.linear.abs();


### PR DESCRIPTION
Numbers have `.to_radians()`, but `AngularVelocity` is already in radians. This can lead to incorrect usage when `Deref` is implemented. For now the best solution seems to be just removing `Deref` from the 2D `AngularVelocity`.

Closes #13.