### PR TITLE
Use masks instead of collision layers for `SpatialQueryFilter`

### DIFF
--- a/src/plugins/spatial_query/query_filter.rs
+++ b/src/plugins/spatial_query/query_filter.rs
@@ -1,6 +1,6 @@
 use bevy::{prelude::*, utils::HashSet};
 
-use crate::prelude::CollisionLayers;
+use crate::prelude::*;
 
 /// Rules that determine which colliders are taken into account in [spatial queries](crate::spatial_query).
 ///
@@ -18,20 +18,28 @@ use crate::prelude::CollisionLayers;
 ///
 ///     // A query filter that only includes one layer and excludes the `object` entity
 ///     let query_filter = SpatialQueryFilter::new()
-///         .with_layers(CollisionLayers::from_bits(0b1111, 0b0001))
+///         .masks_from_bits(0b1011)
 ///         .without_entities([object]);
 ///
 ///     // Spawn a ray caster with the query filter
 ///     commands.spawn(RayCaster::default().with_query_filter(query_filter));
 /// }
 /// ```
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct SpatialQueryFilter {
-    /// If set, only the colliers with compatible [collision layers](CollisionLayers) will be taken into account
-    /// in [spatial queries](crate::spatial_query).
-    pub layers: Option<CollisionLayers>,
+    /// Specifies which [collision groups](CollisionLayers) will be included in a [spatial query](crate::spatial_query).
+    pub masks: u32,
     /// Entities that will not be included in [spatial queries](crate::spatial_query).
     pub excluded_entities: HashSet<Entity>,
+}
+
+impl Default for SpatialQueryFilter {
+    fn default() -> Self {
+        Self {
+            masks: 0xffff_ffff,
+            excluded_entities: default(),
+        }
+    }
 }
 
 impl SpatialQueryFilter {
@@ -40,11 +48,55 @@ impl SpatialQueryFilter {
         Self::default()
     }
 
-    /// Sets the layers that will be included in [spatial queries](crate::spatial_query).
-    /// Colliders that have incompatible [collision layers](CollisionLayers) will be excluded.
-    pub fn with_layers(mut self, layers: CollisionLayers) -> Self {
-        self.layers = Some(layers);
+    /// Disables all masks of the filter configuration. No colliders will be included in
+    /// [spatial queries](crate::spatial_query).
+    pub fn no_masks(mut self) -> Self {
+        self.masks = 0;
         self
+    }
+
+    /// Sets the masks of the filter configuration using a bitmask. Colliders with the corresponding
+    /// [collision group](CollisionLayers) will be included in the [spatial query](crate::spatial_query).
+    pub fn masks_from_bits(mut self, masks: u32) -> Self {
+        self.masks = masks;
+        self
+    }
+
+    /// Adds the given mask to the filter configuration. Colliders with the corresponding
+    /// [collision group](CollisionLayers) will be included in the [spatial query](crate::spatial_query).
+    pub fn with_mask(mut self, mask: impl PhysicsLayer) -> Self {
+        self.masks |= mask.to_bits();
+        self
+    }
+
+    /// Adds the given masks to the filter configuration. Colliders with the corresponding
+    /// [collision groups](CollisionLayers) will be included in the [spatial query](crate::spatial_query).
+    pub fn with_masks(mut self, masks: impl IntoIterator<Item = impl PhysicsLayer>) -> Self {
+        for mask in masks.into_iter().map(|l| l.to_bits()) {
+            self.masks |= mask;
+        }
+        self
+    }
+
+    /// Removes the given mask from the filter configuration. Colliders with the corresponding
+    /// [collision group](CollisionLayers) will be excluded from the [spatial query](crate::spatial_query).
+    pub fn without_mask(mut self, mask: impl PhysicsLayer) -> Self {
+        self.masks &= !mask.to_bits();
+        self
+    }
+
+    /// Removes the given masks from the filter configuration. Colliders with the corresponding
+    /// [collision groups](CollisionLayers) will be excluded from the [spatial query](crate::spatial_query).
+    pub fn without_masks(mut self, masks: impl IntoIterator<Item = impl PhysicsLayer>) -> Self {
+        for mask in masks.into_iter().map(|l| l.to_bits()) {
+            self.masks &= !mask;
+        }
+        self
+    }
+
+    /// Returns true if the given layer is contained in the filter's masks.
+    pub fn contains_mask(self, layer: impl PhysicsLayer) -> bool {
+        (self.masks & layer.to_bits()) != 0
     }
 
     /// Excludes the given entities from [spatial queries](crate::spatial_query).
@@ -58,15 +110,8 @@ impl SpatialQueryFilter {
     /// filter configuration.
     pub fn test(&self, entity: Entity, layers: CollisionLayers) -> bool {
         !self.excluded_entities.contains(&entity)
-            && (self.layers.is_none() || self.layers.is_some_and(|l| l.interacts_with(layers)))
-    }
-}
-
-impl From<CollisionLayers> for SpatialQueryFilter {
-    fn from(value: CollisionLayers) -> Self {
-        Self {
-            layers: Some(value),
-            ..default()
-        }
+            && CollisionLayers::from_bits(0xffff_ffff, self.masks).interacts_with(
+                CollisionLayers::from_bits(layers.groups_bits(), 0xffff_ffff),
+            )
     }
 }

--- a/src/plugins/spatial_query/query_filter.rs
+++ b/src/plugins/spatial_query/query_filter.rs
@@ -16,9 +16,9 @@ use crate::prelude::*;
 /// fn setup(mut commands: Commands) {
 ///     let object = commands.spawn(Collider::ball(0.5)).id();
 ///
-///     // A query filter that only includes one layer and excludes the `object` entity
+///     // A query filter that has three collision masks and excludes the `object` entity
 ///     let query_filter = SpatialQueryFilter::new()
-///         .masks_from_bits(0b1011)
+///         .with_masks_from_bits(0b1011)
 ///         .without_entities([object]);
 ///
 ///     // Spawn a ray caster with the query filter
@@ -48,55 +48,22 @@ impl SpatialQueryFilter {
         Self::default()
     }
 
-    /// Disables all masks of the filter configuration. No colliders will be included in
-    /// [spatial queries](crate::spatial_query).
-    pub fn no_masks(mut self) -> Self {
-        self.masks = 0;
-        self
-    }
-
     /// Sets the masks of the filter configuration using a bitmask. Colliders with the corresponding
     /// [collision group](CollisionLayers) will be included in the [spatial query](crate::spatial_query).
-    pub fn masks_from_bits(mut self, masks: u32) -> Self {
+    pub fn with_masks_from_bits(mut self, masks: u32) -> Self {
         self.masks = masks;
         self
     }
 
-    /// Adds the given mask to the filter configuration. Colliders with the corresponding
-    /// [collision group](CollisionLayers) will be included in the [spatial query](crate::spatial_query).
-    pub fn with_mask(mut self, mask: impl PhysicsLayer) -> Self {
-        self.masks |= mask.to_bits();
-        self
-    }
-
-    /// Adds the given masks to the filter configuration. Colliders with the corresponding
-    /// [collision groups](CollisionLayers) will be included in the [spatial query](crate::spatial_query).
+    /// Sets the masks of the filter configuration using a list of [layers](PhysicsLayer).
+    /// Colliders with the corresponding [collision groups](CollisionLayers) will be included
+    /// in the [spatial query](crate::spatial_query).
     pub fn with_masks(mut self, masks: impl IntoIterator<Item = impl PhysicsLayer>) -> Self {
+        self.masks = 0;
         for mask in masks.into_iter().map(|l| l.to_bits()) {
             self.masks |= mask;
         }
         self
-    }
-
-    /// Removes the given mask from the filter configuration. Colliders with the corresponding
-    /// [collision group](CollisionLayers) will be excluded from the [spatial query](crate::spatial_query).
-    pub fn without_mask(mut self, mask: impl PhysicsLayer) -> Self {
-        self.masks &= !mask.to_bits();
-        self
-    }
-
-    /// Removes the given masks from the filter configuration. Colliders with the corresponding
-    /// [collision groups](CollisionLayers) will be excluded from the [spatial query](crate::spatial_query).
-    pub fn without_masks(mut self, masks: impl IntoIterator<Item = impl PhysicsLayer>) -> Self {
-        for mask in masks.into_iter().map(|l| l.to_bits()) {
-            self.masks &= !mask;
-        }
-        self
-    }
-
-    /// Returns true if the given layer is contained in the filter's masks.
-    pub fn contains_mask(self, layer: impl PhysicsLayer) -> bool {
-        (self.masks & layer.to_bits()) != 0
     }
 
     /// Excludes the given entities from [spatial queries](crate::spatial_query).


### PR DESCRIPTION
Replaces collision layers (groups and masks) with just masks in `SpatialQueryFilter`. Spatial queries don't necessarily exist as physical objects in the world, so it doesn't make sense for them to belong in groups, and this also just makes the API nicer.

## Methods

Removed `with_layers` in favor of:

- `with_masks_from_bits`
- `with_masks`

## Example

```rust
// Previously
let query_filter = SpatialQueryFilter::new().with_layers(CollisionLayers::from_bits(0xffff_ffff, 0b1011));

// Now
let query_filter = SpatialQueryFilter::new().with_masks_from_bits(0b1011);
```