### PR TITLE
Clamp coefficient of restitution between 0 and 1 and improve restitution docs

### DIFF
--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -252,11 +252,14 @@ pub enum CoefficientCombine {
     Max = 4,
 }
 
-/// Controls how bouncy an entity is when colliding with other entities.
+/// A component for the [coefficient of restitution](https://en.wikipedia.org/wiki/Coefficient_of_restitution).
+/// This controls how bouncy a body is.
 ///
-/// 0.0: Perfectly inelastic\
-/// 1.0: Perfectly elastic\
-/// 2.0: Kinetic energy is doubled
+/// The coefficient is between 0 and 1, where 0 corresponds to a **perfectly inelastic collision**, and 1 corresponds
+/// to a **perfectly elastic collision** that preserves all kinetic energy. The default coefficient is 0.3, and it currently
+/// can not be configured at a global level.
+///
+/// When two bodies collide, their restitution coefficients are combined using the specified [`CoefficientCombine`] rule.
 ///
 /// ## Example
 ///
@@ -294,7 +297,10 @@ pub enum CoefficientCombine {
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, PartialOrd)]
 #[reflect(Component)]
 pub struct Restitution {
-    /// Coefficient of restitution.
+    /// The [coefficient of restitution](https://en.wikipedia.org/wiki/Coefficient_of_restitution).
+    ///
+    /// This should be between 0 and 1, where 0 corresponds to a **perfectly inelastic collision**, and 1 corresponds
+    /// to a **perfectly elastic collision** that preserves all kinetic energy. The default value is 0.3.
     pub coefficient: Scalar,
     /// The coefficient combine rule used when two bodies interact.
     pub combine_rule: CoefficientCombine,
@@ -304,22 +310,31 @@ impl Restitution {
     /// A restitution coefficient of 0.0 and a combine rule of [`CoefficientCombine::Average`].
     ///
     /// This is equivalent to [`Restitution::PERFECTLY_INELASTIC`](#associatedconstant.PERFECTLY_INELASTIC).
-    pub const ZERO: Self = Self::new(0.0);
+    pub const ZERO: Self = Self {
+        coefficient: 0.0,
+        combine_rule: CoefficientCombine::Average,
+    };
 
     /// A restitution coefficient of 0.0, which corresponds to a perfectly inelastic collision.
     ///
     /// Uses [`CoefficientCombine::Average`].
-    pub const PERFECTLY_INELASTIC: Self = Self::new(0.0);
+    pub const PERFECTLY_INELASTIC: Self = Self {
+        coefficient: 0.0,
+        combine_rule: CoefficientCombine::Average,
+    };
 
     /// A restitution coefficient of 1.0, which corresponds to a perfectly elastic collision.
     ///
     /// Uses [`CoefficientCombine::Average`].
-    pub const PERFECTLY_ELASTIC: Self = Self::new(1.0);
+    pub const PERFECTLY_ELASTIC: Self = Self {
+        coefficient: 1.0,
+        combine_rule: CoefficientCombine::Average,
+    };
 
     /// Creates a new [`Restitution`] component with the given restitution coefficient.
-    pub const fn new(coefficient: Scalar) -> Self {
+    pub fn new(coefficient: Scalar) -> Self {
         Self {
-            coefficient,
+            coefficient: coefficient.clamp(0.0, 1.0),
             combine_rule: CoefficientCombine::Average,
         }
     }
@@ -536,6 +551,13 @@ pub struct AngularDamping(pub Scalar);
 mod tests {
     use crate::prelude::*;
     use approx::assert_relative_eq;
+
+    #[test]
+    fn restitution_clamping_works() {
+        assert_eq!(Restitution::new(-2.0).coefficient, 0.0);
+        assert_eq!(Restitution::new(0.6).coefficient, 0.6);
+        assert_eq!(Restitution::new(3.0).coefficient, 1.0);
+    }
 
     #[test]
     fn coefficient_combine_works() {

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -301,17 +301,26 @@ pub struct Restitution {
 }
 
 impl Restitution {
-    /// Zero restitution and [`CoefficientCombine::Average`].
-    pub const ZERO: Self = Self {
-        coefficient: 0.0,
-        combine_rule: CoefficientCombine::Average,
-    };
+    /// A restitution coefficient of 0.0 and a combine rule of [`CoefficientCombine::Average`].
+    ///
+    /// This is equivalent to [`Restitution::PERFECTLY_INELASTIC`](#associatedconstant.PERFECTLY_INELASTIC).
+    pub const ZERO: Self = Self::new(0.0);
+
+    /// A restitution coefficient of 0.0, which corresponds to a perfectly inelastic collision.
+    ///
+    /// Uses [`CoefficientCombine::Average`].
+    pub const PERFECTLY_INELASTIC: Self = Self::new(0.0);
+
+    /// A restitution coefficient of 1.0, which corresponds to a perfectly elastic collision.
+    ///
+    /// Uses [`CoefficientCombine::Average`].
+    pub const PERFECTLY_ELASTIC: Self = Self::new(1.0);
 
     /// Creates a new [`Restitution`] component with the given restitution coefficient.
-    pub fn new(coefficient: Scalar) -> Self {
+    pub const fn new(coefficient: Scalar) -> Self {
         Self {
             coefficient,
-            ..default()
+            combine_rule: CoefficientCombine::Average,
         }
     }
 

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -302,7 +302,7 @@ pub struct Restitution {
     /// This should be between 0 and 1, where 0 corresponds to a **perfectly inelastic collision**, and 1 corresponds
     /// to a **perfectly elastic collision** that preserves all kinetic energy. The default value is 0.3.
     pub coefficient: Scalar,
-    /// The coefficient combine rule used when two bodies interact.
+    /// The coefficient combine rule used when two bodies collide.
     pub combine_rule: CoefficientCombine,
 }
 
@@ -437,7 +437,7 @@ pub struct Friction {
     pub dynamic_coefficient: Scalar,
     /// Coefficient of static friction.
     pub static_coefficient: Scalar,
-    /// The coefficient combine rule used when two bodies interact.
+    /// The coefficient combine rule used when two bodies collide.
     pub combine_rule: CoefficientCombine,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,7 +167,7 @@
 //! - [Add a collider](Collider)
 //! - [Listen to collision events](Collider#collision-events)
 //! - [Define collision layers](CollisionLayers#creation)
-//! - [Configure restitution](Restitution)
+//! - [Configure restitution (bounciness)](Restitution)
 //! - [Configure friction](Friction)
 //! - [Configure gravity](Gravity)
 //! - [Apply external forces](ExternalForce)

--- a/src/plugins/prepare.rs
+++ b/src/plugins/prepare.rs
@@ -11,7 +11,9 @@ use bevy::prelude::*;
 ///
 /// - Adds missing rigid body components for entities with a [`RigidBody`] component
 /// - Adds missing collider components for entities with a [`Collider`] component
+/// - Adds missing mass properties for entities with a [`RigidBody`] or [`Collider`] component
 /// - Updates mass properties and adds [`ColliderMassProperties`] on top of the existing mass properties
+/// - Clamps restitution coefficients between 0 and 1
 ///
 /// The systems run in [`PhysicsSet::Prepare`].
 pub struct PreparePlugin {
@@ -50,6 +52,7 @@ impl Plugin for PreparePlugin {
                 init_mass_properties,
                 init_colliders,
                 update_mass_properties,
+                clamp_restitution,
             )
                 .chain()
                 .in_set(PhysicsSet::Prepare),
@@ -391,5 +394,11 @@ fn update_mass_properties(mut bodies: Query<MassPropertiesComponents, MassProper
                 );
             }
         }
+    }
+}
+
+fn clamp_restitution(mut query: Query<&mut Restitution, Changed<Restitution>>) {
+    for mut restitution in &mut query {
+        restitution.coefficient = restitution.coefficient.clamp(0.0, 1.0);
     }
 }


### PR DESCRIPTION
Clamps each `Restitution` coefficient to be between 0 and 1, adds the associated constants `Restitution::PERFECTLY_INELASTIC` and `Restitution::PERFECTLY_ELASTIC`, and significantly improves the restitution docs. This closes #114 and #115.

The clamping avoids issues with unrealistic and explosive behavior when users try to use values that are negative or over 1, which makes things more user-friendly and realistic. For the rare cases where you want bodies to gain kinetic energy on contact, you should implement it manually to work for your specific case in a stable manner.

The main caveat is that you can no longer multiply e.g. 0.5 and 2.0 to get 1.0 when combining coefficients, since 2.0 gets clamped to 1.0, which results in a final coefficient of 0.5. However, I find this clamping to be more explicit since it's clamping the actual component values and not internally clamping just the combined coefficient, and engines like Unity seem to be doing it like this as well. It also allows us to perform the clamping at initialization and not individually for each contact.