### PR TITLE
Add debug rendering axes and joints and improve configuration API

### DIFF
--- a/crates/bevy_xpbd_2d/examples/many_shapes.rs
+++ b/crates/bevy_xpbd_2d/examples/many_shapes.rs
@@ -128,7 +128,6 @@ fn setup(
     );
     let shapes = [ball, cuboid, capsule, triangle];
 
-    // Spawn stacks of marbles
     for x in -12_i32..12 {
         for y in -8_i32..8 {
             let position = Vector::new(x as Scalar * 20.0, y as Scalar * 20.0);

--- a/src/constraints/joints/fixed.rs
+++ b/src/constraints/joints/fixed.rs
@@ -120,6 +120,14 @@ impl Joint for FixedJoint {
         }
     }
 
+    fn local_anchor_1(&self) -> Vector {
+        self.local_anchor1
+    }
+
+    fn local_anchor_2(&self) -> Vector {
+        self.local_anchor2
+    }
+
     fn damping_linear(&self) -> Scalar {
         self.damping_linear
     }

--- a/src/constraints/joints/mod.rs
+++ b/src/constraints/joints/mod.rs
@@ -115,6 +115,12 @@ pub trait Joint: Component + PositionConstraint + AngularConstraint {
     /// Sets the angular velocity damping caused by the joint.
     fn with_angular_velocity_damping(self, damping: Scalar) -> Self;
 
+    /// Returns the local attachment point on the first body.
+    fn local_anchor_1(&self) -> Vector;
+
+    /// Returns the local attachment point on the second body.
+    fn local_anchor_2(&self) -> Vector;
+
     /// Returns the linear velocity damping of the joint.
     fn damping_linear(&self) -> Scalar;
 

--- a/src/constraints/joints/prismatic.rs
+++ b/src/constraints/joints/prismatic.rs
@@ -115,6 +115,14 @@ impl Joint for PrismaticJoint {
         }
     }
 
+    fn local_anchor_1(&self) -> Vector {
+        self.local_anchor1
+    }
+
+    fn local_anchor_2(&self) -> Vector {
+        self.local_anchor2
+    }
+
     fn damping_linear(&self) -> Scalar {
         self.damping_linear
     }

--- a/src/constraints/joints/revolute.rs
+++ b/src/constraints/joints/revolute.rs
@@ -144,6 +144,14 @@ impl Joint for RevoluteJoint {
         }
     }
 
+    fn local_anchor_1(&self) -> Vector {
+        self.local_anchor1
+    }
+
+    fn local_anchor_2(&self) -> Vector {
+        self.local_anchor2
+    }
+
     fn damping_linear(&self) -> Scalar {
         self.damping_linear
     }

--- a/src/constraints/joints/spherical.rs
+++ b/src/constraints/joints/spherical.rs
@@ -141,6 +141,14 @@ impl Joint for SphericalJoint {
         }
     }
 
+    fn local_anchor_1(&self) -> Vector {
+        self.local_anchor1
+    }
+
+    fn local_anchor_2(&self) -> Vector {
+        self.local_anchor2
+    }
+
     fn damping_linear(&self) -> Scalar {
         self.damping_linear
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,8 @@
 //!     - [Shape casting](spatial_query#shape-casting)
 //!     - [Point projection](spatial_query#point-projection)
 //!     - [Intersection tests](spatial_query#intersection-tests)
-//! - Debug rendering [colliders](Collider), [AABBs](ColliderAabb) and [contacts](Contact) (with `debug-plugin` feature)
+//! - Debug rendering [colliders](Collider), [AABBs](ColliderAabb), [contacts](Contact), [joints] and axes
+//! (with `debug-plugin` feature)
 //! - Automatically deactivating bodies with [sleeping](Sleeping)
 //! - Configurable [timesteps](PhysicsTimestep) and [substepping](SubstepCount)
 //! - `f32`/`f64` precision (`f32` by default)

--- a/src/plugins/debug/configuration.rs
+++ b/src/plugins/debug/configuration.rs
@@ -1,0 +1,304 @@
+use crate::prelude::*;
+use bevy::prelude::*;
+
+/// Controls the global physics debug configuration.
+///
+/// To configure the debug rendering of specific entities, use the [`DebugRender`] component.
+#[derive(Reflect, Resource)]
+#[reflect(Resource)]
+pub struct PhysicsDebugConfig {
+    /// The lengths of the axes drawn for an entity.
+    pub axis_lengths: Option<Vector>,
+    /// The color of the [AABBs](ColliderAabb). If `None`, the AABBs will not be rendered.
+    pub aabb_color: Option<Color>,
+    /// The color of the [collider](Collider) wireframes. If `None`, the colliders will not be rendered.
+    pub collider_color: Option<Color>,
+    /// The color of the contact points. If `None`, the contact points will not be rendered.
+    pub contact_color: Option<Color>,
+    /// The color of the lines drawn from the centers of bodies to their joint anchors.
+    pub joint_anchor_color: Option<Color>,
+    /// The color of the lines drawn between joint anchors, indicating the separation.
+    pub joint_separation_color: Option<Color>,
+    /// Determines if the visibility of entities with [colliders](Collider) should be set to `Visibility::Hidden`,
+    /// which will only show the debug renders.
+    pub hide_meshes: bool,
+}
+
+impl Default for PhysicsDebugConfig {
+    fn default() -> Self {
+        Self {
+            #[cfg(feature = "2d")]
+            axis_lengths: Some(Vector::new(5.0, 5.0)),
+            #[cfg(feature = "3d")]
+            axis_lengths: Some(Vector::new(0.5, 0.5, 0.5)),
+            aabb_color: None,
+            collider_color: Some(Color::ORANGE),
+            contact_color: None,
+            joint_anchor_color: Some(Color::PINK),
+            joint_separation_color: Some(Color::RED),
+            hide_meshes: false,
+        }
+    }
+}
+
+impl PhysicsDebugConfig {
+    /// Creates a [`PhysicsDebugConfig`] configuration with all rendering options enabled.
+    pub fn all() -> Self {
+        Self {
+            #[cfg(feature = "2d")]
+            axis_lengths: Some(Vector::new(5.0, 5.0)),
+            #[cfg(feature = "3d")]
+            axis_lengths: Some(Vector::new(0.5, 0.5, 0.5)),
+            aabb_color: Some(Color::rgb(0.8, 0.8, 0.8)),
+            collider_color: Some(Color::ORANGE),
+            contact_color: Some(Color::CYAN),
+            joint_anchor_color: Some(Color::PINK),
+            joint_separation_color: Some(Color::RED),
+            hide_meshes: true,
+        }
+    }
+
+    /// Disables all debug rendering for this entity.
+    pub fn none() -> Self {
+        Self {
+            axis_lengths: None,
+            aabb_color: None,
+            collider_color: None,
+            contact_color: None,
+            joint_anchor_color: None,
+            joint_separation_color: None,
+            hide_meshes: false,
+        }
+    }
+
+    /// Creates a [`PhysicsDebugConfig`] configuration with the given lengths for the axes
+    /// that are drawn for the entity. Other debug rendering options will be disabled.
+    pub fn axes(axis_lengths: Vector) -> Self {
+        Self {
+            axis_lengths: Some(axis_lengths),
+            ..Self::none()
+        }
+    }
+
+    /// Creates a [`PhysicsDebugConfig`] configuration with a given AABB color.
+    /// Other debug rendering options will be disabled.
+    pub fn aabbs(color: Color) -> Self {
+        Self {
+            aabb_color: Some(color),
+            ..Self::none()
+        }
+    }
+
+    /// Creates a [`PhysicsDebugConfig`] configuration with a given collider color.
+    /// Other debug rendering options will be disabled.
+    pub fn colliders(color: Color) -> Self {
+        Self {
+            collider_color: Some(color),
+            ..Self::none()
+        }
+    }
+
+    /// Creates a [`PhysicsDebugConfig`] configuration with a given contact color.
+    /// Other debug rendering options will be disabled.
+    pub fn contacts(color: Color) -> Self {
+        Self {
+            contact_color: Some(color),
+            ..Self::none()
+        }
+    }
+
+    /// Creates a [`PhysicsDebugConfig`] configuration with given colors for
+    /// joint anchors and separation distances. Other debug rendering options will be disabled.
+    pub fn joints(anchor_color: Color, separation_color: Color) -> Self {
+        Self {
+            joint_anchor_color: Some(anchor_color),
+            joint_separation_color: Some(separation_color),
+            ..Self::none()
+        }
+    }
+
+    /// Sets the lengths of the axes drawn for the entity.
+    pub fn with_axes(mut self, axis_lengths: Vector) -> Self {
+        self.axis_lengths = Some(axis_lengths);
+        self
+    }
+
+    /// Sets the AABB color.
+    pub fn with_aabb_color(mut self, color: Color) -> Self {
+        self.aabb_color = Some(color);
+        self
+    }
+
+    /// Sets the collider color.
+    pub fn with_collider_color(mut self, color: Color) -> Self {
+        self.collider_color = Some(color);
+        self
+    }
+
+    /// Sets the contact color.
+    pub fn with_contact_color(mut self, color: Color) -> Self {
+        self.contact_color = Some(color);
+        self
+    }
+
+    /// Sets the visibility of the entity's visual mesh.
+    pub fn with_mesh_visibility(mut self, is_visible: bool) -> Self {
+        self.hide_meshes = !is_visible;
+        self
+    }
+
+    /// Disables axis debug rendering.
+    pub fn without_axes(mut self) -> Self {
+        self.axis_lengths = None;
+        self
+    }
+
+    /// Disables AABB debug rendering.
+    pub fn without_aabbs(mut self) -> Self {
+        self.aabb_color = None;
+        self
+    }
+
+    /// Disables collider debug rendering.
+    pub fn without_colliders(mut self) -> Self {
+        self.collider_color = None;
+        self
+    }
+
+    /// Disables contact debug rendering.
+    pub fn without_contacts(mut self) -> Self {
+        self.contact_color = None;
+        self
+    }
+
+    /// Disables joint debug rendering.
+    pub fn without_joints(mut self) -> Self {
+        self.joint_anchor_color = None;
+        self.joint_separation_color = None;
+        self
+    }
+}
+
+/// A component for the debug render configuration of an entity.
+///
+/// This overwrites the global [`PhysicsDebugConfig`] for this specific entity.
+#[derive(Component, Reflect, Clone, Copy, PartialEq)]
+#[reflect(Component)]
+pub struct DebugRender {
+    /// The lengths of the axes drawn for the entity.
+    pub axis_lengths: Option<Vector>,
+    /// The color of the [AABB](ColliderAabb). If `None`, the AABB will not be rendered.
+    pub aabb_color: Option<Color>,
+    /// The color of the [collider](Collider) wireframe. If `None`, the collider will not be rendered.
+    pub collider_color: Option<Color>,
+    /// Determines if the entity's visibility should be set to `Visibility::Hidden`, which will only show the debug render.
+    pub hide_mesh: bool,
+}
+
+impl Default for DebugRender {
+    fn default() -> Self {
+        Self {
+            #[cfg(feature = "2d")]
+            axis_lengths: Some(Vector::new(5.0, 5.0)),
+            #[cfg(feature = "3d")]
+            axis_lengths: Some(Vector::new(0.5, 0.5, 0.5)),
+            aabb_color: None,
+            collider_color: Some(Color::ORANGE),
+            hide_mesh: false,
+        }
+    }
+}
+
+impl DebugRender {
+    /// Creates a [`DebugRender`] configuration with all rendering options enabled.
+    pub fn all() -> Self {
+        Self {
+            #[cfg(feature = "2d")]
+            axis_lengths: Some(Vector::new(5.0, 5.0)),
+            #[cfg(feature = "3d")]
+            axis_lengths: Some(Vector::new(0.5, 0.5, 0.5)),
+            aabb_color: Some(Color::rgb(0.8, 0.8, 0.8)),
+            collider_color: Some(Color::ORANGE),
+            hide_mesh: true,
+        }
+    }
+
+    /// Disables all debug rendering for this entity.
+    pub fn none() -> Self {
+        Self {
+            axis_lengths: None,
+            aabb_color: None,
+            collider_color: None,
+            hide_mesh: false,
+        }
+    }
+
+    /// Creates a [`DebugRender`] configuration with the given lengths for the axes
+    /// that are drawn for the entity. Other debug rendering options will be disabled.
+    pub fn axes(axis_lengths: Vector) -> Self {
+        Self {
+            axis_lengths: Some(axis_lengths),
+            ..Self::none()
+        }
+    }
+
+    /// Creates a [`DebugRender`] configuration with a given AABB color.
+    /// Other debug rendering options will be disabled.
+    pub fn aabb(color: Color) -> Self {
+        Self {
+            aabb_color: Some(color),
+            ..Self::none()
+        }
+    }
+
+    /// Creates a [`DebugRender`] configuration with a given collider color.
+    /// Other debug rendering options will be disabled.
+    pub fn collider(color: Color) -> Self {
+        Self {
+            collider_color: Some(color),
+            ..Self::none()
+        }
+    }
+
+    /// Sets the lengths of the axes drawn for the entity.
+    pub fn with_axes(mut self, axis_lengths: Vector) -> Self {
+        self.axis_lengths = Some(axis_lengths);
+        self
+    }
+
+    /// Sets the AABB color.
+    pub fn with_aabb_color(mut self, color: Color) -> Self {
+        self.aabb_color = Some(color);
+        self
+    }
+
+    /// Sets the collider color.
+    pub fn with_collider_color(mut self, color: Color) -> Self {
+        self.collider_color = Some(color);
+        self
+    }
+
+    /// Sets the visibility of the entity's visual mesh.
+    pub fn with_mesh_visibility(mut self, is_visible: bool) -> Self {
+        self.hide_mesh = !is_visible;
+        self
+    }
+
+    /// Disables axis debug rendering.
+    pub fn without_axes(mut self) -> Self {
+        self.axis_lengths = None;
+        self
+    }
+
+    /// Disables AABB debug rendering.
+    pub fn without_aabb(mut self) -> Self {
+        self.aabb_color = None;
+        self
+    }
+
+    /// Disables collider debug rendering.
+    pub fn without_collider(mut self) -> Self {
+        self.collider_color = None;
+        self
+    }
+}

--- a/src/plugins/debug/mod.rs
+++ b/src/plugins/debug/mod.rs
@@ -1,19 +1,29 @@
-//! Renders physics objects and properties for debugging purposes. This includes [AABBs](ColliderAabb),
-//! [colliders](Collider) and [contacts](Collision).
+//! Renders physics objects and properties for debugging purposes.
 //!
 //! See [`PhysicsDebugPlugin`].
 
+mod configuration;
 mod renderer;
 
+pub use configuration::*;
 pub use renderer::*;
 
 use crate::prelude::*;
 use bevy::prelude::*;
 
-/// Renders physics objects and properties for debugging purposes. This includes [AABBs](ColliderAabb),
-/// [colliders](Collider) and [contacts](Collision).
+/// Renders physics objects and properties for debugging purposes.
 ///
-/// You can use the [`PhysicsDebugConfig`] resource for the global configuration and the [`DebugRender`] component
+/// Currently, the following are supported for debug rendering:
+///
+/// - Entity axes
+/// - [AABBs](ColliderAabb)
+/// - [Collider] wireframes
+/// - [Contact] points
+/// - [Joints](joints)
+/// - Changing the visibility of entities to only show debug rendering
+///
+/// By default, only axes, colliders and joints are debug rendered. You can use the [`PhysicsDebugConfig`]
+/// resource for the global configuration and the [`DebugRender`] component
 /// for entity-level configuration.
 pub struct PhysicsDebugPlugin {
     schedule: Box<dyn ScheduleLabel>,
@@ -64,145 +74,6 @@ impl Plugin for PhysicsDebugPlugin {
                 )
                     .after(PhysicsSet::StepSimulation),
             );
-    }
-}
-
-/// Controls the global [`PhysicsDebugPlugin`] configuration.
-///
-/// To configure the debug rendering of specific entities, use the [`DebugRender`] component.
-#[derive(Reflect, Resource)]
-#[reflect(Resource)]
-pub struct PhysicsDebugConfig {
-    /// The lengths of the axes drawn for an entity.
-    pub axis_lengths: Option<Vector>,
-    /// The color of the [AABBs](ColliderAabb). If `None`, the AABBs will not be rendered.
-    pub aabb_color: Option<Color>,
-    /// The color of the [collider](Collider) wireframes. If `None`, the colliders will not be rendered.
-    pub collider_color: Option<Color>,
-    /// The color of the contact points. If `None`, the contact points will not be rendered.
-    pub contact_color: Option<Color>,
-    /// The color of the lines drawn from the centers of bodies to their joint anchors.
-    pub joint_anchor_color: Option<Color>,
-    /// The color of the lines drawn between joint anchors, indicating the separation.
-    pub joint_separation_color: Option<Color>,
-    /// Determines if the visibility of entities with [colliders](Collider) should be set to `Visibility::Hidden`,
-    /// which will only show the debug renders.
-    pub hide_meshes: bool,
-}
-
-impl Default for PhysicsDebugConfig {
-    fn default() -> Self {
-        Self {
-            #[cfg(feature = "2d")]
-            axis_lengths: Some(Vector::new(5.0, 5.0)),
-            #[cfg(feature = "3d")]
-            axis_lengths: Some(Vector::new(0.5, 0.5, 0.5)),
-            aabb_color: None,
-            collider_color: Some(Color::ORANGE),
-            contact_color: None,
-            joint_anchor_color: Some(Color::PINK),
-            joint_separation_color: Some(Color::RED),
-            hide_meshes: false,
-        }
-    }
-}
-
-/// A component for the debug render configuration of an entity.
-///
-/// This overwrites the global [`PhysicsDebugConfig`] for this specific entity.
-#[derive(Component, Reflect, Clone, Copy, PartialEq)]
-#[reflect(Component)]
-pub struct DebugRender {
-    /// The lengths of the axes drawn for the entity.
-    pub axis_lengths: Option<Vector>,
-    /// The color of the [AABB](ColliderAabb). If `None`, the AABB will not be rendered.
-    pub aabb_color: Option<Color>,
-    /// The color of the [collider](Collider) wireframe. If `None`, the collider will not be rendered.
-    pub collider_color: Option<Color>,
-    /// Determines if the entity's visibility should be set to `Visibility::Hidden`, which will only show the debug render.
-    pub hide_mesh: bool,
-}
-
-impl Default for DebugRender {
-    fn default() -> Self {
-        Self {
-            #[cfg(feature = "2d")]
-            axis_lengths: Some(Vector::new(5.0, 5.0)),
-            #[cfg(feature = "3d")]
-            axis_lengths: Some(Vector::new(0.5, 0.5, 0.5)),
-            aabb_color: None,
-            collider_color: Some(Color::LIME_GREEN),
-            hide_mesh: false,
-        }
-    }
-}
-
-impl DebugRender {
-    /// Creates a [`DebugRender`] configuration with the given lengths for the axes
-    /// that are drawn for the entity.
-    pub fn axes(axis_lengths: Vector) -> Self {
-        Self {
-            axis_lengths: Some(axis_lengths),
-            ..default()
-        }
-    }
-
-    /// Creates a [`DebugRender`] configuration with a given collider color.
-    pub fn collider(color: Color) -> Self {
-        Self {
-            collider_color: Some(color),
-            ..default()
-        }
-    }
-
-    /// Creates a [`DebugRender`] configuration with a given AABB color.
-    pub fn aabb(color: Color) -> Self {
-        Self {
-            aabb_color: Some(color),
-            ..default()
-        }
-    }
-
-    /// Sets the lengths of the axes drawn for the entity.
-    pub fn with_axes(mut self, axis_lengths: Vector) -> Self {
-        self.axis_lengths = Some(axis_lengths);
-        self
-    }
-
-    /// Sets the collider color.
-    pub fn with_collider_color(mut self, color: Color) -> Self {
-        self.collider_color = Some(color);
-        self
-    }
-
-    /// Sets the AABB color.
-    pub fn with_aabb_color(mut self, color: Color) -> Self {
-        self.aabb_color = Some(color);
-        self
-    }
-
-    /// Sets the visibility of the entity's visual mesh.
-    pub fn with_mesh_visibility(mut self, is_visible: bool) -> Self {
-        self.hide_mesh = !is_visible;
-        self
-    }
-
-    /// Disables axis debug rendering.
-    pub fn without_axes(mut self) -> Self {
-        self.axis_lengths = None;
-        self
-    }
-
-    /// Disables collider debug rendering.
-    pub fn without_collider(mut self) -> Self {
-        self.collider_color = None;
-        self
-    }
-
-    /// Disables AABB debug rendering.
-    pub fn without_aabb(mut self) -> Self {
-        self.aabb_color = None;
-        self
     }
 }
 


### PR DESCRIPTION
Adds several methods for `PhysicsDebugConfig` and `DebugRender` to make the API much nicer, and adds support for debug rendering entity axes and joints.

An example of a global config that renders colliders and hides the visual meshes, but disables all debug rendering for a specific entity:

```rust
app.insert_resource(
    PhysicsDebugConfig::colliders(Color::ORANGE).with_mesh_visibility(false)
);

// In some setup system
commands.spawn((
    RigidBody::Dynamic,
    Collider::ball(0.5),
    DebugRender::none(),
));
```

Closes #75 (although it was already possible, just with a more cumbersome API)