### PR TITLE
Store local contact normals and transform them into world-space at each solve

### DIFF
--- a/src/collision.rs
+++ b/src/collision.rs
@@ -43,7 +43,8 @@ pub struct ContactManifold {
     pub entity2: Entity,
     /// The contacts in this manifold.
     pub contacts: Vec<ContactData>,
-    /// A world-space contact normal shared by all contacts in this manifold.
+    /// A contact normal shared by all contacts in this manifold,
+    /// expressed in the local space of the first entity.
     pub normal: Vector,
 }
 
@@ -51,20 +52,35 @@ pub struct ContactManifold {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ContactData {
     /// Contact point on the first entity in local coordinates.
-    pub local_point1: Vector,
-    /// Contact point on the second entity in local coordinates.
-    pub local_point2: Vector,
-    /// Contact point on the first entity in global coordinates.
     pub point1: Vector,
-    /// Contact point on the second entity in global coordinates.
+    /// Contact point on the second entity in local coordinates.
     pub point2: Vector,
-    /// Contact normal from contact point 1 to 2 in world coordinates.
+    /// A contact normal expressed in the local space of the first entity.
     pub normal: Vector,
     /// Penetration depth.
     pub penetration: Scalar,
     /// True if both colliders are convex. Currently, contacts between
     /// convex and non-convex colliders have to be handled differently.
     pub(crate) convex: bool,
+}
+
+impl ContactData {
+    /// Returns the global contact point on the first entity,
+    /// transforming the local point by the given entity position and rotation.
+    pub fn global_point1(&self, position: &Position, rotation: &Rotation) -> Vector {
+        position.0 + rotation.rotate(self.point1)
+    }
+
+    /// Returns the global contact point on the second entity,
+    /// transforming the local point by the given entity position and rotation.
+    pub fn global_point2(&self, position: &Position, rotation: &Rotation) -> Vector {
+        position.0 + rotation.rotate(self.point2)
+    }
+
+    /// Returns the world-space contact normal pointing towards the exterior of the first entity.
+    pub fn global_normal(&self, rotation: &Rotation) -> Vector {
+        rotation.rotate(self.normal)
+    }
 }
 
 /// Computes one pair of contact points between two shapes.
@@ -103,16 +119,14 @@ pub(crate) fn compute_contacts(
                 .map(|manifold| ContactManifold {
                     entity1,
                     entity2,
-                    normal: rotation1.rotate(manifold.local_n1.into()),
+                    normal: manifold.local_n1.into(),
                     contacts: manifold
                         .contacts()
                         .iter()
                         .map(|contact| ContactData {
-                            local_point1: contact.local_p1.into(),
-                            local_point2: contact.local_p2.into(),
-                            point1: position1 + rotation1.rotate(contact.local_p1.into()),
-                            point2: position2 + rotation2.rotate(contact.local_p2.into()),
-                            normal: rotation1.rotate(manifold.local_n1.into()),
+                            point1: contact.local_p1.into(),
+                            point2: contact.local_p2.into(),
+                            normal: manifold.local_n1.into(),
                             penetration: -contact.dist,
                             convex,
                         })
@@ -134,11 +148,9 @@ pub(crate) fn compute_contacts(
             )
             .unwrap()
             .map(|contact| ContactData {
-                local_point1: contact.point1.into(),
-                local_point2: contact.point2.into(),
-                point1: position1 + rotation1.rotate(contact.point1.into()),
-                point2: position2 + rotation2.rotate(contact.point2.into()),
-                normal: rotation1.rotate(contact.normal1.into()),
+                point1: contact.point1.into(),
+                point2: contact.point2.into(),
+                normal: contact.normal1.into(),
                 penetration: -contact.dist,
                 convex,
             });

--- a/src/plugins/debug/mod.rs
+++ b/src/plugins/debug/mod.rs
@@ -139,6 +139,7 @@ fn debug_render_aabbs(
 }
 
 fn debug_render_contacts(
+    colliders: Query<(&Position, &Rotation), With<Collider>>,
     mut collisions: EventReader<Collision>,
     mut debug_renderer: PhysicsDebugRenderer,
     config: Res<PhysicsDebugConfig>,
@@ -147,10 +148,17 @@ fn debug_render_contacts(
         return;
     };
     for Collision(contacts) in collisions.iter() {
+        let Ok((position1, rotation1)) = colliders.get(contacts.entity1) else {
+            continue;
+        };
+        let Ok((position2, rotation2)) = colliders.get(contacts.entity2) else {
+            continue;
+        };
+
         for manifold in contacts.manifolds.iter() {
             for contact in manifold.contacts.iter() {
-                let p1 = contact.point1;
-                let p2 = contact.point2;
+                let p1 = contact.global_point1(position1, rotation1);
+                let p2 = contact.global_point2(position2, rotation2);
                 #[cfg(feature = "2d")]
                 let len = 5.0;
                 #[cfg(feature = "3d")]

--- a/src/plugins/solver.rs
+++ b/src/plugins/solver.rs
@@ -382,9 +382,9 @@ fn solve_vel(
                 continue;
             }
 
-            let normal = constraint.contact.normal;
-            let r1 = body1.rotation.rotate(constraint.local_r1);
-            let r2 = body2.rotation.rotate(constraint.local_r2);
+            let normal = constraint.contact.global_normal(&body1.rotation);
+            let r1 = body1.rotation.rotate(constraint.r1);
+            let r2 = body2.rotation.rotate(constraint.r2);
 
             // Compute pre-solve relative normal velocities at the contact point (used for restitution)
             let pre_solve_contact_vel1 = compute_contact_vel(


### PR DESCRIPTION
Currently, contact normals are stored in world-space. However, the directions can slightly change during each constraint solve, which can cause positional drift.

This PR stores contact normals and contact points in local space and transforms them into world-space in each penetration constraint and the velocity solve. `ContactData` has helper methods for conversion to global space, although they require the rotation and/or position of the body.

Stacking cubes is now *much* more stable. Below is a screenshot of an 80 cube stack, with f32 precision, with sleeping disabled, after nearly 5 minutes of simulation.

<img width="349" alt="80_cube_stack" src="https://github.com/Jondolf/bevy_xpbd/assets/57632562/5b85c9f6-7c51-4ef6-acab-5d2413795e9c">

Previously, the same stack fell in about 3 seconds due to cubes moving sideways.

Note that perfectly stable stacks require a lot of substeps (I think I used 80 or 90 for the test), but now it should at least be possible to have stable stacks.

Thanks to felixbjorkeson for noticing this issue!