### PR TITLE
Fix 2d `position_to_transform` changing child `Transform` z-component

### DIFF
--- a/src/plugins/sync.rs
+++ b/src/plugins/sync.rs
@@ -245,7 +245,7 @@ fn position_to_transform(
                 // The new local transform of the child body,
                 // computed from the its global transform and its parents global transform
                 let new_transform = GlobalTransform::from(
-                    Transform::from_translation(pos.as_f32().extend(transform.translation.z))
+                    Transform::from_translation(pos.as_f32().extend(0.0))
                         .with_rotation(Quaternion::from(*rot).as_f32()),
                 )
                 .reparented_to(&GlobalTransform::from(parent_transform));


### PR DESCRIPTION
Fixes #125 
child's `Transform.translation.z` was previously added twice, in `extend()` and `reparented_to()`
This change removes the addition that was in `extend()`.