### PR TITLE
Add back global contact positions

### DIFF
--- a/src/collision.rs
+++ b/src/collision.rs
@@ -1,6 +1,6 @@
 //! Collision events, contact data and helpers.
 
-use parry::query::{ContactManifoldsWorkspace, PersistentQueryDispatcher, QueryDispatcher};
+use parry::query::QueryDispatcher;
 
 use crate::prelude::*;
 

--- a/src/collision.rs
+++ b/src/collision.rs
@@ -1,6 +1,6 @@
 //! Collision events, contact data and helpers.
 
-use parry::query::QueryDispatcher;
+use parry::query::{ContactManifoldsWorkspace, PersistentQueryDispatcher, QueryDispatcher};
 
 use crate::prelude::*;
 
@@ -24,8 +24,12 @@ pub struct Contact {
     /// Second entity in the contact.
     pub entity2: Entity,
     /// Contact point on the first entity in local coordinates.
-    pub point1: Vector,
+    pub local_point1: Vector,
     /// Contact point on the second entity in local coordinates.
+    pub local_point2: Vector,
+    /// Contact point on the first entity in global coordinates.
+    pub point1: Vector,
+    /// Contact point on the second entity in global coordinates.
     pub point2: Vector,
     /// Contact normal from contact point 1 to 2 in world coordinates.
     pub normal: Vector,
@@ -58,8 +62,10 @@ pub(crate) fn compute_contact(
         return Some(Contact {
             entity1,
             entity2,
-            point1: contact.point1.into(),
-            point2: contact.point2.into(),
+            local_point1: contact.point1.into(),
+            local_point2: contact.point2.into(),
+            point1: position1 + rotation1.rotate(contact.point1.into()),
+            point2: position2 + rotation2.rotate(contact.point2.into()),
             normal: rotation1.rotate(contact.normal1.into()),
             penetration: -contact.dist,
         });

--- a/src/constraints/penetration.rs
+++ b/src/constraints/penetration.rs
@@ -55,8 +55,8 @@ impl XpbdConstraint<2> for PenetrationConstraint {
 impl PenetrationConstraint {
     /// Creates a new [`PenetrationConstraint`] with the given bodies and contact data.
     pub fn new(body1: &RigidBodyQueryItem, body2: &RigidBodyQueryItem, contact: Contact) -> Self {
-        let local_r1 = contact.point1 - body1.center_of_mass.0;
-        let local_r2 = contact.point2 - body2.center_of_mass.0;
+        let local_r1 = contact.local_point1 - body1.center_of_mass.0;
+        let local_r2 = contact.local_point2 - body2.center_of_mass.0;
 
         let world_r1 = body1.rotation.rotate(local_r1);
         let world_r2 = body2.rotation.rotate(local_r2);


### PR DESCRIPTION
#84 changed contact positions to be local in order to improve numerical stability. However, `Contact` should also have the global contact positions, as users and e.g. the debug plugin often need global coordinates, and it's unnecessry to do extra component queries just to convert into global coordinates manually.

This PR renames `point1` and `point2` to `local_point1` and `local_point2` and adds back the original `point1` and `point2` that were in global coordinates. This also fixes the debug plugin contact rendering, which was broken by #84.