### PR TITLE
Support applying force at point and automatically clearing external force and torque

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,8 @@
 //! - [Define collision layers](CollisionLayers#creation)
 //! - [Define mass properties](RigidBody#adding-mass-properties)
 //! - [Use joints](joints#using-joints)
+//! - [Apply external forces](ExternalForce)
+//! - [Apply external torque](ExternalTorque)
 //! - [Configure gravity](Gravity)
 //! - [Configure restitution](Restitution)
 //! - [Configure friction](Friction)


### PR DESCRIPTION
Expands the `ExternalForce` and `ExternalTorque` APIs by adding a `persistence` property for controlling if a force should persist across frames and by adding several methods. Forces can now be applied at a given point using `apply_at_point`, which will also apply torque. The documentation of these components is also much better.