### PR TITLE
Use contact manifolds instead of single contacts for collisions

### DIFF
--- a/crates/bevy_xpbd_3d/examples/basic_kinematic_character.rs
+++ b/crates/bevy_xpbd_3d/examples/basic_kinematic_character.rs
@@ -134,14 +134,18 @@ fn kinematic_collision(
     mut bodies: Query<(&RigidBody, &mut Position)>,
 ) {
     // Iterate through collisions and move the kinematic body to resolve penetration
-    for Collision(contact) in collision_event_reader.iter() {
+    for Collision(contacts) in collision_event_reader.iter() {
         if let Ok([(rb1, mut position1), (rb2, mut position2)]) =
-            bodies.get_many_mut([contact.entity1, contact.entity2])
+            bodies.get_many_mut([contacts.entity1, contacts.entity2])
         {
-            if rb1.is_kinematic() && !rb2.is_kinematic() {
-                position1.0 -= contact.normal * contact.penetration;
-            } else if rb2.is_kinematic() && !rb1.is_kinematic() {
-                position2.0 += contact.normal * contact.penetration;
+            for manifold in contacts.manifolds.iter() {
+                for contact in manifold.contacts.iter() {
+                    if rb1.is_kinematic() && !rb2.is_kinematic() {
+                        position1.0 -= contact.normal * contact.penetration;
+                    } else if rb2.is_kinematic() && !rb1.is_kinematic() {
+                        position2.0 += contact.normal * contact.penetration;
+                    }
+                }
             }
         }
     }

--- a/src/collision.rs
+++ b/src/collision.rs
@@ -1,12 +1,12 @@
 //! Collision events, contact data and helpers.
 
-use parry::query::QueryDispatcher;
+use parry::query::PersistentQueryDispatcher;
 
 use crate::prelude::*;
 
 /// A [collision event](Collider#collision-events) that is sent for each contact pair during the narrow phase.
 #[derive(Event, Clone, Debug, PartialEq)]
-pub struct Collision(pub Contact);
+pub struct Collision(pub Contacts);
 
 /// A [collision event](Collider#collision-events) that is sent when two entities start colliding.
 #[derive(Event, Clone, Debug, PartialEq)]
@@ -16,9 +16,40 @@ pub struct CollisionStarted(pub Entity, pub Entity);
 #[derive(Event, Clone, Debug, PartialEq)]
 pub struct CollisionEnded(pub Entity, pub Entity);
 
+/// All contacts between two colliders.
+///
+/// The contacts are stored in contact manifolds.
+/// Each manifold contains one or more contact points, and each contact
+/// in a given manifold shares the same contact normal.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Contacts {
+    /// First entity in the contact.
+    pub entity1: Entity,
+    /// Second entity in the contact.
+    pub entity2: Entity,
+    /// A list of contact manifolds between two colliders.
+    /// Each manifold contains one or more contact points, but each contact
+    /// in a given manifold shares the same contact normal.
+    pub manifolds: Vec<ContactManifold>,
+}
+
+/// A contact manifold between two colliders, containing a set of contact points.
+/// Each contact in a manifold shares the same contact normal.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ContactManifold {
+    /// First entity in the contact.
+    pub entity1: Entity,
+    /// Second entity in the contact.
+    pub entity2: Entity,
+    /// The contacts in this manifold.
+    pub contacts: Vec<ContactData>,
+    /// A world-space contact normal shared by all contacts in this manifold.
+    pub normal: Vector,
+}
+
 /// Data related to a contact between two bodies.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct Contact {
+pub struct ContactData {
     /// First entity in the contact.
     pub entity1: Entity,
     /// Second entity in the contact.
@@ -39,7 +70,7 @@ pub struct Contact {
 
 /// Computes one pair of contact points between two shapes.
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn compute_contact(
+pub(crate) fn compute_contacts(
     entity1: Entity,
     entity2: Entity,
     position1: Vector,
@@ -48,27 +79,47 @@ pub(crate) fn compute_contact(
     rotation2: &Rotation,
     collider1: &Collider,
     collider2: &Collider,
-) -> Option<Contact> {
+) -> Contacts {
     let isometry1 = utils::make_isometry(position1, rotation1);
     let isometry2 = utils::make_isometry(position2, rotation2);
     let isometry12 = isometry1.inv_mul(&isometry2);
 
-    if let Ok(Some(contact)) = parry::query::DefaultQueryDispatcher.contact(
+    // Todo: Reuse manifolds from previous frame to improve performance
+    let mut manifolds: Vec<parry::query::ContactManifold<(), ()>> = vec![];
+    let _ = parry::query::DefaultQueryDispatcher.contact_manifolds(
         &isometry12,
         collider1.get_shape().0.as_ref(),
         collider2.get_shape().0.as_ref(),
         0.0,
-    ) {
-        return Some(Contact {
-            entity1,
-            entity2,
-            local_point1: contact.point1.into(),
-            local_point2: contact.point2.into(),
-            point1: position1 + rotation1.rotate(contact.point1.into()),
-            point2: position2 + rotation2.rotate(contact.point2.into()),
-            normal: rotation1.rotate(contact.normal1.into()),
-            penetration: -contact.dist,
-        });
+        &mut manifolds,
+        &mut None,
+    );
+    Contacts {
+        entity1,
+        entity2,
+        manifolds: manifolds
+            .clone()
+            .into_iter()
+            .map(|manifold| ContactManifold {
+                entity1,
+                entity2,
+                normal: rotation1.rotate(manifold.local_n1.into()),
+                contacts: manifold
+                    .contacts()
+                    .iter()
+                    .map(|contact| ContactData {
+                        entity1,
+                        entity2,
+                        local_point1: contact.local_p1.into(),
+                        local_point2: contact.local_p2.into(),
+                        point1: position1 + rotation1.rotate(contact.local_p1.into()),
+                        point2: position2 + rotation2.rotate(contact.local_p2.into()),
+                        normal: rotation1.rotate(manifolds[0].local_n1.into()),
+                        penetration: -contact.dist,
+                    })
+                    .filter(|c| c.penetration > 0.0)
+                    .collect(),
+            })
+            .collect(),
     }
-    None
 }

--- a/src/collision.rs
+++ b/src/collision.rs
@@ -50,10 +50,6 @@ pub struct ContactManifold {
 /// Data related to a contact between two bodies.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ContactData {
-    /// First entity in the contact.
-    pub entity1: Entity,
-    /// Second entity in the contact.
-    pub entity2: Entity,
     /// Contact point on the first entity in local coordinates.
     pub local_point1: Vector,
     /// Contact point on the second entity in local coordinates.
@@ -108,8 +104,6 @@ pub(crate) fn compute_contacts(
                     .contacts()
                     .iter()
                     .map(|contact| ContactData {
-                        entity1,
-                        entity2,
                         local_point1: contact.local_p1.into(),
                         local_point2: contact.local_p2.into(),
                         point1: position1 + rotation1.rotate(contact.local_p1.into()),

--- a/src/constraints/penetration.rs
+++ b/src/constraints/penetration.rs
@@ -13,7 +13,7 @@ pub struct PenetrationConstraint {
     /// Second entity in the constraint.
     pub entity2: Entity,
     /// Data associated with the contact.
-    pub contact: Contact,
+    pub contact: ContactData,
     /// Vector from the first entity's center of mass to the contact point in local coordinates.
     pub local_r1: Vector,
     /// Vector from the second entity's center of mass to the contact point in local coordinates.
@@ -54,7 +54,11 @@ impl XpbdConstraint<2> for PenetrationConstraint {
 
 impl PenetrationConstraint {
     /// Creates a new [`PenetrationConstraint`] with the given bodies and contact data.
-    pub fn new(body1: &RigidBodyQueryItem, body2: &RigidBodyQueryItem, contact: Contact) -> Self {
+    pub fn new(
+        body1: &RigidBodyQueryItem,
+        body2: &RigidBodyQueryItem,
+        contact: ContactData,
+    ) -> Self {
         let local_r1 = contact.local_point1 - body1.center_of_mass.0;
         let local_r2 = contact.local_point2 - body2.center_of_mass.0;
 

--- a/src/constraints/penetration.rs
+++ b/src/constraints/penetration.rs
@@ -47,6 +47,30 @@ impl XpbdConstraint<2> for PenetrationConstraint {
     /// Solves overlap between two bodies.
     fn solve(&mut self, bodies: [&mut RigidBodyQueryItem; 2], dt: Scalar) {
         let [body1, body2] = bodies;
+
+        // For convex-convex collider contacts, we can compute the penetration at the current state
+        // using the contact points like the XPBD paper suggests, which reduces explosiveness.
+        //
+        // However, non-convex colliders cause convex colliders to sink into them unless we use
+        // the penetration depth provided by Parry.
+        //
+        // Todo: Figure out why this is and use the method below for all collider types in order to fix
+        // explosions for all contacts.
+        if self.contact.convex {
+            let p1 = body1.position.0
+                + body1.accumulated_translation.0
+                + body1.rotation.rotate(self.local_r1);
+            let p2 = body2.position.0
+                + body2.accumulated_translation.0
+                + body2.rotation.rotate(self.local_r2);
+            self.contact.penetration = (p1 - p2).dot(self.contact.normal);
+        }
+
+        // If penetration depth is under 0, skip the collision
+        if self.contact.penetration <= Scalar::EPSILON {
+            return;
+        }
+
         self.solve_contact(body1, body2, dt);
         self.solve_friction(body1, body2, dt);
     }
@@ -93,13 +117,8 @@ impl PenetrationConstraint {
         let normal = self.contact.normal;
         let compliance = self.compliance;
         let lagrange = self.normal_lagrange;
-        let r1 = self.world_r1;
-        let r2 = self.world_r2;
-
-        // If penetration depth is under 0, skip the collision
-        if penetration <= 0.0 {
-            return;
-        }
+        let r1 = body1.rotation.rotate(self.local_r1);
+        let r2 = body2.rotation.rotate(self.local_r2);
 
         // Compute generalized inverse masses
         let w1 = self.compute_generalized_inverse_mass(body1, r1, normal);
@@ -132,8 +151,8 @@ impl PenetrationConstraint {
         let normal = self.contact.normal;
         let compliance = self.compliance;
         let lagrange = self.tangent_lagrange;
-        let r1 = self.world_r1;
-        let r2 = self.world_r2;
+        let r1 = body1.rotation.rotate(self.local_r1);
+        let r2 = body2.rotation.rotate(self.local_r2);
 
         // Compute relative motion of the contact points and get the tangential component
         let delta_p1 =

--- a/src/plugins/debug/mod.rs
+++ b/src/plugins/debug/mod.rs
@@ -146,23 +146,27 @@ fn debug_render_contacts(
     let Some(color) = config.contact_color else {
         return;
     };
-    for Collision(contact) in collisions.iter() {
-        let p1 = contact.point1;
-        let p2 = contact.point2;
-        #[cfg(feature = "2d")]
-        let len = 5.0;
-        #[cfg(feature = "3d")]
-        let len = 0.3;
+    for Collision(contacts) in collisions.iter() {
+        for manifold in contacts.manifolds.iter() {
+            for contact in manifold.contacts.iter() {
+                let p1 = contact.point1;
+                let p2 = contact.point2;
+                #[cfg(feature = "2d")]
+                let len = 5.0;
+                #[cfg(feature = "3d")]
+                let len = 0.3;
 
-        debug_renderer.draw_line(p1 - Vector::X * len, p1 + Vector::X * len, color);
-        debug_renderer.draw_line(p1 - Vector::Y * len, p1 + Vector::Y * len, color);
-        #[cfg(feature = "3d")]
-        debug_renderer.draw_line(p1 - Vector::Z * len, p1 + Vector::Z * len, color);
+                debug_renderer.draw_line(p1 - Vector::X * len, p1 + Vector::X * len, color);
+                debug_renderer.draw_line(p1 - Vector::Y * len, p1 + Vector::Y * len, color);
+                #[cfg(feature = "3d")]
+                debug_renderer.draw_line(p1 - Vector::Z * len, p1 + Vector::Z * len, color);
 
-        debug_renderer.draw_line(p2 - Vector::X * len, p2 + Vector::X * len, color);
-        debug_renderer.draw_line(p2 - Vector::Y * len, p2 + Vector::Y * len, color);
-        #[cfg(feature = "3d")]
-        debug_renderer.draw_line(p2 - Vector::Z * len, p2 + Vector::Z * len, color);
+                debug_renderer.draw_line(p2 - Vector::X * len, p2 + Vector::X * len, color);
+                debug_renderer.draw_line(p2 - Vector::Y * len, p2 + Vector::Y * len, color);
+                #[cfg(feature = "3d")]
+                debug_renderer.draw_line(p2 - Vector::Z * len, p2 + Vector::Z * len, color);
+            }
+        }
     }
 }
 

--- a/src/plugins/solver.rs
+++ b/src/plugins/solver.rs
@@ -372,17 +372,12 @@ fn solve_vel(
     sub_dt: Res<SubDeltaTime>,
 ) {
     for constraint in penetration_constraints.0.iter() {
-        let ContactData {
-            entity1,
-            entity2,
-            normal,
-            ..
-        } = constraint.contact;
-
-        if let Ok([mut body1, mut body2]) = bodies.get_many_mut([entity1, entity2]) {
+        if let Ok([mut body1, mut body2]) = bodies.get_many_mut(constraint.entities()) {
             if !body1.rb.is_dynamic() && !body2.rb.is_dynamic() {
                 continue;
             }
+
+            let normal = constraint.contact.normal;
 
             // Compute pre-solve relative normal velocities at the contact point (used for restitution)
             let pre_solve_contact_vel1 = compute_contact_vel(


### PR DESCRIPTION
Currently, each collision only uses one contact. When a box is on the ground, the contact point oscillates between the corners, which can often cause significant instability and positional drift.

This PR changes this behaviour by computing multiple contact points using contact manifolds. This allows all four corners of a cube to be in contact at the same time, which essentially eliminates drifting, closing #85.

## Comparison

Before: 

https://github.com/Jondolf/bevy_xpbd/assets/57632562/5aeaa265-ce15-465b-9eab-42a732a1f657

After:

https://github.com/Jondolf/bevy_xpbd/assets/57632562/a4136550-0872-442c-ad36-cbf4d105e1d0

As you can see, the cubes now land in a much more stable way, drifting is almost nonexistent, and explosions or small jumps are significantly reduced.

## Caveats and future work

### Small jumps

Edit: Fixed this for convex colliders, but non-convex colliders are still buggy. Read my comment below this post.

Despite drifting being essentially removed and explosions being heavily reduced, there are still occasional jumps, which might be because the constraint only uses the initial penetration depths (from Parry) instead of computing them based on the current state, which would cause the applied correction to be too large.

This seems to be mitigated by manually computing the penetration depth based on contact points computed at the current state, just like the XPBD paper recommends:

```rust
let p1 = body1.position.0
    + body1.accumulated_translation.0
    + body1.rotation.rotate(self.local_r1);
let p2 = body2.position.0
    + body2.accumulated_translation.0
    + body2.rotation.rotate(self.local_r2);
let penetration = (p1 - p2).dot(normal);
```

However, this causes problems with trimesh colliders, so I didn't add it yet. This will have to be investigated later.

### Non-convex colliders

These changes only fix convex-convex collisions, and non-convex colliders (like trimeshes) still have the old behaviour. Read my comment below this post.

### Performance

As you might expect, using multiple contact points instead of one can be more expensive, but the difference seems to actually be quite small.

Parry supports reusing the previous contact manifold to speed up the computation, so it could even be faster than the old method if implemented correctly. I didn't implement this yet due to facing more problems, but it will have to be tried again, as it should give a significant performance boost.

### API change

Collisions are no longer just singular contacts, so I added a `Contacts` struct for a collision between two entities. It contains the entities and a `Vec<ContactManifold>`, where each contact manifold contains the entities, a normal, and the contacts, which are represented as `Vec<Contact>`.

This is quite a few added layers, so it would be nice to add simple methods to e.g. get all contacts as a flat structure or to compute the deepest contact.