### PR TITLE
feature: Add DistanceJoint and 2D and 3D examples.

### DIFF
--- a/crates/bevy_xpbd_2d/examples/distance_joint_2d.rs
+++ b/crates/bevy_xpbd_2d/examples/distance_joint_2d.rs
@@ -1,0 +1,50 @@
+use bevy::prelude::*;
+use bevy_xpbd_2d::{math::*, prelude::*};
+use examples_common_2d::XpbdExamplePlugin;
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, XpbdExamplePlugin))
+        .insert_resource(ClearColor(Color::rgb(0.05, 0.05, 0.1)))
+        .insert_resource(SubstepCount(50))
+        .insert_resource(Gravity(Vector::NEG_Y * 1000.0))
+        .add_systems(Startup, setup)
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    commands.spawn(Camera2dBundle::default());
+
+    let square = SpriteBundle {
+        sprite: Sprite {
+            color: Color::rgb(0.2, 0.7, 0.9),
+            custom_size: Some(Vec2::splat(50.0)),
+            ..default()
+        },
+        ..default()
+    };
+
+    let anchor = commands
+        .spawn((square.clone(), RigidBody::Kinematic))
+        .id();
+
+    let object = commands
+        .spawn((
+            square,
+            RigidBody::Dynamic,
+            Position(-Vector::Y * 100.0),
+            MassPropertiesBundle::new_computed(&Collider::cuboid(50.0, 50.0), 1.0),
+        ))
+        .id();
+
+    commands.spawn(
+        DistanceJoint::new(anchor, object)
+            .with_local_anchor_1(-Vector::Y * 25.0)
+            .with_local_anchor_2(Vector::ONE * 25.0)
+            .with_rest_length(100.0)
+            // .with_linear_velocity_damping(0.1)
+            .with_angular_velocity_damping(1.0)
+            .with_limits(55.0, 150.0)
+            .with_compliance(1.0/50000.0),
+    );
+}

--- a/crates/bevy_xpbd_2d/examples/distance_joint_2d.rs
+++ b/crates/bevy_xpbd_2d/examples/distance_joint_2d.rs
@@ -24,9 +24,7 @@ fn setup(mut commands: Commands) {
         ..default()
     };
 
-    let anchor = commands
-        .spawn((square.clone(), RigidBody::Kinematic))
-        .id();
+    let anchor = commands.spawn((square.clone(), RigidBody::Kinematic)).id();
 
     let object = commands
         .spawn((
@@ -45,6 +43,6 @@ fn setup(mut commands: Commands) {
             // .with_linear_velocity_damping(0.1)
             .with_angular_velocity_damping(1.0)
             .with_limits(55.0, 150.0)
-            .with_compliance(1.0/50000.0),
+            .with_compliance(1.0 / 50000.0),
     );
 }

--- a/crates/bevy_xpbd_3d/examples/distance_joint_3d.rs
+++ b/crates/bevy_xpbd_3d/examples/distance_joint_3d.rs
@@ -23,9 +23,13 @@ fn setup(
     };
 
     // Spawn a static cube and a dynamic cube that is outside of the rest length.
-    let static_cube = commands.spawn((cube_mesh.clone(),
-                                      RigidBody::Static,
-                                      Collider::cuboid(1., 1., 1.))).id();
+    let static_cube = commands
+        .spawn((
+            cube_mesh.clone(),
+            RigidBody::Static,
+            Collider::cuboid(1., 1., 1.),
+        ))
+        .id();
     let dynamic_cube = commands
         .spawn((
             cube_mesh,
@@ -46,7 +50,7 @@ fn setup(
             .with_limits(0.75, 2.5)
             // .with_linear_velocity_damping(0.1)
             // .with_angular_velocity_damping(1.0)
-            .with_compliance(1.0 / 100.0)
+            .with_compliance(1.0 / 100.0),
     );
 
     // Light

--- a/crates/bevy_xpbd_3d/examples/distance_joint_3d.rs
+++ b/crates/bevy_xpbd_3d/examples/distance_joint_3d.rs
@@ -1,0 +1,68 @@
+use bevy::prelude::*;
+use bevy_xpbd_3d::{math::*, prelude::*, SubstepSchedule, SubstepSet};
+
+fn main() {
+    let mut app = App::new();
+
+    // Add plugins and startup system
+    app.add_plugins((DefaultPlugins, PhysicsPlugins::default()))
+        .add_systems(Startup, setup);
+    // Run the app
+    app.run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    let cube_mesh = PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        ..default()
+    };
+
+    // Spawn a static cube and a dynamic cube that is outside of the rest length.
+    let static_cube = commands.spawn((cube_mesh.clone(),
+                                      RigidBody::Static,
+                                      Collider::cuboid(1., 1., 1.))).id();
+    let dynamic_cube = commands
+        .spawn((
+            cube_mesh,
+            RigidBody::Dynamic,
+            Position(Vector::new(0.0, -2.5, 0.0)),
+            Collider::cuboid(1., 1., 1.),
+            MassPropertiesBundle::new_computed(&Collider::cuboid(1.0, 1.0, 1.0), 1.0),
+        ))
+        .id();
+
+    // Add a distance joint to keep the cubes at a certain distance from each other.
+    // The dynamic cube should bounce like it's on a spring.
+    commands.spawn(
+        DistanceJoint::new(static_cube, dynamic_cube)
+            .with_local_anchor_1(0.5 * Vector::NEG_Y)
+            .with_local_anchor_2(0.5 * Vector::new(1.0, 1.0, 1.0))
+            .with_rest_length(1.5)
+            .with_limits(0.75, 2.5)
+            // .with_linear_velocity_damping(0.1)
+            // .with_angular_velocity_damping(1.0)
+            .with_compliance(1.0 / 100.0)
+    );
+
+    // Light
+    commands.spawn(PointLightBundle {
+        point_light: PointLight {
+            intensity: 1500.0,
+            shadows_enabled: true,
+            ..default()
+        },
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..default()
+    });
+
+    // Camera
+    commands.spawn(Camera3dBundle {
+        transform: Transform::from_xyz(0.0, 0.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..default()
+    });
+}

--- a/src/constraints/joints/distance.rs
+++ b/src/constraints/joints/distance.rs
@@ -1,0 +1,194 @@
+//! [`DistanceJoint`] component.
+
+use crate::prelude::*;
+use bevy::prelude::*;
+
+/// A distance joint prevents relative translation of the attached bodies away from its rest length while allowing rotation around all axes.
+///
+/// Distance joints can be useful for things like springs, muscles, and mass-spring networks.
+#[derive(Component, Clone, Copy, Debug, PartialEq)]
+pub struct DistanceJoint {
+    /// First entity constrained by the joint.
+    pub entity1: Entity,
+    /// Second entity constrained by the joint.
+    pub entity2: Entity,
+    /// Attachment point on the first body.
+    pub local_anchor1: Vector,
+    /// Attachment point on the second body.
+    pub local_anchor2: Vector,
+    /// The distance the attached bodies will be kept relative to each other.
+    pub rest_length: Scalar,
+    /// The extents of the allowed relative translation between the attached bodies.
+    pub length_limits: Option<DistanceLimit>,
+    /// Linear damping applied by the joint.
+    pub damping_linear: Scalar,
+    /// Angular damping applied by the joint.
+    pub damping_angular: Scalar,
+    /// Lagrange multiplier for the positional correction.
+    pub lagrange: Scalar,
+    /// The joint's compliance, the inverse of stiffness, has the unit meters / Newton.
+    pub compliance: Scalar,
+    /// The force exerted by the joint.
+    pub force: Vector,
+}
+
+impl XpbdConstraint<2> for DistanceJoint {
+    fn entities(&self) -> [Entity; 2] {
+        [self.entity1, self.entity2]
+    }
+
+    fn clear_lagrange_multipliers(&mut self) {
+        self.lagrange = 0.0;
+    }
+
+    fn solve(&mut self, bodies: [&mut RigidBodyQueryItem; 2], dt: Scalar) {
+        self.force = self.constrain_length(bodies, dt);
+    }
+}
+
+impl Joint for DistanceJoint {
+    fn new(entity1: Entity, entity2: Entity) -> Self {
+        Self {
+            entity1,
+            entity2,
+            local_anchor1: Vector::ZERO,
+            local_anchor2: Vector::ZERO,
+            rest_length: 0.0,
+            length_limits: None,
+            damping_linear: 0.0,
+            damping_angular: 0.0,
+            lagrange: 0.0,
+            compliance: 0.0,
+            force: Vector::ZERO,
+        }
+    }
+
+    fn with_compliance(self, compliance: Scalar) -> Self {
+        Self { compliance, ..self }
+    }
+
+    fn with_local_anchor_1(self, anchor: Vector) -> Self {
+        Self {
+            local_anchor1: anchor,
+            ..self
+        }
+    }
+
+    fn with_local_anchor_2(self, anchor: Vector) -> Self {
+        Self {
+            local_anchor2: anchor,
+            ..self
+        }
+    }
+
+    fn with_linear_velocity_damping(self, damping: Scalar) -> Self {
+        Self {
+            damping_linear: damping,
+            ..self
+        }
+    }
+
+    fn with_angular_velocity_damping(self, damping: Scalar) -> Self {
+        Self {
+            damping_angular: damping,
+            ..self
+        }
+    }
+
+    fn local_anchor_1(&self) -> Vector {
+        self.local_anchor1
+    }
+
+    fn local_anchor_2(&self) -> Vector {
+        self.local_anchor2
+    }
+
+    fn damping_linear(&self) -> Scalar {
+        self.damping_linear
+    }
+
+    fn damping_angular(&self) -> Scalar {
+        self.damping_angular
+    }
+}
+
+impl DistanceJoint {
+
+    /// Constrains the distance the bodies with no constraint on their rotation.
+    ///
+    /// Returns the force exerted by this constraint.
+    fn constrain_length(&mut self, bodies: [&mut RigidBodyQueryItem; 2], dt: Scalar) -> Vector {
+        let [body1, body2] = bodies;
+        let world_r1 = body1.rotation.rotate(self.local_anchor1);
+        let world_r2 = body2.rotation.rotate(self.local_anchor2);
+
+        // // Compute the positional difference
+        let mut delta_x
+            = (body1.position.0 + body1.accumulated_translation.0 + world_r1)
+            - (body2.position.0 + body2.accumulated_translation.0 + world_r2);
+
+        // The current separation distance
+        let mut length = delta_x.length();
+
+        if let Some(limits) = self.length_limits {
+            if length < Scalar::EPSILON {
+                return Vector::ZERO;
+            }
+            delta_x += limits.compute_correction(
+                body1.position.0 + body1.accumulated_translation.0 + world_r1,
+                body2.position.0 + body2.accumulated_translation.0 + world_r2);
+            length = delta_x.length();
+        }
+
+        // The value of the constraint function. When this is zero, the
+        // constraint is satisfied, and the distance between the bodies is the
+        // rest length.
+        let c = length - self.rest_length;
+
+        // Avoid division by zero and unnecessary computation.
+        if length < Scalar::EPSILON || c.abs() < Scalar::EPSILON {
+            return Vector::ZERO;
+        }
+
+        // Normalized delta_x
+        let n = delta_x / length;
+
+        // Compute generalized inverse masses (method from PositionConstraint)
+        let w1 = <Self as PositionConstraint>::compute_generalized_inverse_mass(self, body1, world_r1, n);
+        let w2 = <Self as PositionConstraint>::compute_generalized_inverse_mass(self, body2, world_r2, n);
+        let w = [w1, w2];
+
+        // Constraint gradients, i.e. how the bodies should be moved
+        // relative to each other in order to satisfy the constraint
+        let gradients = [n, -n];
+
+        // Compute Lagrange multiplier update, essentially the signed magnitude of the correction
+        let delta_lagrange =
+            self.compute_lagrange_update(self.lagrange, c, &gradients, &w, self.compliance, dt);
+        self.lagrange += delta_lagrange;
+
+        // Apply positional correction (method from PositionConstraint)
+        self.apply_positional_correction(body1, body2, delta_lagrange, n, world_r1, world_r2);
+
+        // Return constraint force
+        self.compute_force(self.lagrange, n, dt)
+    }
+
+    /// Sets the translational limits along the joint's free axis.
+    pub fn with_limits(self, min: Scalar, max: Scalar) -> Self {
+        Self {
+            length_limits: Some(DistanceLimit::new(min, max)),
+            ..self
+        }
+    }
+
+    /// Sets the joint's rest length, or distance the bodies will be kept at.
+    pub fn with_rest_length(self, rest_length: Scalar) -> Self {
+        Self { rest_length, ..self }
+    }
+
+}
+
+impl PositionConstraint for DistanceJoint {}
+
+impl AngularConstraint for DistanceJoint {}

--- a/src/constraints/joints/distance.rs
+++ b/src/constraints/joints/distance.rs
@@ -113,7 +113,6 @@ impl Joint for DistanceJoint {
 }
 
 impl DistanceJoint {
-
     /// Constrains the distance the bodies with no constraint on their rotation.
     ///
     /// Returns the force exerted by this constraint.
@@ -123,8 +122,7 @@ impl DistanceJoint {
         let world_r2 = body2.rotation.rotate(self.local_anchor2);
 
         // // Compute the positional difference
-        let mut delta_x
-            = (body1.position.0 + body1.accumulated_translation.0 + world_r1)
+        let mut delta_x = (body1.position.0 + body1.accumulated_translation.0 + world_r1)
             - (body2.position.0 + body2.accumulated_translation.0 + world_r2);
 
         // The current separation distance
@@ -136,7 +134,8 @@ impl DistanceJoint {
             }
             delta_x += limits.compute_correction(
                 body1.position.0 + body1.accumulated_translation.0 + world_r1,
-                body2.position.0 + body2.accumulated_translation.0 + world_r2);
+                body2.position.0 + body2.accumulated_translation.0 + world_r2,
+            );
             length = delta_x.length();
         }
 
@@ -154,8 +153,12 @@ impl DistanceJoint {
         let n = delta_x / length;
 
         // Compute generalized inverse masses (method from PositionConstraint)
-        let w1 = <Self as PositionConstraint>::compute_generalized_inverse_mass(self, body1, world_r1, n);
-        let w2 = <Self as PositionConstraint>::compute_generalized_inverse_mass(self, body2, world_r2, n);
+        let w1 = <Self as PositionConstraint>::compute_generalized_inverse_mass(
+            self, body1, world_r1, n,
+        );
+        let w2 = <Self as PositionConstraint>::compute_generalized_inverse_mass(
+            self, body2, world_r2, n,
+        );
         let w = [w1, w2];
 
         // Constraint gradients, i.e. how the bodies should be moved
@@ -184,9 +187,11 @@ impl DistanceJoint {
 
     /// Sets the joint's rest length, or distance the bodies will be kept at.
     pub fn with_rest_length(self, rest_length: Scalar) -> Self {
-        Self { rest_length, ..self }
+        Self {
+            rest_length,
+            ..self
+        }
     }
-
 }
 
 impl PositionConstraint for DistanceJoint {}

--- a/src/constraints/joints/distance.rs
+++ b/src/constraints/joints/distance.rs
@@ -3,7 +3,7 @@
 use crate::prelude::*;
 use bevy::prelude::*;
 
-/// A distance joint prevents relative translation of the attached bodies away from its rest length while allowing rotation around all axes.
+/// A distance joint keeps the attached bodies at a certain distance from each other while while allowing rotation around all axes.
 ///
 /// Distance joints can be useful for things like springs, muscles, and mass-spring networks.
 #[derive(Component, Clone, Copy, Debug, PartialEq)]

--- a/src/constraints/joints/distance.rs
+++ b/src/constraints/joints/distance.rs
@@ -174,7 +174,7 @@ impl DistanceJoint {
         self.compute_force(self.lagrange, n, dt)
     }
 
-    /// Sets the translational limits along the joint's free axis.
+    /// Sets the minimum and maximum distances between the attached bodies.
     pub fn with_limits(self, min: Scalar, max: Scalar) -> Self {
         Self {
             length_limits: Some(DistanceLimit::new(min, max)),

--- a/src/constraints/joints/mod.rs
+++ b/src/constraints/joints/mod.rs
@@ -13,12 +13,13 @@
 //!
 //! Below is a table containing the joints that are currently implemented.
 //!
-//! | Joint              | Allowed 2D DOF | Allowed 3D DOF |
-//! | ------------------ | -------------- | -------------- |
-//! | [`FixedJoint`]     | None           | None           |
-//! | [`PrismaticJoint`] | 1 Translation  | 1 Translation  |
-//! | [`RevoluteJoint`]  | 1 Rotation     | 1 Rotation     |
-//! | [`SphericalJoint`] | 1 Rotation     | 3 Rotations    |
+//! | Joint              | Allowed 2D DOF            | Allowed 3D DOF              |
+//! | ------------------ | ------------------------- | --------------------------- |
+//! | [`FixedJoint`]     | None                      | None                        |
+//! | [`DistanceJoint`]  | 1 Translation, 1 Rotation | 2 Translations, 3 Rotations |
+//! | [`PrismaticJoint`] | 1 Translation             | 1 Translation               |
+//! | [`RevoluteJoint`]  | 1 Rotation                | 1 Rotation                  |
+//! | [`SphericalJoint`] | 1 Rotation                | 3 Rotations                 |
 //!
 //! ## Using joints
 //!
@@ -86,11 +87,13 @@ mod fixed;
 mod prismatic;
 mod revolute;
 mod spherical;
+mod distance;
 
 pub use fixed::*;
 pub use prismatic::*;
 pub use revolute::*;
 pub use spherical::*;
+pub use distance::*;
 
 use crate::prelude::*;
 use bevy::prelude::*;
@@ -278,7 +281,7 @@ impl DistanceLimit {
         // Equation 25
         if a < self.min {
             // Separation distance lower limit
-            -axis * (a - self.min)
+            axis * (self.min - a)
         } else if a > self.max {
             // Separation distance upper limit
             -axis * (a - self.max)

--- a/src/constraints/joints/mod.rs
+++ b/src/constraints/joints/mod.rs
@@ -83,17 +83,17 @@
 //! [See the code implementations](https://github.com/Jondolf/bevy_xpbd/tree/main/src/constraints/joints)
 //! of the implemented joints to get a better idea of how to create joints.
 
+mod distance;
 mod fixed;
 mod prismatic;
 mod revolute;
 mod spherical;
-mod distance;
 
+pub use distance::*;
 pub use fixed::*;
 pub use prismatic::*;
 pub use revolute::*;
 pub use spherical::*;
-pub use distance::*;
 
 use crate::prelude::*;
 use bevy::prelude::*;

--- a/src/constraints/mod.rs
+++ b/src/constraints/mod.rs
@@ -17,6 +17,7 @@
 //! - [`PenetrationConstraint`](PenetrationConstraint)
 //! - [Joints](joints)
 //!     - [`FixedJoint`]
+//!     - [`DistanceJoint`]
 //!     - [`SphericalJoint`]
 //!     - [`RevoluteJoint`]
 //!     - [`PrismaticJoint`]

--- a/src/plugins/debug/mod.rs
+++ b/src/plugins/debug/mod.rs
@@ -68,6 +68,7 @@ impl Plugin for PhysicsDebugPlugin {
                     // Todo: Refactor joints to allow iterating over all of them without generics
                     debug_render_joints::<FixedJoint>,
                     debug_render_joints::<PrismaticJoint>,
+                    debug_render_joints::<DistanceJoint>,
                     debug_render_joints::<RevoluteJoint>,
                     debug_render_joints::<SphericalJoint>,
                     change_mesh_visibility,

--- a/src/plugins/solver.rs
+++ b/src/plugins/solver.rs
@@ -46,6 +46,7 @@ impl Plugin for SolverPlugin {
                 solve_constraint::<RevoluteJoint, 2>,
                 solve_constraint::<SphericalJoint, 2>,
                 solve_constraint::<PrismaticJoint, 2>,
+                solve_constraint::<DistanceJoint, 2>,
             )
                 .chain()
                 .in_set(SubstepSet::SolveConstraints),
@@ -60,6 +61,7 @@ impl Plugin for SolverPlugin {
                 joint_damping::<RevoluteJoint>,
                 joint_damping::<SphericalJoint>,
                 joint_damping::<PrismaticJoint>,
+                joint_damping::<DistanceJoint>,
             )
                 .chain()
                 .in_set(SubstepSet::SolveVelocities),


### PR DESCRIPTION
Hi,

This is a really cool project you've put together. I was using Rapier before this, and I really wanted a spring joint which isn't supported there. I hoped to find it here, but better than finding it I found that the XPBD means of expressing constraints and joints is so much easier to work with that I put one together myself that I hope you'll find useful. 

Taking note from other XPBD implementations, I called this a DistanceJoint. When it's compliance does not equal 0 though it very much behaves like a spring joint.

I added examples in 2D and 3D. Here are some gifs on them.

![distance_joint_2d](https://github.com/Jondolf/bevy_xpbd/assets/54390/1f43ddb6-8e79-4a66-a8f4-525efe825a0f)

![distance_joint_3d](https://github.com/Jondolf/bevy_xpbd/assets/54390/1c9d9a72-5e20-4288-b55c-8af99505f866)

One problem I didn't tackle was if you look at the heading describing a SphericalJoint and a DistanceJoint, they're not terribly distinct. However, upon inspection SphericalJoint is doing more than DistanceJoint. I wonder if there's a clearer way to discriminate between them in their one line descriptions.

Thanks for the code, and thanks for turning me onto the the XPBD methodology. Happy hacking!