### PR TITLE
Fixes for spatial queries

### DIFF
--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -192,7 +192,7 @@ impl PluginGroup for PhysicsPlugins {
             .add(IntegratorPlugin)
             .add(SolverPlugin)
             .add(SleepingPlugin)
-            .add(SpatialQueryPlugin)
+            .add(SpatialQueryPlugin::new(self.schedule.dyn_clone()))
             .add(SyncPlugin::new(self.schedule))
     }
 }

--- a/src/plugins/spatial_query/shape_caster.rs
+++ b/src/plugins/spatial_query/shape_caster.rs
@@ -262,7 +262,7 @@ impl ShapeCaster {
                 &pipeline_shape,
                 &**self.shape.get_shape(),
                 self.max_time_of_impact,
-                self.ignore_origin_penetration,
+                !self.ignore_origin_penetration,
             );
 
             if let Some(hit) = query_pipeline.qbvh.traverse_best_first(&mut visitor).map(

--- a/src/plugins/spatial_query/shape_caster.rs
+++ b/src/plugins/spatial_query/shape_caster.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
-use bevy::{prelude::*, utils::HashMap};
-use parry::{query::details::TOICompositeShapeShapeBestFirstVisitor, shape::Shape};
+use bevy::prelude::*;
+use parry::query::details::TOICompositeShapeShapeBestFirstVisitor;
 
 /// A component used for [shape casting](spatial_query#shape-casting).
 ///
@@ -237,12 +237,7 @@ impl ShapeCaster {
         self.global_direction = global_direction;
     }
 
-    pub(crate) fn cast(
-        &self,
-        hits: &mut ShapeHits,
-        colliders: &HashMap<Entity, (Isometry<Scalar>, &dyn Shape, CollisionLayers)>,
-        query_pipeline: &SpatialQueryPipeline,
-    ) {
+    pub(crate) fn cast(&self, hits: &mut ShapeHits, query_pipeline: &SpatialQueryPipeline) {
         hits.count = 0;
         let shape_rotation: Rotation;
         #[cfg(feature = "2d")]
@@ -259,7 +254,7 @@ impl ShapeCaster {
 
         let mut query_filter = self.query_filter.clone();
         while hits.count < self.max_hits {
-            let pipeline_shape = query_pipeline.as_composite_shape(colliders, query_filter.clone());
+            let pipeline_shape = query_pipeline.as_composite_shape(query_filter.clone());
             let mut visitor = TOICompositeShapeShapeBestFirstVisitor::new(
                 &*query_pipeline.dispatcher,
                 &shape_isometry,
@@ -272,7 +267,7 @@ impl ShapeCaster {
 
             if let Some(hit) = query_pipeline.qbvh.traverse_best_first(&mut visitor).map(
                 |(_, (entity_index, hit))| ShapeHitData {
-                    entity: Entity::from_raw(entity_index),
+                    entity: query_pipeline.entity_from_index(entity_index),
                     time_of_impact: hit.toi,
                     point1: hit.witness1.into(),
                     point2: hit.witness2.into(),

--- a/src/plugins/spatial_query/system_param.rs
+++ b/src/plugins/spatial_query/system_param.rs
@@ -93,7 +93,7 @@ pub struct SpatialQuery<'w, 's> {
     >,
     pub(crate) added_colliders: Query<'w, 's, Entity, Added<Collider>>,
     pub(crate) changed_colliders: Query<'w, 's, Entity, ColliderChangedFilter>,
-    pub(crate) removed_colliders: ResMut<'w, spatial_query::RemovedColliders>,
+    pub(crate) removed_colliders: Res<'w, spatial_query::RemovedColliders>,
     /// The [`SpatialQueryPipeline`].
     pub query_pipeline: ResMut<'w, SpatialQueryPipeline>,
 }

--- a/src/plugins/spatial_query/system_param.rs
+++ b/src/plugins/spatial_query/system_param.rs
@@ -93,7 +93,7 @@ pub struct SpatialQuery<'w, 's> {
     >,
     pub(crate) added_colliders: Query<'w, 's, Entity, Added<Collider>>,
     pub(crate) changed_colliders: Query<'w, 's, Entity, ColliderChangedFilter>,
-    pub(crate) removed_colliders: Res<'w, spatial_query::RemovedColliders>,
+    pub(crate) removed_colliders: ResMut<'w, spatial_query::RemovedColliders>,
     /// The [`SpatialQueryPipeline`].
     pub query_pipeline: ResMut<'w, SpatialQueryPipeline>,
 }
@@ -119,7 +119,7 @@ impl<'w, 's> SpatialQuery<'w, 's> {
             .collect();
         let added = self.added_colliders.iter().collect::<Vec<_>>();
         let modified = self.changed_colliders.iter().collect::<Vec<_>>();
-        let removed = self.removed_colliders.iter().cloned().collect::<Vec<_>>();
+        let removed = self.removed_colliders.drain().collect::<Vec<_>>();
         self.query_pipeline
             .update_incremental(colliders, &added, &modified, &removed, true);
     }

--- a/src/plugins/spatial_query/system_param.rs
+++ b/src/plugins/spatial_query/system_param.rs
@@ -91,9 +91,9 @@ pub struct SpatialQuery<'w, 's> {
             Option<&'static CollisionLayers>,
         ),
     >,
-    added_colliders: Query<'w, 's, Entity, Added<Collider>>,
-    changed_colliders: Query<'w, 's, Entity, ColliderChangedFilter>,
-    removed_colliders: Res<'w, spatial_query::RemovedColliders>,
+    pub(crate) added_colliders: Query<'w, 's, Entity, Added<Collider>>,
+    pub(crate) changed_colliders: Query<'w, 's, Entity, ColliderChangedFilter>,
+    pub(crate) removed_colliders: ResMut<'w, spatial_query::RemovedColliders>,
     /// The [`SpatialQueryPipeline`].
     pub query_pipeline: ResMut<'w, SpatialQueryPipeline>,
 }
@@ -119,13 +119,9 @@ impl<'w, 's> SpatialQuery<'w, 's> {
             .collect();
         let added = self.added_colliders.iter().collect::<Vec<_>>();
         let modified = self.changed_colliders.iter().collect::<Vec<_>>();
-        self.query_pipeline.update_incremental(
-            colliders,
-            &added,
-            &modified,
-            &self.removed_colliders,
-            true,
-        );
+        let removed = self.removed_colliders.iter().cloned().collect::<Vec<_>>();
+        self.query_pipeline
+            .update_incremental(colliders, &added, &modified, &removed, true);
     }
 
     /// Casts a [ray](spatial_query#ray-casting) and computes the closest [hit](RayHitData) with a collider.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -12,6 +12,10 @@ pub(crate) fn make_isometry(pos: Vector, rot: &Rotation) -> Isometry<Scalar> {
     Isometry::<Scalar>::new(pos.into(), rot.to_scaled_axis().into())
 }
 
+pub(crate) fn entity_from_index_and_gen(index: u32, generation: u32) -> bevy::prelude::Entity {
+    bevy::prelude::Entity::from_bits((generation as u64) << 32 | index as u64)
+}
+
 #[cfg(feature = "3d")]
 pub(crate) fn get_rotated_inertia_tensor(inertia_tensor: Matrix3, rot: Quaternion) -> Matrix3 {
     let rot_mat3 = Matrix3::from_quat(rot);


### PR DESCRIPTION
- Fixed an issue where spatial queries weren't detecting colliders of entities with a generation of over 0 (i.e. spawned multiple times)
- Fixed removal detection so that collider removals aren't missed
- Fixed shape caster `ignore_origin_penetration` that did the opposite of what it was supposed to do
- Refactored spatial query pipeline code, e.g. the pipeline now stores the colliders, so calling the query methods doesn't query the ECS to get the colliders each time