### PR TITLE
Debug render rigid body axes at center of mass

### DIFF
--- a/crates/bevy_xpbd_3d/examples/distance_joint_3d.rs
+++ b/crates/bevy_xpbd_3d/examples/distance_joint_3d.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy_xpbd_3d::{math::*, prelude::*, SubstepSchedule, SubstepSet};
+use bevy_xpbd_3d::{math::*, prelude::*};
 
 fn main() {
     let mut app = App::new();

--- a/src/plugins/debug/configuration.rs
+++ b/src/plugins/debug/configuration.rs
@@ -9,7 +9,7 @@ use bevy::prelude::*;
 pub struct PhysicsDebugConfig {
     /// Determines if debug rendering is enabled.
     pub enabled: bool,
-    /// The lengths of the axes drawn for an entity.
+    /// The lengths of the axes drawn for an entity at the center of mass.
     pub axis_lengths: Option<Vector>,
     /// The color of the [AABBs](ColliderAabb). If `None`, the AABBs will not be rendered.
     pub aabb_color: Option<Color>,
@@ -79,7 +79,7 @@ impl PhysicsDebugConfig {
     }
 
     /// Creates a [`PhysicsDebugConfig`] configuration with the given lengths for the axes
-    /// that are drawn for the entity. Other debug rendering options will be disabled.
+    /// that are drawn for the entity at the center of mass. Other debug rendering options will be disabled.
     pub fn axes(axis_lengths: Vector) -> Self {
         Self {
             axis_lengths: Some(axis_lengths),
@@ -192,7 +192,7 @@ impl PhysicsDebugConfig {
 #[derive(Component, Reflect, Clone, Copy, PartialEq)]
 #[reflect(Component)]
 pub struct DebugRender {
-    /// The lengths of the axes drawn for the entity.
+    /// The lengths of the axes drawn for the entity at the center of mass.
     pub axis_lengths: Option<Vector>,
     /// The color of the [AABB](ColliderAabb). If `None`, the AABB will not be rendered.
     pub aabb_color: Option<Color>,
@@ -241,7 +241,7 @@ impl DebugRender {
     }
 
     /// Creates a [`DebugRender`] configuration with the given lengths for the axes
-    /// that are drawn for the entity. Other debug rendering options will be disabled.
+    /// that are drawn for the entity at the center of mass. Other debug rendering options will be disabled.
     pub fn axes(axis_lengths: Vector) -> Self {
         Self {
             axis_lengths: Some(axis_lengths),
@@ -267,7 +267,7 @@ impl DebugRender {
         }
     }
 
-    /// Sets the lengths of the axes drawn for the entity.
+    /// Sets the lengths of the axes drawn for the entity at the center of mass.
     pub fn with_axes(mut self, axis_lengths: Vector) -> Self {
         self.axis_lengths = Some(axis_lengths);
         self

--- a/src/plugins/debug/mod.rs
+++ b/src/plugins/debug/mod.rs
@@ -80,33 +80,38 @@ impl Plugin for PhysicsDebugPlugin {
 }
 
 fn debug_render_axes(
-    bodies: Query<(&Position, &Rotation, Option<&DebugRender>)>,
+    bodies: Query<(&Position, &Rotation, &CenterOfMass, Option<&DebugRender>)>,
     mut debug_renderer: PhysicsDebugRenderer,
     config: Res<PhysicsDebugConfig>,
 ) {
-    for (pos, rot, render_config) in &bodies {
+    for (pos, rot, local_com, render_config) in &bodies {
         if let Some(lengths) = render_config.map_or(config.axis_lengths, |c| c.axis_lengths) {
+            let global_com = pos.0 + rot.rotate(local_com.0);
             let x = rot.rotate(Vector::X * lengths.x);
-            debug_renderer.draw_line(pos.0 - x, pos.0 + x, Color::hsl(0.0, 1.0, 0.5));
+            debug_renderer.draw_line(global_com - x, global_com + x, Color::hsl(0.0, 1.0, 0.5));
 
             let y = rot.rotate(Vector::Y * lengths.y);
-            debug_renderer.draw_line(pos.0 - y, pos.0 + y, Color::hsl(120.0, 1.0, 0.4));
+            debug_renderer.draw_line(global_com - y, global_com + y, Color::hsl(120.0, 1.0, 0.4));
 
             #[cfg(feature = "3d")]
             {
                 let z = rot.rotate(Vector::Z * lengths.z);
-                debug_renderer.draw_line(pos.0 - z, pos.0 + z, Color::hsl(220.0, 1.0, 0.6));
+                debug_renderer.draw_line(
+                    global_com - z,
+                    global_com + z,
+                    Color::hsl(220.0, 1.0, 0.6),
+                );
             }
 
-            // Draw dot at the center of the body
+            // Draw dot at the center of mass
             #[cfg(feature = "2d")]
             debug_renderer
                 .gizmos
-                .circle_2d(pos.as_f32(), 0.5, Color::YELLOW);
+                .circle_2d(global_com.as_f32(), 0.5, Color::YELLOW);
             #[cfg(feature = "3d")]
             debug_renderer
                 .gizmos
-                .sphere(pos.as_f32(), rot.as_f32(), 0.025, Color::YELLOW);
+                .sphere(global_com.as_f32(), rot.as_f32(), 0.025, Color::YELLOW);
         }
     }
 }


### PR DESCRIPTION
Changes rigid body axes to be debug rendered at the center of mass instead of the rigid body position.