### PR TITLE
Setup `PhysicsSchedule` and `SubstepSchedule` to use single-threaded executor

### DIFF
--- a/src/plugins/setup.rs
+++ b/src/plugins/setup.rs
@@ -2,7 +2,10 @@
 //!
 //! See [`PhysicsSetupPlugin`].
 
-use bevy::transform::TransformSystem;
+use bevy::{
+    ecs::schedule::{ExecutorKind, ScheduleBuildSettings},
+    transform::TransformSystem,
+};
 
 use crate::prelude::*;
 
@@ -115,10 +118,12 @@ impl Plugin for PhysicsSetupPlugin {
         // Create physics schedule, the schedule that advances the physics simulation
         let mut physics_schedule = Schedule::default();
 
-        physics_schedule.set_build_settings(bevy::ecs::schedule::ScheduleBuildSettings {
-            ambiguity_detection: LogLevel::Error,
-            ..default()
-        });
+        physics_schedule
+            .set_executor_kind(ExecutorKind::SingleThreaded)
+            .set_build_settings(ScheduleBuildSettings {
+                ambiguity_detection: LogLevel::Error,
+                ..default()
+            });
 
         physics_schedule.configure_sets(
             (
@@ -140,10 +145,12 @@ impl Plugin for PhysicsSetupPlugin {
         // Create substep schedule, the schedule that runs the inner substepping loop
         let mut substep_schedule = Schedule::default();
 
-        substep_schedule.set_build_settings(bevy::ecs::schedule::ScheduleBuildSettings {
-            ambiguity_detection: LogLevel::Error,
-            ..default()
-        });
+        substep_schedule
+            .set_executor_kind(ExecutorKind::SingleThreaded)
+            .set_build_settings(ScheduleBuildSettings {
+                ambiguity_detection: LogLevel::Error,
+                ..default()
+            });
 
         substep_schedule.configure_sets(
             (


### PR DESCRIPTION
By default schedules use multi-threaded executor, but since all systems are chained together and run one after another, using the multi-threaded executor is pointless and adds overhead.

This improves performance in benchmarks by between 12% and 50%:

3x3 cubes, 30 steps:
![image](https://github.com/Jondolf/bevy_xpbd/assets/42153076/782f706b-a2e8-442f-b48e-d1fd2052c758)

5x5 cubes, 30 steps:
![image](https://github.com/Jondolf/bevy_xpbd/assets/42153076/37c5b371-8e7d-42b9-9dc0-1f71a74990d2)

10x10 cubes, 30 steps:
![image](https://github.com/Jondolf/bevy_xpbd/assets/42153076/f8e7f9d9-2914-431b-951f-35cef35f283d)

The relative speedup is smaller with more cubes, since task overhead is static.

In the future, systems should be internally parallelized (probably using rayon), so using the single threaded executor will free other threads for performing parallel work.