### PR TITLE
Expand AABBs only in the movement direction

### DIFF
--- a/src/plugins/broad_phase.rs
+++ b/src/plugins/broad_phase.rs
@@ -63,25 +63,33 @@ fn update_aabb(
     let safety_margin_factor = 2.0 * dt.0;
 
     for (collider, mut aabb, pos, rot, lin_vel, ang_vel) in &mut bodies {
-        let lin_vel_len = lin_vel.map_or(0.0, |v| v.length());
+        let lin_vel = lin_vel.map_or(Vector::ZERO, |v| v.0);
 
         #[cfg(feature = "2d")]
-        let ang_vel_len = ang_vel.map_or(0.0, |v| v.0.abs());
+        let ang_vel_magnitude = ang_vel.map_or(0.0, |v| v.0.abs());
         #[cfg(feature = "3d")]
-        let ang_vel_len = ang_vel.map_or(0.0, |v| v.0.length());
+        let ang_vel_magnitude = ang_vel.map_or(0.0, |v| v.0.length());
 
+        // Compute AABB half extents and center
         let computed_aabb = collider
             .get_shape()
             .compute_aabb(&utils::make_isometry(pos.0, rot));
         let half_extents = Vector::from(computed_aabb.half_extents());
         let center = Vector::from(computed_aabb.center());
 
-        // Add a safety margin.
-        let safety_margin = safety_margin_factor * (lin_vel_len + ang_vel_len);
-        let extended_half_extents = half_extents + safety_margin;
+        // Todo: Somehow consider the shape of the object for the safety margin
+        // caused by angular velocity. For example, balls shouldn't get any safety margin.
+        let ang_vel_safety_margin = safety_margin_factor * ang_vel_magnitude;
 
-        aabb.mins.coords = (center - extended_half_extents).into();
-        aabb.maxs.coords = (center + extended_half_extents).into();
+        // Compute AABB mins and maxs, extending them by a safety margin that depends on the velocity
+        // of the body. Linear velocity only extends the AABB in the movement direction.
+        let mut mins = center - half_extents - ang_vel_safety_margin;
+        mins += safety_margin_factor * lin_vel.min(Vector::ZERO);
+        let mut maxs = center + half_extents + ang_vel_safety_margin;
+        maxs += safety_margin_factor * lin_vel.max(Vector::ZERO);
+
+        aabb.mins.coords = mins.into();
+        aabb.maxs.coords = maxs.into();
     }
 }
 


### PR DESCRIPTION
Previously, AABBs were expanded equally in all directions based on the velocity of the body in order to avoid missing potential collisions during the broad phase. However, expanding the AABBs in the direction opposite of the movement direction is unnecessary.

This PR changes it so that AABBs are only expanded in the direction of the linear velocity. The angular velocity still expands AABBs in all directions regardless of the shape, but that can maybe be addressed in another PR.

This is how AABBs look now: (gizmos have a delay, so it can often look like the AABBs are still expanded behind the bodies; this is not actually the case)

https://github.com/Jondolf/bevy_xpbd/assets/57632562/cbdeb58a-a8eb-43b5-b086-da3cf571e2bc

This also gives a significant performance boost for situations with many colliders close to each other. For example, previously 1040 moving marbles gave 10 FPS, but now it's a stable 60 FPS.