### PR TITLE
 Improve simulation stability when object are far from world origin 

### DIFF
--- a/crates/bevy_xpbd_3d/examples/cubes.rs
+++ b/crates/bevy_xpbd_3d/examples/cubes.rs
@@ -22,6 +22,9 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
     mut meshes: ResMut<Assets<Mesh>>,
 ) {
+    let origin = Vector::new(0.0, 0.0, 0.0);
+    let density = 1.0;
+
     let cube_mesh = meshes.add(Mesh::from(shape::Cube { size: 1.0 }));
 
     // Ground
@@ -33,7 +36,7 @@ fn setup(
             ..default()
         },
         RigidBody::Static,
-        Position(Vector::NEG_Y * 2.0),
+        Position(origin + Vector::NEG_Y * 2.0),
         Collider::cuboid(100.0, 1.0, 100.0),
     ));
 
@@ -48,6 +51,9 @@ fn setup(
                     y as Scalar * (cube_size + 0.05),
                     z as Scalar * (cube_size + 0.05),
                 );
+
+                let collider = Collider::cuboid(cube_size, cube_size, cube_size);
+
                 commands.spawn((
                     PbrBundle {
                         mesh: cube_mesh.clone(),
@@ -56,8 +62,9 @@ fn setup(
                         ..default()
                     },
                     RigidBody::Dynamic,
-                    Position(pos + Vector::Y * 5.0),
-                    Collider::cuboid(cube_size, cube_size, cube_size),
+                    ColliderMassProperties::new_computed(&collider, density),
+                    collider,
+                    Position(origin + pos + Vector::Y * 5.0),
                     Cube,
                 ));
             }
@@ -77,8 +84,8 @@ fn setup(
 
     // Camera
     commands.spawn(Camera3dBundle {
-        transform: Transform::from_translation(Vec3::new(0.0, 12.0, 40.0))
-            .looking_at(Vec3::Y * 5.0, Vec3::Y),
+        transform: Transform::from_translation(origin + Vec3::new(0.0, 12.0, 40.0))
+            .looking_at(origin + Vec3::Y * 5.0, Vec3::Y),
         ..default()
     });
 }

--- a/crates/bevy_xpbd_3d/examples/cubes.rs
+++ b/crates/bevy_xpbd_3d/examples/cubes.rs
@@ -22,9 +22,6 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
     mut meshes: ResMut<Assets<Mesh>>,
 ) {
-    let origin = Vector::new(0.0, 0.0, 0.0);
-    let density = 1.0;
-
     let cube_mesh = meshes.add(Mesh::from(shape::Cube { size: 1.0 }));
 
     // Ground
@@ -36,7 +33,7 @@ fn setup(
             ..default()
         },
         RigidBody::Static,
-        Position(origin + Vector::NEG_Y * 2.0),
+        Position(Vector::NEG_Y * 2.0),
         Collider::cuboid(100.0, 1.0, 100.0),
     ));
 
@@ -51,9 +48,6 @@ fn setup(
                     y as Scalar * (cube_size + 0.05),
                     z as Scalar * (cube_size + 0.05),
                 );
-
-                let collider = Collider::cuboid(cube_size, cube_size, cube_size);
-
                 commands.spawn((
                     PbrBundle {
                         mesh: cube_mesh.clone(),
@@ -62,9 +56,8 @@ fn setup(
                         ..default()
                     },
                     RigidBody::Dynamic,
-                    ColliderMassProperties::new_computed(&collider, density),
-                    collider,
-                    Position(origin + pos + Vector::Y * 5.0),
+                    Position(pos + Vector::Y * 5.0),
+                    Collider::cuboid(cube_size, cube_size, cube_size),
                     Cube,
                 ));
             }
@@ -82,13 +75,10 @@ fn setup(
         ..default()
     });
 
-    // convert to Vec3 so code compiles when `f64` feature is enabled
-    let origin = Vec3::new(origin.x as _, origin.y as _, origin.z as _);
-
     // Camera
     commands.spawn(Camera3dBundle {
-        transform: Transform::from_translation(origin + Vec3::new(0.0, 12.0, 40.0))
-            .looking_at(origin + Vec3::Y * 5.0, Vec3::Y),
+        transform: Transform::from_translation(Vec3::new(0.0, 12.0, 40.0))
+            .looking_at(Vec3::Y * 5.0, Vec3::Y),
         ..default()
     });
 }

--- a/crates/bevy_xpbd_3d/examples/cubes.rs
+++ b/crates/bevy_xpbd_3d/examples/cubes.rs
@@ -82,6 +82,9 @@ fn setup(
         ..default()
     });
 
+    // convert to Vec3 so code compiles when `f64` feature is enabled
+    let origin = Vec3::new(origin.x as _, origin.y as _, origin.z as _);
+
     // Camera
     commands.spawn(Camera3dBundle {
         transform: Transform::from_translation(origin + Vec3::new(0.0, 12.0, 40.0))

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -167,6 +167,12 @@ pub struct Position(pub Vector);
 pub struct PreviousPosition(pub Vector);
 
 /// Translation accumulated during a sub-step.
+///
+/// When updating position during integration or constraint solving, the required translation
+/// is added to [`AccumulatedTranslation`], instead of [`Position`]. This improves numerical stability
+/// of the simulation, especially for bodies far away from world origin.
+///
+/// After each substep, actual [`Position`] is updated during [`SubstepSet::ApplyTranslation`].
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[reflect(Component)]
 pub struct AccumulatedTranslation(pub Vector);

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -166,6 +166,11 @@ pub struct Position(pub Vector);
 #[reflect(Component)]
 pub struct PreviousPosition(pub Vector);
 
+/// Translation accumulated during a sub-step.
+#[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
+#[reflect(Component)]
+pub struct AccumulatedTranslation(pub Vector);
+
 /// The linear velocity of a body.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[reflect(Component)]

--- a/src/components/world_queries.rs
+++ b/src/components/world_queries.rs
@@ -14,6 +14,7 @@ pub struct RigidBodyQuery {
     pub rotation: &'static mut Rotation,
     pub previous_position: &'static mut PreviousPosition,
     pub previous_rotation: &'static mut PreviousRotation,
+    pub accumulated_translation: &'static mut AccumulatedTranslation,
     pub linear_velocity: &'static mut LinearVelocity,
     pub(crate) pre_solve_linear_velocity: &'static mut PreSolveLinearVelocity,
     pub angular_velocity: &'static mut AngularVelocity,

--- a/src/constraints/joints/mod.rs
+++ b/src/constraints/joints/mod.rs
@@ -144,8 +144,10 @@ pub trait Joint: Component + PositionConstraint + AngularConstraint {
         let world_r1 = body1.rotation.rotate(r1);
         let world_r2 = body2.rotation.rotate(r2);
 
-        let delta_x = DistanceLimit::new(0.0, 0.0)
-            .compute_correction(body1.position.0 + world_r1, body2.position.0 + world_r2);
+        let delta_x = DistanceLimit::new(0.0, 0.0).compute_correction(
+            body1.position.0 + body1.accumulated_translation.0 + world_r1,
+            body2.position.0 + body2.accumulated_translation.0 + world_r2,
+        );
         let magnitude = delta_x.length();
 
         if magnitude <= Scalar::EPSILON {

--- a/src/constraints/joints/prismatic.rs
+++ b/src/constraints/joints/prismatic.rs
@@ -150,8 +150,8 @@ impl PrismaticJoint {
         let axis1 = body1.rotation.rotate(self.free_axis);
         if let Some(limits) = self.free_axis_limits {
             delta_x += limits.compute_correction_along_axis(
-                body1.position.0 + world_r1,
-                body2.position.0 + world_r2,
+                body1.position.0 + body1.accumulated_translation.0 + world_r1,
+                body2.position.0 + body2.accumulated_translation.0 + world_r2,
                 axis1,
             );
         }
@@ -162,8 +162,8 @@ impl PrismaticJoint {
         {
             let axis2 = Vector::new(axis1.y, -axis1.x);
             delta_x += zero_distance_limit.compute_correction_along_axis(
-                body1.position.0 + world_r1,
-                body2.position.0 + world_r2,
+                body1.position.0 + body1.accumulated_translation.0 + world_r1,
+                body2.position.0 + body2.accumulated_translation.0 + world_r2,
                 axis2,
             );
         }
@@ -173,13 +173,13 @@ impl PrismaticJoint {
             let axis3 = axis1.cross(axis2);
 
             delta_x += zero_distance_limit.compute_correction_along_axis(
-                body1.position.0 + world_r1,
-                body2.position.0 + world_r2,
+                body1.position.0 + body1.accumulated_translation.0 + world_r1,
+                body2.position.0 + body2.accumulated_translation.0 + world_r2,
                 axis2,
             );
             delta_x += zero_distance_limit.compute_correction_along_axis(
-                body1.position.0 + world_r1,
-                body2.position.0 + world_r2,
+                body1.position.0 + body1.accumulated_translation.0 + world_r1,
+                body2.position.0 + body2.accumulated_translation.0 + world_r2,
                 axis3,
             );
         }

--- a/src/constraints/position_constraint.rs
+++ b/src/constraints/position_constraint.rs
@@ -32,11 +32,11 @@ pub trait PositionConstraint: XpbdConstraint<2> {
 
         // Apply positional and rotational updates
         if body1.rb.is_dynamic() {
-            body1.position.0 += p * inv_mass1;
+            body1.accumulated_translation.0 += p * inv_mass1;
             *body1.rotation += Self::get_delta_rot(rot1, inv_inertia1, r1, p);
         }
         if body2.rb.is_dynamic() {
-            body2.position.0 -= p * inv_mass2;
+            body2.accumulated_translation.0 -= p * inv_mass2;
             *body2.rotation -= Self::get_delta_rot(rot2, inv_inertia2, r2, p);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -565,4 +565,8 @@ pub enum SubstepSet {
     ///
     /// See [`SolverPlugin`].
     SolveVelocities,
+    /// Responsible for applying translation accumulated during the substep.
+    ///
+    /// See [`SolverPlugin`].
+    ApplyTranslation,
 }

--- a/src/plugins/integrator.rs
+++ b/src/plugins/integrator.rs
@@ -32,8 +32,9 @@ impl Plugin for IntegratorPlugin {
 
 type PosIntegrationComponents = (
     &'static RigidBody,
-    &'static mut Position,
+    &'static Position,
     &'static mut PreviousPosition,
+    &'static mut AccumulatedTranslation,
     &'static mut LinearVelocity,
     Option<&'static LinearDamping>,
     Option<&'static GravityScale>,
@@ -52,8 +53,9 @@ fn integrate_pos(
 ) {
     for (
         rb,
-        mut pos,
+        pos,
         mut prev_pos,
+        mut translation,
         mut lin_vel,
         lin_damping,
         gravity_scale,
@@ -87,7 +89,7 @@ fn integrate_pos(
             lin_vel.0 += sub_dt.0 * external_forces * effective_inv_mass;
         }
 
-        pos.0 += locked_axes.apply_to_vec(sub_dt.0 * lin_vel.0);
+        translation.0 += locked_axes.apply_to_vec(sub_dt.0 * lin_vel.0);
     }
 }
 

--- a/src/plugins/prepare.rs
+++ b/src/plugins/prepare.rs
@@ -85,6 +85,7 @@ fn init_rigid_bodies(
     ) in &mut bodies
     {
         let mut body = commands.entity(entity);
+        body.insert(AccumulatedTranslation(Vector::ZERO));
 
         if let Some(pos) = pos {
             body.insert(PreviousPosition(pos.0));
@@ -268,8 +269,13 @@ fn update_mass_properties(mut bodies: Query<MassPropertiesComponents, MassProper
         }
 
         if let Some(collider) = collider {
-            let Some(mut collider_mass_properties)=collider_mass_properties else { continue; };
-            let Some(mut previous_collider_mass_properties)=previous_collider_mass_properties else { continue; };
+            let Some(mut collider_mass_properties) = collider_mass_properties else {
+                continue;
+            };
+            let Some(mut previous_collider_mass_properties) = previous_collider_mass_properties
+            else {
+                continue;
+            };
 
             // Subtract previous collider mass props from the body's mass props
             mass_properties -= previous_collider_mass_properties.0;

--- a/src/plugins/setup.rs
+++ b/src/plugins/setup.rs
@@ -78,6 +78,7 @@ impl Plugin for PhysicsSetupPlugin {
             .register_type::<Rotation>()
             .register_type::<PreviousPosition>()
             .register_type::<PreviousRotation>()
+            .register_type::<AccumulatedTranslation>()
             .register_type::<LinearVelocity>()
             .register_type::<AngularVelocity>()
             .register_type::<PreSolveLinearVelocity>()
@@ -151,6 +152,7 @@ impl Plugin for PhysicsSetupPlugin {
                 SubstepSet::SolveUserConstraints,
                 SubstepSet::UpdateVelocities,
                 SubstepSet::SolveVelocities,
+                SubstepSet::ApplyTranslation,
             )
                 .chain(),
         );

--- a/src/plugins/solver.rs
+++ b/src/plugins/solver.rs
@@ -261,6 +261,7 @@ pub fn solve_constraint<C: XpbdConstraint<ENTITY_COUNT> + Component, const ENTIT
 }
 
 /// Updates the linear velocity of all dynamic bodies based on the change in position from the previous step.
+#[allow(clippy::type_complexity)]
 fn update_lin_vel(
     mut bodies: Query<
         (

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -37,11 +37,10 @@ pub(crate) fn get_dynamic_friction(
         return Vector::ZERO;
     }
 
-    let normal_force = normal_lagrange / sub_dt.powi(2);
+    let normal_impulse = normal_lagrange / sub_dt;
 
     // Velocity update caused by dynamic friction, never exceeds the magnitude of the tangential velocity itself
-    -tangent_vel / tangent_vel_magnitude
-        * (sub_dt * coefficient * normal_force.abs()).min(tangent_vel_magnitude)
+    -tangent_vel * (coefficient * normal_impulse.abs() / tangent_vel_magnitude).min(1.0)
 }
 
 /// Calculates velocity correction caused by restitution.


### PR DESCRIPTION
During integration and constraint solving, position gets incremented by very small amounts, especially at high substep count.  When the objects are far from origin, small increments to position are rounded to zero. To mitigate that, I've added `AccumulatedTranslation` component, which gets incremented instead of `Position`. Then, at the end of each substep, a system updates the actual position.

This change seems to be the magic bullet for "far from origin" kinds of problems. But it's not perfect yet.

Here's the cubes example with origin set to (10000, 10000). When using `f32`, the next float after `10000` is `10000.0009766`, which gives precision of roughly `1e-3` . 

Here's the before:

https://github.com/Jondolf/bevy_xpbd/assets/42153076/3e96809b-8cfa-4fc2-b288-05c8a2c4f37e

Here's the after:

https://github.com/Jondolf/bevy_xpbd/assets/42153076/b6a717d5-a981-428a-9e44-f1976f89ef50

As you can see, it starts very promising, but then explodes. I don't know what causes that, but If I change substeps from 12 to 6 (not part of PR), it doesn't explode:

https://github.com/Jondolf/bevy_xpbd/assets/42153076/6b7ecf5a-7824-4c91-b933-4bca0778304f

Also, I've changed contacts to be queried in local space, since that's what parry does internally, only then to transform it back to world space (and back to local in `PenetrationConstraint`). This improves precision.

Additionally, I've found a few places where values of different orders of magnitude were subtracted (for example when computing relative motion of contact points): I've reordered operands to try and keep relative magnitudes close.

# Future work

In the future, perhaps it would be beneficial to update actual position not on every substep, but on every _step_ instead. This way, even on very large substep counts (where dt is very tiny) everything should work fine.