### PR TITLE
Fix center of mass and inertia computations and add tests

### DIFF
--- a/src/components/mass_properties.rs
+++ b/src/components/mass_properties.rs
@@ -94,15 +94,14 @@ impl Inertia {
     /// Computes the inertia of a body with the given mass, shifted by the given offset.
     #[cfg(feature = "3d")]
     pub fn shifted(&self, mass: Scalar, offset: Vector) -> Matrix3 {
+        type NaMatrix3 = parry::na::Matrix3<math::Scalar>;
         use parry::na::*;
-        #[cfg(feature = "f64")]
-        type Matrix3 = parry::na::DMatrix<Scalar, Const<3>, Const<3>, ArrayStorage<Scalar, 3, 3>>;
 
         if mass > 0.0 && mass.is_finite() {
-            let matrix = Matrix3::from(self.0);
+            let matrix = NaMatrix3::from(self.0);
             let offset = Vector::from(offset);
             let diagonal_el = offset.norm_squared();
-            let diagonal_mat = Matrix3::from_diagonal_element(diagonal_el);
+            let diagonal_mat = NaMatrix3::from_diagonal_element(diagonal_el);
             math::Matrix3::from(matrix + (diagonal_mat + offset * offset.transpose()) * mass)
         } else {
             self.0

--- a/src/components/mass_properties.rs
+++ b/src/components/mass_properties.rs
@@ -81,7 +81,7 @@ impl Inertia {
         InverseInertia(self.0.inverse())
     }
 
-    /// Shifts the inertia a body with a given mass by the given offset.
+    /// Computes the inertia of a body with the given mass, shifted by the given offset.
     #[cfg(feature = "2d")]
     pub fn shifted(&self, mass: Scalar, offset: Vector) -> Scalar {
         if mass > 0.0 && mass.is_finite() {
@@ -91,7 +91,7 @@ impl Inertia {
         }
     }
 
-    /// Shifts the inertia tensor pf a body with a given mass by the given offset.
+    /// Computes the inertia of a body with the given mass, shifted by the given offset.
     #[cfg(feature = "3d")]
     pub fn shifted(&self, mass: Scalar, offset: Vector) -> Matrix3 {
         use parry::na::*;

--- a/src/components/mass_properties.rs
+++ b/src/components/mass_properties.rs
@@ -80,6 +80,34 @@ impl Inertia {
     pub fn inverse(&self) -> InverseInertia {
         InverseInertia(self.0.inverse())
     }
+
+    /// Shifts the inertia a body with a given mass by the given offset.
+    #[cfg(feature = "2d")]
+    pub fn shifted(&self, mass: Scalar, offset: Vector) -> Scalar {
+        if mass > 0.0 && mass.is_finite() {
+            self.0 + offset.length_squared() * mass
+        } else {
+            self.0
+        }
+    }
+
+    /// Shifts the inertia tensor pf a body with a given mass by the given offset.
+    #[cfg(feature = "3d")]
+    pub fn shifted(&self, mass: Scalar, offset: Vector) -> Matrix3 {
+        use parry::na::*;
+        #[cfg(feature = "f64")]
+        type Matrix3 = parry::na::DMatrix<Scalar, Const<3>, Const<3>, ArrayStorage<Scalar, 3, 3>>;
+
+        if mass > 0.0 && mass.is_finite() {
+            let matrix = Matrix3::from(self.0);
+            let offset = Vector::from(offset);
+            let diagonal_el = offset.norm_squared();
+            let diagonal_mat = parry::na::Matrix3::from_diagonal_element(diagonal_el);
+            math::Matrix3::from(matrix + (diagonal_mat + offset * offset.transpose()) * mass)
+        } else {
+            self.0
+        }
+    }
 }
 
 /// The inverse moment of inertia of the body. This represents the inverse of the torque needed for a desired angular acceleration.

--- a/src/components/mass_properties.rs
+++ b/src/components/mass_properties.rs
@@ -102,7 +102,7 @@ impl Inertia {
             let matrix = Matrix3::from(self.0);
             let offset = Vector::from(offset);
             let diagonal_el = offset.norm_squared();
-            let diagonal_mat = parry::na::Matrix3::from_diagonal_element(diagonal_el);
+            let diagonal_mat = Matrix3::from_diagonal_element(diagonal_el);
             math::Matrix3::from(matrix + (diagonal_mat + offset * offset.transpose()) * mass)
         } else {
             self.0

--- a/src/components/world_queries.rs
+++ b/src/components/world_queries.rs
@@ -231,28 +231,21 @@ mod tests {
         );
     }
 
-    // Todo: Test if inertia values are correct
     #[test]
-    fn mass_properties_add_sub_equals_original() {
+    fn mass_properties_add_sub_works() {
         // Create app
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
 
-        // Spawn an entity with mass properties
-        app.world.spawn(MassPropertiesBundle {
-            mass: Mass(1.6),
-            inverse_mass: InverseMass(1.0 / 1.6),
-            center_of_mass: CenterOfMass(Vector::X * 1.2 + Vector::Y),
-            ..default()
-        });
+        let original_mass_props =
+            MassPropertiesBundle::new_computed(&Collider::capsule(2.4, 0.6), 3.9);
 
-        // Create collider mass properties that will be subtracted from the existing mass properties
-        let collider_mass_props = ColliderMassProperties {
-            mass: Mass(1.6),
-            inverse_mass: InverseMass(1.0 / 1.6),
-            center_of_mass: CenterOfMass(Vector::X * 1.2 + Vector::Y),
-            ..default()
-        };
+        // Spawn an entity with mass properties
+        app.world.spawn(original_mass_props.clone());
+
+        // Create collider mass properties
+        let collider_mass_props =
+            ColliderMassProperties::new_computed(&Collider::capsule(7.4, 2.1), 14.3);
 
         // Get the mass properties and then add and subtract the collider mass properties
         let mut query = app.world.query::<MassPropertiesQuery>();
@@ -261,8 +254,30 @@ mod tests {
         mass_props -= collider_mass_props;
 
         // Test if values are correct. They should be equal to the original values.
-        assert_eq!(mass_props.mass.0, 1.6);
-        assert_eq!(mass_props.inverse_mass.0, 1.0 / 1.6);
-        assert_eq!(mass_props.center_of_mass.0, Vector::X * 1.2 + Vector::Y);
+        assert_relative_eq!(
+            mass_props.mass.0,
+            original_mass_props.mass.0,
+            epsilon = 0.000_001
+        );
+        assert_relative_eq!(
+            mass_props.inverse_mass.0,
+            original_mass_props.inverse_mass.0,
+            epsilon = 0.000_001
+        );
+        assert_relative_eq!(
+            mass_props.inertia.0,
+            original_mass_props.inertia.0,
+            epsilon = 0.000_001
+        );
+        assert_relative_eq!(
+            mass_props.inverse_inertia.0,
+            original_mass_props.inverse_inertia.0,
+            epsilon = 0.000_001
+        );
+        assert_relative_eq!(
+            mass_props.center_of_mass.0,
+            original_mass_props.center_of_mass.0,
+            epsilon = 0.000_001
+        );
     }
 }


### PR DESCRIPTION
Previously, the combined center of mass of a body and its collider was computed as `com1 + com2`, but this doesn't take into account different masses. The combined inertia was also computed as `inertia1 + inertia2` without taking into account mass or the center of mass, i.e. the offset.

This PR fixes the center of mass issue by computing it correctly like `(com1 * mass1 + com2 * mass2) / (mass1 + mass2)`, and the inertia issue by first shifting the inertia values by the relative center of mass. Subtracting mass properties is handled similarly, but by simply using `-` instead of `+` in many places. These fixes will be very important especially when we implement child colliders.

I also added tests to verify that the mass and center of mass are correct after adding or subtracting mass properties. I didn't add tests for inertia yet (other than checking that `self + other - other = self`) as the calculations seem quite daunting to do by hand, so I'm not 100% sure if it's correct still. This can be verified later.