### PR TITLE
Add `collider-from-mesh` feature and make `bevy_render` optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
 
       - name: Run cargo test
-        run: cargo test --no-default-features --features enhanced-determinism,bevy_xpbd_2d/2d,bevy_xpbd_3d/3d,bevy_xpbd_2d/f64,bevy_xpbd_3d/f64
+        run: cargo test --no-default-features --features enhanced-determinism,collider-from-mesh,bevy_xpbd_2d/2d,bevy_xpbd_3d/3d,bevy_xpbd_2d/f64,bevy_xpbd_3d/f64
 
   lints:
     name: Lints

--- a/crates/bevy_xpbd_2d/Cargo.toml
+++ b/crates/bevy_xpbd_2d/Cargo.toml
@@ -12,13 +12,14 @@ keywords = [ "gamedev", "physics", "simulation", "xpbd", "bevy" ]
 categories = [ "game-development", "science", "simulation" ]
 
 [features]
-default = [ "2d", "f32" ]
+default = [ "2d", "f32", "collider-from-mesh" ]
 2d = []
 f32 = [ "dep:parry2d" ]
 f64 = [ "dep:parry2d-f64" ]
 debug-plugin = [ "dep:bevy_prototype_debug_lines", "examples_common_2d/debug-plugin" ]
 simd = [ "parry2d?/simd-stable", "parry2d-f64?/simd-stable" ]
 enhanced-determinism = [ "parry2d?/enhanced-determinism", "parry2d-f64?/enhanced-determinism" ]
+collider-from-mesh = [ "bevy/bevy_render" ]
 
 [lib]
 name = "bevy_xpbd_2d"
@@ -27,7 +28,7 @@ required-features = [ "2d" ]
 
 [dependencies]
 bevy_xpbd_derive = { path = "../bevy_xpbd_derive", version = "0.1" }
-bevy = { version = "0.10.1", default-features = false, features = [ "bevy_render" ] }
+bevy = { version = "0.10.1", default-features = false }
 bevy_prototype_debug_lines = { version = "0.10.1", optional = true }
 parry2d = { version = "0.13.1", optional = true }
 parry2d-f64 = { version = "0.13.1", optional = true }

--- a/crates/bevy_xpbd_3d/Cargo.toml
+++ b/crates/bevy_xpbd_3d/Cargo.toml
@@ -12,13 +12,14 @@ keywords = [ "gamedev", "physics", "simulation", "xpbd", "bevy" ]
 categories = [ "game-development", "science", "simulation" ]
 
 [features]
-default = [ "3d", "f32" ]
+default = [ "3d", "f32", "collider-from-mesh" ]
 3d = []
 f32 = [ "dep:parry3d" ]
 f64 = [ "dep:parry3d-f64" ]
 debug-plugin = [ "dep:bevy_prototype_debug_lines", "examples_common_3d/debug-plugin" ]
 simd = [ "parry3d?/simd-stable", "parry3d-f64?/simd-stable" ]
 enhanced-determinism = [ "parry3d?/enhanced-determinism", "parry3d-f64?/enhanced-determinism" ]
+collider-from-mesh = [ "bevy/bevy_render" ]
 
 [lib]
 name = "bevy_xpbd_3d"
@@ -27,7 +28,7 @@ required-features = [ "3d" ]
 
 [dependencies]
 bevy_xpbd_derive = { path = "../bevy_xpbd_derive", version = "0.1" }
-bevy = { version = "0.10.1", default-features = false, features = [ "bevy_render" ] }
+bevy = { version = "0.10.1", default-features = false }
 bevy_prototype_debug_lines = { version = "0.10.1", optional = true, features = [ "3d" ] }
 parry3d = { version = "0.13.1", optional = true }
 parry3d-f64 = { version = "0.13.1", optional = true }

--- a/src/components/collider.rs
+++ b/src/components/collider.rs
@@ -204,7 +204,7 @@ impl Collider {
     }
 
     /// Creates a collider with a triangle mesh shape built from a given Bevy `Mesh`.
-    #[cfg(feature = "3d")]
+    #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
     pub fn trimesh_from_bevy_mesh(mesh: &Mesh) -> Option<Self> {
         use parry::shape::TriMeshFlags;
 
@@ -216,7 +216,7 @@ impl Collider {
 
     /// Creates a collider with a compound shape obtained from the decomposition of a triangle mesh
     /// built from a given Bevy `Mesh`.
-    #[cfg(feature = "3d")]
+    #[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
     pub fn convex_decomposition_from_bevy_mesh(mesh: &Mesh) -> Option<Self> {
         let vertices_indices = extract_mesh_vertices_indices(mesh);
         vertices_indices.map(|(v, i)| SharedShape::convex_decomposition(&v, &i).into())
@@ -291,10 +291,10 @@ impl Collider {
     }
 }
 
-#[cfg(feature = "3d")]
+#[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
 type VerticesIndices = (Vec<nalgebra::Point3<Scalar>>, Vec<[u32; 3]>);
 
-#[cfg(feature = "3d")]
+#[cfg(all(feature = "3d", feature = "collider-from-mesh"))]
 fn extract_mesh_vertices_indices(mesh: &Mesh) -> Option<VerticesIndices> {
     let vertices = mesh.attribute(Mesh::ATTRIBUTE_POSITION)?;
     let indices = mesh.indices()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,8 @@
 //!
 //! ### Feature flags
 //!
+//! Default features: `2d`/`3d`, `f32` and `collider-from-mesh`
+//!
 //! - `2d` enables simulation on the `x` and `y` axes. Enabled by default for `bevy_xpbd_2d`. Incompatible with `3d`.
 //! - `3d` enables simulation on the `x`, `y` and `z` axes. Enabled by default for `bevy_xpbd_3d`. Incompatible with `2d`.
 //! - `f32` enables using `f32` numbers. Incompatible with `f64`.
@@ -78,6 +80,7 @@
 //! small timesteps. Incompatible with `f32`.
 //! - `debug-plugin` enables the `PhysicsDebugPlugin` used for rendering physics objects and events like [AABBs](ColliderAabb)
 //! and [contacts](Contact).
+//! - `collider-from-mesh` allows you to create [colliders](Collider) from Bevy meshes. Enables `bevy_render`.
 //! - `simd` enables [SIMD](https://en.wikipedia.org/wiki/Single_instruction,_multiple_data) optimizations.
 //! - `enhanced-determinism` enables increased determinism. (Note: cross-platform determinism doesn't work yet, even
 //! with this feature enabled)


### PR DESCRIPTION
Removes `bevy_render` from Bevy's default features to support headless usage. Adds a `collider-from-mesh` feature to still support creating colliders from Bevy meshes.