### PR TITLE
Automatically add `Position` and `Rotation` for colliders

### DIFF
--- a/crates/bevy_xpbd_2d/examples/ray_caster.rs
+++ b/crates/bevy_xpbd_2d/examples/ray_caster.rs
@@ -35,16 +35,16 @@ fn setup(
 
             commands.spawn((
                 MaterialMesh2dBundle {
-                    mesh: meshes.add(shape::Circle::new(radius as f32).into()).into(),
+                    mesh: meshes.add(shape::Circle::new(radius).into()).into(),
                     material: materials.add(ColorMaterial::from(Color::rgb(0.2, 0.7, 0.9))),
+                    transform: Transform::from_xyz(
+                        x as f32 * radius * 3.0,
+                        y as f32 * radius * 3.0,
+                        0.0,
+                    ),
                     ..default()
                 },
-                RigidBody::Kinematic,
-                Position(Vector::new(
-                    x as Scalar * radius * 3.0,
-                    y as Scalar * radius * 3.0,
-                )),
-                Collider::ball(radius),
+                Collider::ball(radius as Scalar),
             ));
         }
     }

--- a/src/plugins/broad_phase.rs
+++ b/src/plugins/broad_phase.rs
@@ -98,10 +98,16 @@ fn update_aabb(
 struct AabbIntervals(Vec<(Entity, ColliderAabb, RigidBody, CollisionLayers)>);
 
 /// Updates [`AabbIntervals`] to keep them in sync with the [`ColliderAabb`]s.
-fn update_aabb_intervals(aabbs: Query<&ColliderAabb>, mut intervals: ResMut<AabbIntervals>) {
-    intervals.0.retain_mut(|(entity, aabb, _, _)| {
-        if let Ok(new_aabb) = aabbs.get(*entity) {
+fn update_aabb_intervals(
+    aabbs: Query<(&ColliderAabb, Option<&RigidBody>)>,
+    mut intervals: ResMut<AabbIntervals>,
+) {
+    intervals.0.retain_mut(|(entity, aabb, rb, _)| {
+        if let Ok((new_aabb, new_rb)) = aabbs.get(*entity) {
             *aabb = *new_aabb;
+            if let Some(new_rb) = new_rb {
+                *rb = *new_rb;
+            }
             true
         } else {
             false

--- a/src/plugins/prepare.rs
+++ b/src/plugins/prepare.rs
@@ -320,7 +320,7 @@ fn init_colliders(
 
 type MassPropertiesComponents = (
     Entity,
-    &'static RigidBody,
+    Option<&'static RigidBody>,
     MassPropertiesQuery,
     Option<&'static Collider>,
     Option<&'static mut ColliderMassProperties>,
@@ -375,19 +375,21 @@ fn update_mass_properties(mut bodies: Query<MassPropertiesComponents, MassProper
         }
 
         // Warn about dynamic bodies with no mass or inertia
-        let is_mass_valid =
-            mass_properties.mass.is_finite() && mass_properties.mass.0 >= Scalar::EPSILON;
-        #[cfg(feature = "2d")]
-        let is_inertia_valid =
-            mass_properties.inertia.is_finite() && mass_properties.inertia.0 >= Scalar::EPSILON;
-        #[cfg(feature = "3d")]
-        let is_inertia_valid =
-            mass_properties.inertia.is_finite() && *mass_properties.inertia != Inertia::ZERO;
-        if rb.is_dynamic() && !(is_mass_valid && is_inertia_valid) {
-            warn!(
-                "Dynamic rigid body {:?} has no mass or inertia. This can cause NaN values. Consider adding a `MassPropertiesBundle` or a `Collider` with mass.",
-                entity
-            );
+        if let Some(rb) = rb {
+            let is_mass_valid =
+                mass_properties.mass.is_finite() && mass_properties.mass.0 >= Scalar::EPSILON;
+            #[cfg(feature = "2d")]
+            let is_inertia_valid =
+                mass_properties.inertia.is_finite() && mass_properties.inertia.0 >= Scalar::EPSILON;
+            #[cfg(feature = "3d")]
+            let is_inertia_valid =
+                mass_properties.inertia.is_finite() && *mass_properties.inertia != Inertia::ZERO;
+            if rb.is_dynamic() && !(is_mass_valid && is_inertia_valid) {
+                warn!(
+                    "Dynamic rigid body {:?} has no mass or inertia. This can cause NaN values. Consider adding a `MassPropertiesBundle` or a `Collider` with mass.",
+                    entity
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
This PR adds the `Position` and `Rotation` components for colliders automatically. Colliders can also be moved using `Transform`, just like rigid bodies.