### PR TITLE
Add `enabled` flag to `PhysicsDebugConfig` to globally disable debug rendering at runtime

### DIFF
--- a/src/plugins/debug/configuration.rs
+++ b/src/plugins/debug/configuration.rs
@@ -62,10 +62,12 @@ impl PhysicsDebugConfig {
         }
     }
 
-    /// Disables all debug rendering.
+    /// Creates a [`PhysicsDebugConfig`] configuration with debug rendering enabled but all options turned off.
+    ///
+    /// Note: this doesn't affect entities with [`DebugRender`] component; their debug gizmos will be visible.
     pub fn none() -> Self {
         Self {
-            enabled: false,
+            enabled: true,
             axis_lengths: None,
             aabb_color: None,
             collider_color: None,

--- a/src/plugins/debug/configuration.rs
+++ b/src/plugins/debug/configuration.rs
@@ -7,6 +7,8 @@ use bevy::prelude::*;
 #[derive(Reflect, Resource)]
 #[reflect(Resource)]
 pub struct PhysicsDebugConfig {
+    /// Determines if debug rendering is enabled.
+    pub enabled: bool,
     /// The lengths of the axes drawn for an entity.
     pub axis_lengths: Option<Vector>,
     /// The color of the [AABBs](ColliderAabb). If `None`, the AABBs will not be rendered.
@@ -27,6 +29,7 @@ pub struct PhysicsDebugConfig {
 impl Default for PhysicsDebugConfig {
     fn default() -> Self {
         Self {
+            enabled: true,
             #[cfg(feature = "2d")]
             axis_lengths: Some(Vector::new(5.0, 5.0)),
             #[cfg(feature = "3d")]
@@ -45,6 +48,7 @@ impl PhysicsDebugConfig {
     /// Creates a [`PhysicsDebugConfig`] configuration with all rendering options enabled.
     pub fn all() -> Self {
         Self {
+            enabled: true,
             #[cfg(feature = "2d")]
             axis_lengths: Some(Vector::new(5.0, 5.0)),
             #[cfg(feature = "3d")]
@@ -58,9 +62,10 @@ impl PhysicsDebugConfig {
         }
     }
 
-    /// Disables all debug rendering for this entity.
+    /// Disables all debug rendering.
     pub fn none() -> Self {
         Self {
+            enabled: false,
             axis_lengths: None,
             aabb_color: None,
             collider_color: None,

--- a/src/plugins/debug/mod.rs
+++ b/src/plugins/debug/mod.rs
@@ -72,7 +72,8 @@ impl Plugin for PhysicsDebugPlugin {
                     debug_render_joints::<SphericalJoint>,
                     change_mesh_visibility,
                 )
-                    .after(PhysicsSet::StepSimulation),
+                    .after(PhysicsSet::StepSimulation)
+                    .run_if(|config: Res<PhysicsDebugConfig>| config.enabled),
             );
     }
 }
@@ -140,7 +141,9 @@ fn debug_render_contacts(
     mut debug_renderer: PhysicsDebugRenderer,
     config: Res<PhysicsDebugConfig>,
 ) {
-    let Some(color) = config.contact_color else { return };
+    let Some(color) = config.contact_color else {
+        return;
+    };
     for Collision(contact) in collisions.iter() {
         let p1 = contact.point1;
         let p2 = contact.point2;


### PR DESCRIPTION
This allows easily turning debug renderer on and off by changing `enabled` field of `PhysicsDebugConfig`

Also it matches similar approach by `GizmoConfig` from bevy and `DebugRenderContext` from rapier.