### PR TITLE
Separate narrow phase from solver into `NarrowPhasePlugin`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,7 +412,6 @@ pub extern crate parry3d as parry;
 #[cfg(all(feature = "3d", feature = "f64"))]
 pub extern crate parry3d_f64 as parry;
 
-pub mod collision;
 pub mod components;
 pub mod constraints;
 pub mod math;
@@ -422,7 +421,6 @@ pub mod resources;
 /// Re-exports common components, bundles, resources, plugins and types.
 pub mod prelude {
     pub use crate::{
-        collision::*,
         components::*,
         constraints::{joints::*, *},
         plugins::*,
@@ -501,9 +499,10 @@ pub enum PhysicsSet {
 /// 1. Broad phase
 /// 2. Substeps
 ///     1. Integrate
-///     2. Solve positional and angular constraints
-///     3. Update velocities
-///     4. Solve velocity constraints (dynamic friction and restitution)
+///     2. Narrow phase
+///     3. Solve positional and angular constraints
+///     4. Update velocities
+///     5. Solve velocity constraints (dynamic friction and restitution)
 /// 3. Sleeping
 /// 4. Spatial queries
 #[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -540,9 +539,11 @@ pub enum SubstepSet {
     ///
     /// See [`IntegratorPlugin`].
     Integrate,
+    /// Responsible for computing contacts between entities and sending collision events.
+    ///
+    /// See [`NarrowPhasePlugin`].
+    NarrowPhase,
     /// The [solver] iterates through [constraints] and solves them.
-    /// This step is also responsible for narrow phase collision detection,
-    /// as it creates a [`PenetrationConstraint`] for each contact.
     ///
     /// **Note**: If you want to [create your own constraints](constraints#custom-constraints),
     /// you should add them in [`SubstepSet::SolveUserConstraints`]

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -24,6 +24,7 @@ pub mod broad_phase;
 #[cfg(feature = "debug-plugin")]
 pub mod debug;
 pub mod integrator;
+pub mod narrow_phase;
 pub mod prepare;
 pub mod setup;
 pub mod sleeping;
@@ -35,6 +36,7 @@ pub use broad_phase::BroadPhasePlugin;
 #[cfg(feature = "debug-plugin")]
 pub use debug::*;
 pub use integrator::IntegratorPlugin;
+pub use narrow_phase::*;
 pub use prepare::PreparePlugin;
 pub use setup::*;
 pub use sleeping::SleepingPlugin;
@@ -56,6 +58,7 @@ use bevy::prelude::*;
 /// - [`BroadPhasePlugin`]: Collects pairs of potentially colliding entities into [`BroadCollisionPairs`] using
 /// [AABB](ColliderAabb) intersection checks.
 /// - [`IntegratorPlugin`]: Integrates Newton's 2nd law of motion, applying forces and moving entities according to their velocities.
+/// - [`NarrowPhasePlugin`]: Computes contacts between entities and sends collision events.
 /// - [`SolverPlugin`]: Solves positional and angular [constraints], updates velocities and solves velocity constraints
 /// (dynamic [friction](Friction) and [restitution](Restitution)).
 /// - [`SleepingPlugin`]: Controls when bodies should be deactivated and marked as [`Sleeping`] to improve performance.
@@ -193,6 +196,7 @@ impl PluginGroup for PhysicsPlugins {
             .add(PreparePlugin::new(self.schedule.dyn_clone()))
             .add(BroadPhasePlugin)
             .add(IntegratorPlugin)
+            .add(NarrowPhasePlugin)
             .add(SolverPlugin)
             .add(SleepingPlugin)
             .add(SpatialQueryPlugin::new(self.schedule.dyn_clone()))

--- a/src/plugins/narrow_phase.rs
+++ b/src/plugins/narrow_phase.rs
@@ -1,8 +1,36 @@
-//! Collision events, contact data and helpers.
-
-use parry::query::{PersistentQueryDispatcher, QueryDispatcher};
+//! Computes contacts between entities and sends collision events.
+//!
+//! See [`NarrowPhasePlugin`].
 
 use crate::prelude::*;
+use bevy::prelude::*;
+use parry::query::{PersistentQueryDispatcher, QueryDispatcher};
+
+/// Computes contacts between entities and sends collision events.
+///
+/// Collisions are only checked between entities contained in [`BroadCollisionPairs`],
+/// which is handled by the [`BroadPhasePlugin`].
+///
+/// The following collision events are sent each frame:
+///
+/// - [`Collision`]
+/// - [`CollisionStarted`]
+/// - [`CollisionEnded`]
+pub struct NarrowPhasePlugin;
+
+impl Plugin for NarrowPhasePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_event::<Collision>()
+            .add_event::<CollisionStarted>()
+            .add_event::<CollisionEnded>();
+
+        let substep_schedule = app
+            .get_schedule_mut(SubstepSchedule)
+            .expect("add SubstepSchedule first");
+
+        substep_schedule.add_systems((collect_collisions).chain().in_set(SubstepSet::NarrowPhase));
+    }
+}
 
 /// A [collision event](Collider#collision-events) that is sent for each contact pair during the narrow phase.
 #[derive(Event, Clone, Debug, PartialEq)]
@@ -15,6 +43,119 @@ pub struct CollisionStarted(pub Entity, pub Entity);
 /// A [collision event](Collider#collision-events) that is sent when two entities stop colliding.
 #[derive(Event, Clone, Debug, PartialEq)]
 pub struct CollisionEnded(pub Entity, pub Entity);
+
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::type_complexity)]
+fn collect_collisions(
+    mut bodies: Query<(
+        Option<&RigidBody>,
+        &Position,
+        Option<&AccumulatedTranslation>,
+        &Rotation,
+        &Collider,
+        Option<&CollisionLayers>,
+        Option<&mut CollidingEntities>,
+        Option<&Sleeping>,
+    )>,
+    broad_collision_pairs: Res<BroadCollisionPairs>,
+    mut collision_ev_writer: EventWriter<Collision>,
+    mut collision_started_ev_writer: EventWriter<CollisionStarted>,
+    mut collision_ended_ev_writer: EventWriter<CollisionEnded>,
+) {
+    let mut collision_events = Vec::with_capacity(broad_collision_pairs.0.len());
+    let mut started_collisions = Vec::new();
+    let mut ended_collisions = Vec::new();
+
+    for (entity1, entity2) in broad_collision_pairs.0.iter() {
+        if let Ok([bundle1, bundle2]) = bodies.get_many_mut([*entity1, *entity2]) {
+            let (
+                rb1,
+                position1,
+                accumulated_translation1,
+                rotation1,
+                collider1,
+                layers1,
+                mut colliding_entities1,
+                sleeping1,
+            ) = bundle1;
+            let (
+                rb2,
+                position2,
+                accumulated_translation2,
+                rotation2,
+                collider2,
+                layers2,
+                mut colliding_entities2,
+                sleeping2,
+            ) = bundle2;
+
+            let layers1 = layers1.map_or(CollisionLayers::default(), |l| *l);
+            let layers2 = layers2.map_or(CollisionLayers::default(), |l| *l);
+
+            // Skip collision if collision layers are incompatible
+            if !layers1.interacts_with(layers2) {
+                continue;
+            }
+
+            let inactive1 = rb1.map_or(false, |rb| rb.is_static()) || sleeping1.is_some();
+            let inactive2 = rb2.map_or(false, |rb| rb.is_static()) || sleeping2.is_some();
+
+            // No collision if the bodies are static or sleeping
+            if inactive1 && inactive2 {
+                continue;
+            }
+
+            let contacts = compute_contacts(
+                *entity1,
+                *entity2,
+                position1.0 + accumulated_translation1.map_or(Vector::default(), |t| t.0),
+                position2.0 + accumulated_translation2.map_or(Vector::default(), |t| t.0),
+                rotation1,
+                rotation2,
+                collider1,
+                collider2,
+            );
+
+            if !contacts.manifolds.is_empty() {
+                let mut collision_started_1 = false;
+                let mut collision_started_2 = false;
+
+                // Add entity to set of colliding entities
+                if let Some(ref mut entities) = colliding_entities1 {
+                    collision_started_1 = entities.insert(*entity2);
+                }
+                if let Some(ref mut entities) = colliding_entities2 {
+                    collision_started_2 = entities.insert(*entity1);
+                }
+
+                if collision_started_1 || collision_started_2 {
+                    started_collisions.push(CollisionStarted(*entity1, *entity2));
+                }
+
+                collision_events.push(Collision(contacts));
+            } else {
+                let mut collision_ended_1 = false;
+                let mut collision_ended_2 = false;
+
+                // Remove entity from set of colliding entities
+                if let Some(mut entities) = colliding_entities1 {
+                    collision_ended_1 = entities.remove(entity2);
+                }
+                if let Some(mut entities) = colliding_entities2 {
+                    collision_ended_2 = entities.remove(entity1);
+                }
+
+                if collision_ended_1 || collision_ended_2 {
+                    ended_collisions.push(CollisionEnded(*entity1, *entity2));
+                }
+            }
+        }
+    }
+
+    collision_ev_writer.send_batch(collision_events);
+    collision_started_ev_writer.send_batch(started_collisions);
+    collision_ended_ev_writer.send_batch(ended_collisions);
+}
 
 /// All contacts between two colliders.
 ///
@@ -99,6 +240,10 @@ pub(crate) fn compute_contacts(
     let isometry2 = utils::make_isometry(position2, rotation2);
     let isometry12 = isometry1.inv_mul(&isometry2);
     let convex = collider1.is_convex() && collider2.is_convex();
+    #[cfg(feature = "2d")]
+    let prediction_distance = 2.0;
+    #[cfg(feature = "3d")]
+    let prediction_distance = 0.002;
 
     if convex {
         // Todo: Reuse manifolds from previous frame to improve performance
@@ -107,7 +252,7 @@ pub(crate) fn compute_contacts(
             &isometry12,
             collider1.get_shape().0.as_ref(),
             collider2.get_shape().0.as_ref(),
-            0.0,
+            prediction_distance,
             &mut manifolds,
             &mut None,
         );
@@ -123,7 +268,6 @@ pub(crate) fn compute_contacts(
                     contacts: manifold
                         .contacts()
                         .iter()
-                        .filter(|contact| -contact.dist > 0.0)
                         .map(|contact| ContactData {
                             point1: contact.local_p1.into(),
                             point2: contact.local_p2.into(),
@@ -144,7 +288,7 @@ pub(crate) fn compute_contacts(
                 &isometry12,
                 collider1.get_shape().0.as_ref(),
                 collider2.get_shape().0.as_ref(),
-                0.0,
+                prediction_distance,
             )
             .unwrap()
             .map(|contact| ContactData {

--- a/src/plugins/setup.rs
+++ b/src/plugins/setup.rs
@@ -157,6 +157,7 @@ impl Plugin for PhysicsSetupPlugin {
         substep_schedule.configure_sets(
             (
                 SubstepSet::Integrate,
+                SubstepSet::NarrowPhase,
                 SubstepSet::SolveConstraints,
                 SubstepSet::SolveUserConstraints,
                 SubstepSet::UpdateVelocities,


### PR DESCRIPTION
Currently, narrow phase collision detection is tightly coupled with the penetration constraint solver. This makes implementing more advanced collision detection features like child colliders quite cumbersome and difficult, makes things much harder to parallelize, makes it impossible to use custom collision detection implementations without rewriting the entire solver, and is overall very annoying to work with.

This PR separates the narrow phase into a `NarrowPhasePlugin` that nicely encapsulates all collision detection logic and handles collision events. The solver requires no knowledge of colliders, so you could even make your own `Collider` component and collision detection implementation if you wanted to.

To avoid problems with missed collisions when the solver moves bodies into a penetrating state and the penetration is only detected the next frame, the contact computation methods need to use a "prediction distance" larger than 0. This way, the solver doesn't miss any collisions, and the penetration constraints can determine if the bodies are really penetrating using a simple calculation. The main caveat is that the narrow phase can send collision events for bodies that aren't actually penetrating, so we might have to filter out these contacts in the solver.

## Todo

- [ ] Filter out non-penetrating collisions in the solver, and have the narrow phase only send collision events at the end of each physics frame
- [ ] Handle `CollisionStarted`, `CollisionEnded` and `CollidingEntities` correctly; they shouldn't be sent/cleared at every substep, but rather at every physics frame