### PR TITLE
Add `clear` methods for ray and shape hits and clear the hits on disable

### DIFF
--- a/src/plugins/spatial_query/mod.rs
+++ b/src/plugins/spatial_query/mod.rs
@@ -375,6 +375,8 @@ fn raycast(mut rays: Query<(&RayCaster, &mut RayHits)>, spatial_query: SpatialQu
     for (ray, mut hits) in &mut rays {
         if ray.enabled {
             ray.cast(&mut hits, &spatial_query.query_pipeline);
+        } else if !hits.is_empty() {
+            hits.clear();
         }
     }
 }
@@ -386,6 +388,8 @@ fn shapecast(
     for (shape_caster, mut hits) in &mut shape_casters {
         if shape_caster.enabled {
             shape_caster.cast(&mut hits, &spatial_query.query_pipeline);
+        } else if !hits.is_empty() {
+            hits.clear();
         }
     }
 }

--- a/src/plugins/spatial_query/ray_caster.rs
+++ b/src/plugins/spatial_query/ray_caster.rs
@@ -322,6 +322,12 @@ impl RayHits {
         self.count == 0
     }
 
+    /// Clears the hits.
+    pub fn clear(&mut self) {
+        self.vector.clear();
+        self.count = 0;
+    }
+
     /// Returns an iterator over the hits in arbitrary order.
     ///
     /// If you want to get them sorted by time of impact, use `iter_sorted`.

--- a/src/plugins/spatial_query/shape_caster.rs
+++ b/src/plugins/spatial_query/shape_caster.rs
@@ -351,6 +351,12 @@ impl ShapeHits {
         self.count == 0
     }
 
+    /// Clears the hits.
+    pub fn clear(&mut self) {
+        self.vector.clear();
+        self.count = 0;
+    }
+
     /// Returns an iterator over the hits in the order of time of impact.
     pub fn iter(&self) -> std::slice::Iter<ShapeHitData> {
         self.as_slice().iter()


### PR DESCRIPTION
Hits are now cleared automatically when the `RayCaster`/`ShapeCaster` is disabled.