### PR TITLE
Add `LockedAxes`

### DIFF
--- a/src/components/locked_axes.rs
+++ b/src/components/locked_axes.rs
@@ -1,0 +1,238 @@
+use bevy::prelude::*;
+use derive_more::From;
+
+use crate::prelude::*;
+
+/// A component that specifies which translational and rotational axes of a [rigid body](RigidBody) are locked.
+///
+/// The axes are represented using a total of six bits, one for each axis. The easiest way is to lock or unlock
+/// specific axes is to use the methods like [`lock_translation_x`](#method.lock_translation_x), but you can also
+/// use bits directly with the [`from_bits`](#method.from_bits) and [`to_bits`](#method.to_bits) methods.
+///
+/// ## Example
+///
+/// ```
+/// use bevy::prelude::*;
+/// # #[cfg(feature = "2d")]
+/// # use bevy_xpbd_2d::prelude::*;
+/// # #[cfg(feature = "3d")]
+/// use bevy_xpbd_3d::prelude::*;
+///
+/// #[cfg(feature = "3d")]
+/// fn spawn(mut commands: Commands) {
+///     // Spawn a capsule that only rotates around the Y axis
+///     commands.spawn((
+///         RigidBody::Dynamic,
+///         Collider::capsule(1.0, 0.5),
+///         // In 2D, use use LockedAxes::new().lock_rotation()
+///         LockedAxes::new().lock_rotation_x().lock_rotation_z(),
+///     ));
+/// }
+/// ```
+#[derive(Component, Reflect, Clone, Copy, Debug, Default, From)]
+#[reflect(Component)]
+pub struct LockedAxes(u8);
+
+impl LockedAxes {
+    /// All translational axes are locked, but all rotational axes are unlocked.
+    pub const TRANSLATION_LOCKED: Self = Self(0b111_000);
+    /// All rotational axes are locked, but all translational axes are unlocked.
+    pub const ROTATION_LOCKED: Self = Self(0b000_111);
+    /// All translational and rotational axes are locked.
+    pub const ALL_LOCKED: Self = Self(0b111_111);
+
+    /// Creates a new [`LockedAxes`] configuration with all axes unlocked by default.
+    pub fn new() -> Self {
+        Self(0)
+    }
+
+    /// Creates a new [`LockedAxes`] configuration using bits.
+    ///
+    /// The first three bits correspond to translational axes, while the last three bits correspond to rotational
+    /// axes. For example, `0b100_010` would lock translation along the `X` axis and rotation around the `Y` axis.
+    pub fn from_bits(bits: u8) -> Self {
+        Self(bits)
+    }
+
+    /// Returns the locked axes as bits.
+    ///
+    /// The first three bits correspond to translational axes, while the last three bits correspond to rotational
+    /// axes. For example, `0b100_010` would mean that translation along the `X` axis and rotation around the `Y` axis
+    /// are locked.
+    pub fn to_bits(&self) -> u8 {
+        self.0
+    }
+
+    /// Locks translation along the `X` axis.
+    pub fn lock_translation_x(mut self) -> Self {
+        self.0 |= 0b100_000;
+        self
+    }
+
+    /// Locks translation along the `Y` axis.
+    pub fn lock_translation_y(mut self) -> Self {
+        self.0 |= 0b010_000;
+        self
+    }
+
+    /// Locks translation along the `Z` axis.
+    #[cfg(feature = "3d")]
+    pub fn lock_translation_z(mut self) -> Self {
+        self.0 |= 0b001_000;
+        self
+    }
+
+    /// Locks rotation around the `X` axis.
+    #[cfg(feature = "3d")]
+    pub fn lock_rotation_x(mut self) -> Self {
+        self.0 |= 0b000_100;
+        self
+    }
+
+    /// Locks rotation around the `Y` axis.
+    #[cfg(feature = "3d")]
+    pub fn lock_rotation_y(mut self) -> Self {
+        self.0 |= 0b000_010;
+        self
+    }
+
+    /// Locks rotation around the `Z` axis.
+    #[cfg(feature = "3d")]
+    pub fn lock_rotation_z(mut self) -> Self {
+        self.0 |= 0b000_001;
+        self
+    }
+
+    /// Locks all rotation.
+    #[cfg(feature = "2d")]
+    pub fn lock_rotation(mut self) -> Self {
+        self.0 |= 0b000_001;
+        self
+    }
+
+    /// Unlocks translation along the `X` axis.
+    pub fn unlock_translation_x(mut self) -> Self {
+        self.0 &= !0b100_000;
+        self
+    }
+
+    /// Unlocks translation along the `Y` axis.
+    pub fn unlock_translation_y(mut self) -> Self {
+        self.0 &= !0b010_000;
+        self
+    }
+
+    /// Unlocks translation along the `Z` axis.
+    #[cfg(feature = "3d")]
+    pub fn unlock_translation_z(mut self) -> Self {
+        self.0 &= !0b001_000;
+        self
+    }
+
+    /// Unlocks rotation around the `X` axis.
+    #[cfg(feature = "3d")]
+    pub fn unlock_rotation_x(mut self) -> Self {
+        self.0 &= !0b000_100;
+        self
+    }
+
+    /// Unlocks rotation around the `Y` axis.
+    #[cfg(feature = "3d")]
+    pub fn unlock_rotation_y(mut self) -> Self {
+        self.0 &= !0b000_010;
+        self
+    }
+
+    /// Unlocks rotation around the `Z` axis.
+    #[cfg(feature = "3d")]
+    pub fn unlock_rotation_z(mut self) -> Self {
+        self.0 &= !0b000_001;
+        self
+    }
+
+    /// Unlocks all rotation.
+    #[cfg(feature = "2d")]
+    pub fn unlock_rotation(mut self) -> Self {
+        self.0 &= !0b000_001;
+        self
+    }
+
+    /// Returns true if translation is locked along the `X` axis.
+    pub fn is_translation_x_locked(&self) -> bool {
+        (self.0 & 0b100_000) != 0
+    }
+
+    /// Returns true if translation is locked along the `X` axis.
+    pub fn is_translation_y_locked(&self) -> bool {
+        (self.0 & 0b010_000) != 0
+    }
+
+    /// Returns true if translation is locked along the `X` axis.
+    #[cfg(feature = "3d")]
+    pub fn is_translation_z_locked(&self) -> bool {
+        (self.0 & 0b001_000) != 0
+    }
+
+    /// Returns true if rotation is locked around the `X` axis.
+    #[cfg(feature = "3d")]
+    pub fn is_rotation_x_locked(&self) -> bool {
+        (self.0 & 0b000_100) != 0
+    }
+
+    /// Returns true if rotation is locked around the `Y` axis.
+    #[cfg(feature = "3d")]
+    pub fn is_rotation_y_locked(&self) -> bool {
+        (self.0 & 0b000_010) != 0
+    }
+
+    /// Returns true if rotation is locked around the `Z` axis.
+    #[cfg(feature = "3d")]
+    pub fn is_rotation_z_locked(&self) -> bool {
+        (self.0 & 0b000_001) != 0
+    }
+
+    /// Returns true if all rotation is locked.
+    #[cfg(feature = "2d")]
+    pub fn is_rotation_locked(&self) -> bool {
+        (self.0 & 0b000_001) != 0
+    }
+
+    /// Sets translational axes of the given vector to zero based on the [`LockedAxes`] configuration.
+    pub(crate) fn apply_to_vec(&self, mut vector: Vector) -> Vector {
+        if self.is_translation_x_locked() {
+            vector.x = 0.0;
+        }
+        if self.is_translation_y_locked() {
+            vector.y = 0.0;
+        }
+        #[cfg(feature = "3d")]
+        if self.is_translation_z_locked() {
+            vector.z = 0.0;
+        }
+        vector
+    }
+
+    /// Sets the given rotation to zero if rotational axes are locked.
+    #[cfg(feature = "2d")]
+    pub(crate) fn apply_to_rotation(&self, mut rotation: Scalar) -> Scalar {
+        if self.is_rotation_locked() {
+            rotation = 0.0;
+        }
+        rotation
+    }
+
+    /// Sets rotational axes of the given 3x3 matrix to zero based on the [`LockedAxes`] configuration.
+    #[cfg(feature = "3d")]
+    pub(crate) fn apply_to_rotation(&self, mut rotation: Matrix3) -> Matrix3 {
+        if self.is_rotation_x_locked() {
+            rotation.x_axis = Vector::ZERO;
+        }
+        if self.is_rotation_y_locked() {
+            rotation.y_axis = Vector::ZERO;
+        }
+        if self.is_rotation_z_locked() {
+            rotation.z_axis = Vector::ZERO;
+        }
+        rotation
+    }
+}

--- a/src/components/locked_axes.rs
+++ b/src/components/locked_axes.rs
@@ -24,7 +24,7 @@ use crate::prelude::*;
 ///     commands.spawn((
 ///         RigidBody::Dynamic,
 ///         Collider::capsule(1.0, 0.5),
-///         // In 2D, use use LockedAxes::new().lock_rotation()
+///         // In 2D, use LockedAxes::new().lock_rotation()
 ///         LockedAxes::new().lock_rotation_x().lock_rotation_z(),
 ///     ));
 /// }

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -2,6 +2,7 @@
 
 mod collider;
 mod layers;
+mod locked_axes;
 mod mass_properties;
 mod rotation;
 mod world_queries;
@@ -10,6 +11,7 @@ use std::ops::{Deref, DerefMut};
 
 pub use collider::*;
 pub use layers::*;
+pub use locked_axes::*;
 pub use mass_properties::*;
 pub use rotation::*;
 pub use world_queries::*;

--- a/src/components/rotation.rs
+++ b/src/components/rotation.rs
@@ -9,6 +9,13 @@ use nalgebra::Matrix3x1;
 
 use crate::prelude::*;
 
+/// Radians
+#[cfg(feature = "2d")]
+pub(crate) type RotationValue = Scalar;
+/// Quaternion
+#[cfg(feature = "3d")]
+pub(crate) type RotationValue = Quaternion;
+
 /// The rotation of a body.
 ///
 /// To speed up computation, the rotation is stored as the cosine and sine of the given angle in radians.

--- a/src/constraints/angular_constraint.rs
+++ b/src/constraints/angular_constraint.rs
@@ -26,8 +26,8 @@ pub trait AngularConstraint: XpbdConstraint<2> {
         let rot1 = *body1.rotation;
         let rot2 = *body2.rotation;
 
-        let inv_inertia1 = body1.world_inv_inertia().0;
-        let inv_inertia2 = body2.world_inv_inertia().0;
+        let inv_inertia1 = body1.effective_world_inv_inertia();
+        let inv_inertia2 = body2.effective_world_inv_inertia();
 
         // Apply rotational updates
         if body1.rb.is_dynamic() {
@@ -61,8 +61,8 @@ pub trait AngularConstraint: XpbdConstraint<2> {
         let rot1 = *body1.rotation;
         let rot2 = *body2.rotation;
 
-        let inv_inertia1 = body1.world_inv_inertia().0;
-        let inv_inertia2 = body2.world_inv_inertia().0;
+        let inv_inertia1 = body1.effective_world_inv_inertia();
+        let inv_inertia2 = body2.effective_world_inv_inertia();
 
         // Apply rotational updates
         if body1.rb.is_dynamic() {
@@ -95,7 +95,7 @@ pub trait AngularConstraint: XpbdConstraint<2> {
     #[cfg(feature = "3d")]
     fn compute_generalized_inverse_mass(&self, body: &RigidBodyQueryItem, axis: Vector) -> Scalar {
         if body.rb.is_dynamic() {
-            axis.dot(body.world_inv_inertia().0 * axis)
+            axis.dot(body.effective_world_inv_inertia() * axis)
         } else {
             // Static and kinematic bodies are a special case, where 0.0 can be thought of as infinite mass.
             0.0

--- a/src/constraints/position_constraint.rs
+++ b/src/constraints/position_constraint.rs
@@ -25,16 +25,18 @@ pub trait PositionConstraint: XpbdConstraint<2> {
         let rot1 = *body1.rotation;
         let rot2 = *body2.rotation;
 
-        let inv_inertia1 = body1.world_inv_inertia().0;
-        let inv_inertia2 = body2.world_inv_inertia().0;
+        let inv_mass1 = body1.effective_inv_mass();
+        let inv_mass2 = body2.effective_inv_mass();
+        let inv_inertia1 = body1.effective_world_inv_inertia();
+        let inv_inertia2 = body2.effective_world_inv_inertia();
 
         // Apply positional and rotational updates
         if body1.rb.is_dynamic() {
-            body1.position.0 += p * body1.inverse_mass.0;
+            body1.position.0 += p * inv_mass1;
             *body1.rotation += Self::get_delta_rot(rot1, inv_inertia1, r1, p);
         }
         if body2.rb.is_dynamic() {
-            body2.position.0 -= p * body2.inverse_mass.0;
+            body2.position.0 -= p * inv_mass2;
             *body2.rotation -= Self::get_delta_rot(rot2, inv_inertia2, r2, p);
         }
 
@@ -68,7 +70,7 @@ pub trait PositionConstraint: XpbdConstraint<2> {
         n: Vector,
     ) -> Scalar {
         if body.rb.is_dynamic() {
-            let inverse_inertia = body.world_inv_inertia().0;
+            let inverse_inertia = body.effective_world_inv_inertia();
 
             let r_cross_n = r.cross(n); // Compute the cross product only once
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@
 //!     - [Shape casting](spatial_query#shape-casting)
 //!     - [Point projection](spatial_query#point-projection)
 //!     - [Intersection tests](spatial_query#intersection-tests)
+//! - [Locking](LockedAxes) translational and rotational axes
 //! - Automatically deactivating bodies with [sleeping](Sleeping)
 //! - Configurable [timesteps](PhysicsTimestep) and [substepping](SubstepCount)
 //! - `f32`/`f64` precision (`f32` by default)
@@ -161,6 +162,7 @@
 //! - [Define collision layers](CollisionLayers#creation)
 //! - [Define mass properties](RigidBody#adding-mass-properties)
 //! - [Use joints](joints#using-joints)
+//! - [Lock translational and rotational axes](LockedAxes)
 //! - [Apply external forces](ExternalForce)
 //! - [Apply external torque](ExternalTorque)
 //! - [Configure gravity](Gravity)

--- a/src/plugins/setup.rs
+++ b/src/plugins/setup.rs
@@ -74,6 +74,7 @@ impl Plugin for PhysicsSetupPlugin {
             .register_type::<Inertia>()
             .register_type::<InverseInertia>()
             .register_type::<CenterOfMass>()
+            .register_type::<LockedAxes>()
             .register_type::<CollisionLayers>()
             .register_type::<CollidingEntities>();
 

--- a/src/plugins/solver.rs
+++ b/src/plugins/solver.rs
@@ -411,8 +411,10 @@ fn solve_vel(
             let normal_vel = normal.dot(relative_vel);
             let tangent_vel = relative_vel - normal * normal_vel;
 
-            let inv_inertia1 = body1.world_inv_inertia().0;
-            let inv_inertia2 = body2.world_inv_inertia().0;
+            let inv_mass1 = body1.effective_inv_mass();
+            let inv_mass2 = body2.effective_inv_mass();
+            let inv_inertia1 = body1.effective_world_inv_inertia();
+            let inv_inertia2 = body2.effective_world_inv_inertia();
 
             // Compute dynamic friction
             let friction_impulse = get_dynamic_friction(
@@ -456,12 +458,12 @@ fn solve_vel(
             // Compute velocity impulse and apply velocity updates (equation 33)
             let p = delta_v / (w1 + w2);
             if body1.rb.is_dynamic() {
-                body1.linear_velocity.0 += p / body1.mass.0;
+                body1.linear_velocity.0 += p * inv_mass1;
                 body1.angular_velocity.0 +=
                     compute_delta_ang_vel(inv_inertia1, constraint.world_r1, p);
             }
             if body2.rb.is_dynamic() {
-                body2.linear_velocity.0 -= p / body2.mass.0;
+                body2.linear_velocity.0 -= p * inv_mass2;
                 body2.angular_velocity.0 -=
                     compute_delta_ang_vel(inv_inertia2, constraint.world_r2, p);
             }

--- a/src/plugins/spatial_query/system_param.rs
+++ b/src/plugins/spatial_query/system_param.rs
@@ -10,11 +10,6 @@ use parry::query::{
     },
 };
 
-#[cfg(feature = "2d")]
-type ShapeRotation = Scalar;
-#[cfg(feature = "3d")]
-type ShapeRotation = Quaternion;
-
 /// A system parameter for performing [spatial queries](spatial_query).
 ///
 /// ## Methods
@@ -373,7 +368,7 @@ impl<'w, 's> SpatialQuery<'w, 's> {
         &self,
         shape: &Collider,
         origin: Vector,
-        shape_rotation: ShapeRotation,
+        shape_rotation: RotationValue,
         direction: Vector,
         max_time_of_impact: Scalar,
         ignore_origin_penetration: bool,
@@ -686,7 +681,7 @@ impl<'w, 's> SpatialQuery<'w, 's> {
         &self,
         shape: &Collider,
         shape_position: Vector,
-        shape_rotation: ShapeRotation,
+        shape_rotation: RotationValue,
         query_filter: SpatialQueryFilter,
     ) -> Vec<Entity> {
         self.shape_intersections_callback(
@@ -743,7 +738,7 @@ impl<'w, 's> SpatialQuery<'w, 's> {
         &self,
         shape: &Collider,
         shape_position: Vector,
-        shape_rotation: ShapeRotation,
+        shape_rotation: RotationValue,
         query_filter: SpatialQueryFilter,
         mut callback: impl FnMut(Entity) -> bool,
     ) -> Vec<Entity> {


### PR DESCRIPTION
Adds a `LockedAxes` component for locking translational and rotational axes.

The locked axes are represented as a `u8`, where each axis has one bit, a total of 6 bits. There are methods like `lock_translation_x`, `lock_rotation_y` and `unlock_rotation_z`, and the constants `TRANSLATION_LOCKED`, `ROTATION_LOCKED` and `ALL_LOCKED`.

To take the locked axes into account, an effective mass/inertia is computed before applying any positional or rotational updates. For example the effective mass is just a vector where the locked axes have a mass of zero. This works similarly for other updates.

## Example

```rust
use bevy::prelude::*;
use bevy_xpbd_3d::prelude::*;

fn spawn(mut commands: Commands) {
    // Spawn a capsule that only rotates around the Y axis
    commands.spawn((
        RigidBody::Dynamic,
        Collider::capsule(1.0, 0.5),
        // In 2D, use use LockedAxes::new().lock_rotation()
        LockedAxes::new().lock_rotation_x().lock_rotation_z(),
    ));
}
```