### PR TITLE
Add `LinearDamping` and `AngularDamping`

### DIFF
--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -500,6 +500,26 @@ impl From<Scalar> for Friction {
     }
 }
 
+/// Automatically slows down a dynamic [rigid body](RigidBody), decreasing it's [linear velocity](LinearVelocity)
+/// each frame. This can be used to simulate air resistance.
+///
+/// The default linear damping coefficient is `0.0`, which corresponds to no damping.
+#[derive(
+    Component, Reflect, Debug, Clone, Copy, PartialEq, PartialOrd, Default, Deref, DerefMut,
+)]
+#[reflect(Component)]
+pub struct LinearDamping(pub Scalar);
+
+/// Automatically slows down a dynamic [rigid body](RigidBody), decreasing it's [angular velocity](AngularVelocity)
+/// each frame. This can be used to simulate air resistance.
+///
+/// The default angular damping coefficient is `0.0`, which corresponds to no damping.
+#[derive(
+    Component, Reflect, Debug, Clone, Copy, PartialEq, PartialOrd, Default, Deref, DerefMut,
+)]
+#[reflect(Component)]
+pub struct AngularDamping(pub Scalar);
+
 #[cfg(test)]
 mod tests {
     use crate::prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@
 //!     - [Sensor colliders](Sensor)
 //!     - [Collision layers](CollisionLayers)
 //! - Material properties like [restitution](Restitution) and [friction](Friction)
+//! - [Linear damping](LinearDamping) and [angular damping](AngularDamping) for simulating drag
 //! - External [forces](ExternalForce) and [torque](ExternalTorque)
 //! - [Gravity](Gravity)
 //! - [Joints](joints)

--- a/src/plugins/setup.rs
+++ b/src/plugins/setup.rs
@@ -64,6 +64,8 @@ impl Plugin for PhysicsSetupPlugin {
             .register_type::<PreSolveAngularVelocity>()
             .register_type::<Restitution>()
             .register_type::<Friction>()
+            .register_type::<LinearDamping>()
+            .register_type::<AngularDamping>()
             .register_type::<ExternalForce>()
             .register_type::<ExternalTorque>()
             .register_type::<Mass>()


### PR DESCRIPTION
Adds the `LinearDamping` and `AngularDamping` components for simulating drag and air resistance. They are optional, so no damping is applied by default.