### PR TITLE
Fix generalized inverse mass in velocity solve

### DIFF
--- a/src/resources.rs
+++ b/src/resources.rs
@@ -42,7 +42,7 @@ pub struct SubstepCount(pub u32);
 
 impl Default for SubstepCount {
     fn default() -> Self {
-        Self(8)
+        Self(12)
     }
 }
 


### PR DESCRIPTION
Fixes #29.

The generalized inverse mass was being calculated based on the contact normal and not `delta_v`, so it didn't take dynamic friction into account.

In cases where the physics units used were larger, this caused explosive behaviour. Below is the `move_marbles` example, modified to use pixels instead of 3D units.

Previously it exploded when moving the marbles:

https://github.com/Jondolf/bevy_xpbd/assets/57632562/630e9b4a-8a7d-48f5-8ce0-2a18f74b3657

Now it works as expected:

https://github.com/Jondolf/bevy_xpbd/assets/57632562/feca6220-4ae6-4523-b251-38f12e08e02f