### PR TITLE
Collision post processing

### DIFF
--- a/crates/bevy_xpbd_2d/examples/one_way_platform_2d.rs
+++ b/crates/bevy_xpbd_2d/examples/one_way_platform_2d.rs
@@ -1,0 +1,327 @@
+use bevy::{prelude::*, sprite::MaterialMesh2dBundle, utils::HashSet};
+use bevy_xpbd_2d::{math::*, prelude::*, PostProcessCollisionsSchedule};
+use examples_common_2d::XpbdExamplePlugin;
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, XpbdExamplePlugin))
+        .insert_resource(ClearColor(Color::rgb(0.05, 0.05, 0.1)))
+        .insert_resource(SubstepCount(6))
+        .insert_resource(Gravity(Vector::NEG_Y * 1000.0))
+        .add_systems(Startup, setup)
+        .add_systems(Update, (movement, pass_through_one_way_platform))
+        .add_systems(PostProcessCollisionsSchedule, one_way_platform)
+        .run();
+}
+
+#[derive(Component)]
+struct Actor;
+
+#[derive(Clone, Eq, PartialEq, Debug, Default, Component)]
+pub struct OneWayPlatform(HashSet<Entity>);
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Default, Component, Reflect)]
+pub enum PassThroughOneWayPlatform {
+    #[default]
+    /// Passes through a `OneWayPlatform` if the contact normal is in line with the platform's local-space up vector
+    ByNormal,
+    /// Always passes through a `OneWayPlatform`, temporarily set this to allow an actor to jump down through a platform
+    Always,
+    /// Never passes through a `OneWayPlatform`
+    Never,
+}
+
+fn setup(
+    mut commands: Commands,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+    mut meshes: ResMut<Assets<Mesh>>,
+) {
+    commands.spawn(Camera2dBundle::default());
+
+    // For borders
+    let square_sprite = Sprite {
+        color: Color::rgb(0.7, 0.7, 0.8),
+        custom_size: Some(Vec2::splat(50.0)),
+        ..default()
+    };
+
+    // Ceiling
+    commands.spawn((
+        SpriteBundle {
+            sprite: square_sprite.clone(),
+            transform: Transform::from_scale(Vec3::new(20.0, 1.0, 1.0)),
+            ..default()
+        },
+        RigidBody::Static,
+        Position(Vector::Y * 50.0 * 6.0),
+        Collider::cuboid(50.0 * 20.0, 50.0),
+    ));
+    // Floor
+    commands.spawn((
+        SpriteBundle {
+            sprite: square_sprite.clone(),
+            transform: Transform::from_scale(Vec3::new(20.0, 1.0, 1.0)),
+            ..default()
+        },
+        RigidBody::Static,
+        Position(Vector::NEG_Y * 50.0 * 6.0),
+        Collider::cuboid(50.0 * 20.0, 50.0),
+    ));
+    // Left wall
+    commands.spawn((
+        SpriteBundle {
+            sprite: square_sprite.clone(),
+            transform: Transform::from_scale(Vec3::new(1.0, 11.0, 1.0)),
+            ..default()
+        },
+        RigidBody::Static,
+        Position(Vector::NEG_X * 50.0 * 9.5),
+        Collider::cuboid(50.0, 50.0 * 11.0),
+    ));
+    // Right wall
+    commands.spawn((
+        SpriteBundle {
+            sprite: square_sprite,
+            transform: Transform::from_scale(Vec3::new(1.0, 11.0, 1.0)),
+            ..default()
+        },
+        RigidBody::Static,
+        Position(Vector::X * 50.0 * 9.5),
+        Collider::cuboid(50.0, 50.0 * 11.0),
+    ));
+
+    // For one-way platforms
+    let one_way_sprite = Sprite {
+        color: Color::rgba(0.7, 0.7, 0.8, 0.25),
+        custom_size: Some(Vec2::splat(50.0)),
+        ..default()
+    };
+
+    // Spawn some one way platforms
+    for y in -2..=2 {
+        commands.spawn((
+            SpriteBundle {
+                sprite: one_way_sprite.clone(),
+                transform: Transform::from_scale(Vec3::new(10.0, 0.5, 1.0)),
+                ..default()
+            },
+            RigidBody::Static,
+            Position(Vector::Y * 15.0 * 6.0 * y as f32),
+            Collider::cuboid(25.0 * 20.0, 25.0),
+            OneWayPlatform::default(),
+        ));
+    }
+
+    // Spawn an actor for the user to control
+    let actor_size = Vec2::new(20.0, 20.0);
+    let actor_mesh = MaterialMesh2dBundle {
+        mesh: meshes.add(shape::Quad::new(actor_size).into()).into(),
+        material: materials.add(ColorMaterial::from(Color::rgb(0.2, 0.7, 0.9))),
+        ..default()
+    };
+
+    commands.spawn((
+        actor_mesh.clone(),
+        RigidBody::Dynamic,
+        LockedAxes::ROTATION_LOCKED,
+        Position(Vector::ZERO),
+        Collider::cuboid(actor_size.x, actor_size.y),
+        Actor,
+        PassThroughOneWayPlatform::ByNormal,
+    ));
+}
+
+fn movement(
+    keyboard_input: Res<Input<KeyCode>>,
+    mut actors: Query<&mut LinearVelocity, With<Actor>>,
+) {
+    for mut linear_velocity in &mut actors {
+        if keyboard_input.pressed(KeyCode::Left) {
+            linear_velocity.x -= 10.0;
+        }
+        if keyboard_input.pressed(KeyCode::Right) {
+            linear_velocity.x += 10.0;
+        }
+
+        if linear_velocity.y.abs() < 0.1 // Assume "mostly stopped" to mean "grounded"
+            && !keyboard_input.pressed(KeyCode::Down)
+            && keyboard_input.just_pressed(KeyCode::Space)
+        {
+            linear_velocity.y = 500.0;
+        }
+    }
+}
+
+fn pass_through_one_way_platform(
+    keyboard_input: Res<Input<KeyCode>>,
+    mut actors: Query<&mut PassThroughOneWayPlatform, With<Actor>>,
+) {
+    for mut pass_through_one_way_platform in &mut actors {
+        if keyboard_input.pressed(KeyCode::Down) && keyboard_input.pressed(KeyCode::Space) {
+            *pass_through_one_way_platform = PassThroughOneWayPlatform::Always;
+        } else {
+            *pass_through_one_way_platform = PassThroughOneWayPlatform::ByNormal;
+        }
+    }
+}
+
+/// Allows entities to pass through [`OneWayPlatform`] entities.
+/// Passing through is achieved by removing the collisions between the [`OneWayPlatform`]
+/// and the other entity if the entity should pass through.
+/// If a [`PassThroughOneWayPlatform`] is present on the non-platform entity,
+/// the value of the component dictates the pass-through behaviour.
+///
+/// Entities known to be passing through each [`OneWayPlatform`] are stored in the
+/// [`OneWayPlatform`]. If an entity is known to be passing through a [`OneWayPlatform`],
+/// it is allowed to continue to do so.
+///
+/// > Note that this is a very simplistic implementation of one-way
+/// > platforms to demonstrate filtering collisions via [`PostProcessCollisionsSchedule`].
+/// > You will probably want something more robust to implement one-way
+/// > platforms properly, or may elect to use sensor colliders instead, which
+/// > means you won't have collisions at all.
+///
+/// #### When an entity is known to already be passing through the [`OneWayPlatform`]
+/// Any time an entity begins passing through a [`OneWayPlatform`], it is added to the
+/// [`OneWayPlatform`]'s set of currently active penetrations, and will be allowed to
+/// continue to pass through the platform until it is no longer penetrating the platform.
+///
+/// The entity is allowed to continue to pass through the platform as long as at least
+/// one contact is penetrating.
+///
+/// Once all of the contacts are no longer penetrating the [`OneWayPlatform`], or all contacts
+/// have stopped, the entity is forgotten about and the logic falls through to the next part.
+///
+/// #### When an entity is NOT known to be passing through the [`OneWayPlatform`]
+/// Depending on the setting of [`PassThroughOneWayPlatform`], the entity may be allowed to
+/// pass through.
+///
+/// If no [`PassThroughOneWayPlatform`] is present, [`PassThroughOneWayPlatform::ByNormal`] is used.
+///
+/// [`PassThroughOneWayPlatform`] may be in one of three states:
+/// 1. [`PassThroughOneWayPlatform::ByNormal`]
+///     - This is the default state
+///     - The entity may be allowed to pass through the [`OneWayPlatform`] depending on the contact normal
+///         - If all contact normals are in line with the [`OneWayPlatform`]'s local-space up vector,
+///           the entity is allowed to pass through
+/// 2. [`PassThroughOneWayPlatform::Always`]
+///     - The entity will always pass through the [`OneWayPlatform`], regardless of contact normal
+///     - This is useful for allowing an entity to jump down through a platform
+/// 3. [`PassThroughOneWayPlatform::Never`]
+///     - The entity will never pass through the [`OneWayPlatform`], meaning the platform will act
+///       as normal hard collision for this entity
+///
+/// Even if an entity is changed to [`PassThroughOneWayPlatform::Never`], it will be allowed to pass
+/// through a [`OneWayPlatform`] if it is already penetrating the platform. Once it exits the platform,
+/// it will no longer be allowed to pass through.
+fn one_way_platform(
+    mut one_way_platforms_query: Query<(&mut OneWayPlatform, Option<&Rotation>)>,
+    other_colliders_query: Query<
+        Option<&PassThroughOneWayPlatform>,
+        (With<Collider>, Without<OneWayPlatform>), // NOTE: This precludes OneWayPlatform passing through a OneWayPlatform
+    >,
+    rotations_query: Query<&Rotation>,
+    mut collisions: ResMut<Collisions>,
+) {
+    // This assumes that Collisions contains empty entries for entities
+    // that were once colliding but no longer are.
+
+    collisions.retain(|(entity1, entity2), contacts| {
+        // This is used in a couple of if statements below; writing here for brevity below.
+        fn any_penetrating(contacts: &Contacts) -> bool {
+            contacts.manifolds.iter().any(|manifold| {
+                manifold
+                    .contacts
+                    .iter()
+                    .any(|contact| contact.penetration > 0.)
+            })
+        }
+
+        // First, figure out which entity is the one-way platform, and which is the other.
+        // Choose the appropriate normal for pass-through depending on which is which.
+        let (
+            mut one_way_platform,
+            platform_entity,
+            other_entity,
+            maybe_platform_rotation,
+            pass_through_vector,
+        ) = if let Ok((one_way_platform, maybe_platform_rotation)) =
+            one_way_platforms_query.get_mut(*entity1)
+        {
+            (
+                one_way_platform,
+                entity1,
+                entity2,
+                maybe_platform_rotation,
+                Vector::Y * 1.,
+            )
+        } else if let Ok((one_way_platform, maybe_platform_rotation)) =
+            one_way_platforms_query.get_mut(*entity2)
+        {
+            (
+                one_way_platform,
+                entity2,
+                entity1,
+                maybe_platform_rotation,
+                Vector::Y * -1.,
+            )
+        } else {
+            // Neither is a one-way-platform, so accept the collision:
+            // we're done here.
+            return true;
+        };
+
+        if one_way_platform.0.contains(other_entity) {
+            // If we were already allowing a collision for a particular entity,
+            // and if it is penetrating us still, continue to allow it to do so.
+            if any_penetrating(&contacts) {
+                return false;
+            } else {
+                // If it's no longer penetrating us, forget it.
+                one_way_platform.0.remove(other_entity);
+            }
+        }
+
+        let pass_through_global_vector = maybe_platform_rotation
+            .unwrap_or(&Rotation::default())
+            .inverse()
+            .rotate(pass_through_vector);
+
+        match other_colliders_query.get(*other_entity) {
+            // Pass-through is set to never, so accept the collision.
+            Ok(Some(PassThroughOneWayPlatform::Never)) => true,
+            // Pass-through is set to always, so always ignore this collision
+            // and register it as an entity that's currently penetrating.
+            Ok(Some(PassThroughOneWayPlatform::Always)) => {
+                one_way_platform.0.insert(*other_entity);
+                false
+            }
+            // Default behaviour is "by normal".
+            Err(_) | Ok(None) | Ok(Some(PassThroughOneWayPlatform::ByNormal)) => {
+                // Rotate the global pass through vector into the platform's local space.
+                let pass_through_vector = rotations_query
+                    .get(*platform_entity)
+                    .unwrap_or(&Rotation::default())
+                    .rotate(pass_through_global_vector);
+
+                // If all contact normals are in line with the pass_through_vector of this platform
+                // (in its local space), then ignore the collision and register it as an entity
+                // that's currently penetrating.
+                if contacts.manifolds.iter().all(|manifold| {
+                    manifold.normal.length() > Scalar::EPSILON
+                        && manifold.normal.dot(pass_through_vector) >= 0.5
+                }) {
+                    true
+                } else if any_penetrating(&contacts) {
+                    // If it's already penetrating, ignore the collision and register
+                    // the other entity as one that's currently penetrating.
+                    one_way_platform.0.insert(*other_entity);
+                    false
+                } else {
+                    // In all other cases, allow this collision.
+                    true
+                }
+            }
+        }
+    });
+}

--- a/crates/bevy_xpbd_2d/examples/one_way_platform_2d.rs
+++ b/crates/bevy_xpbd_2d/examples/one_way_platform_2d.rs
@@ -1,3 +1,9 @@
+//! A 2D platformer example with one-way platforms to demonstrate
+//! filtering collisions with systems in the `PostProcessCollisions` schedule.
+//!
+//! Move with arrow keys, jump with Space and descend through
+//! platforms by pressing Space while holding the down arrow.
+
 use bevy::{prelude::*, sprite::MaterialMesh2dBundle, utils::HashSet};
 use bevy_xpbd_2d::{math::*, prelude::*, PostProcessCollisionsSchedule};
 use examples_common_2d::XpbdExamplePlugin;
@@ -124,7 +130,7 @@ fn setup(
         actor_mesh.clone(),
         RigidBody::Dynamic,
         LockedAxes::ROTATION_LOCKED,
-        Position(Vector::ZERO),
+        Restitution::ZERO.with_combine_rule(CoefficientCombine::Min),
         Collider::cuboid(actor_size.x.into(), actor_size.y.into()),
         Actor,
         PassThroughOneWayPlatform::ByNormal,
@@ -143,11 +149,14 @@ fn movement(
             linear_velocity.x += 10.0;
         }
 
-        if linear_velocity.y.abs() < 0.1 // Assume "mostly stopped" to mean "grounded"
+        // Assume "mostly stopped" to mean "grounded".
+        // You should use ray casting, shape casting or sensor colliders
+        // for more robust ground detection.
+        if linear_velocity.y.abs() < 0.1
             && !keyboard_input.pressed(KeyCode::Down)
             && keyboard_input.just_pressed(KeyCode::Space)
         {
-            linear_velocity.y = 500.0;
+            linear_velocity.y = 450.0;
         }
     }
 }
@@ -226,7 +235,6 @@ fn one_way_platform(
 ) {
     // This assumes that Collisions contains empty entries for entities
     // that were once colliding but no longer are.
-
     collisions.retain(|(entity1, entity2), contacts| {
         // This is used in a couple of if statements below; writing here for brevity below.
         fn any_penetrating(contacts: &Contacts) -> bool {

--- a/crates/bevy_xpbd_2d/examples/one_way_platform_2d.rs
+++ b/crates/bevy_xpbd_2d/examples/one_way_platform_2d.rs
@@ -5,7 +5,7 @@
 //! platforms by pressing Space while holding the down arrow.
 
 use bevy::{prelude::*, sprite::MaterialMesh2dBundle, utils::HashSet};
-use bevy_xpbd_2d::{math::*, prelude::*, PostProcessCollisionsSchedule};
+use bevy_xpbd_2d::{math::*, prelude::*, PostProcessCollisions};
 use examples_common_2d::XpbdExamplePlugin;
 
 fn main() {
@@ -16,7 +16,7 @@ fn main() {
         .insert_resource(Gravity(Vector::NEG_Y * 1000.0))
         .add_systems(Startup, setup)
         .add_systems(Update, (movement, pass_through_one_way_platform))
-        .add_systems(PostProcessCollisionsSchedule, one_way_platform)
+        .add_systems(PostProcessCollisions, one_way_platform)
         .run();
 }
 
@@ -187,7 +187,7 @@ fn pass_through_one_way_platform(
 /// set to disallow passing through.
 ///
 /// > Note that this is a very simplistic implementation of one-way
-/// > platforms to demonstrate filtering collisions via [`PostProcessCollisionsSchedule`].
+/// > platforms to demonstrate filtering collisions via [`PostProcessCollisions`].
 /// > You will probably want something more robust to implement one-way
 /// > platforms properly, or may elect to use a sensor collider for your entities instead,
 /// > which means you won't need to filter collisions at all.

--- a/crates/bevy_xpbd_2d/examples/one_way_platform_2d.rs
+++ b/crates/bevy_xpbd_2d/examples/one_way_platform_2d.rs
@@ -106,7 +106,7 @@ fn setup(
                 ..default()
             },
             RigidBody::Static,
-            Position(Vector::Y * 15.0 * 6.0 * y as f32),
+            Position(Vector::Y * 15.0 * 6.0 * y as Scalar),
             Collider::cuboid(25.0 * 20.0, 25.0),
             OneWayPlatform::default(),
         ));
@@ -125,7 +125,7 @@ fn setup(
         RigidBody::Dynamic,
         LockedAxes::ROTATION_LOCKED,
         Position(Vector::ZERO),
-        Collider::cuboid(actor_size.x, actor_size.y),
+        Collider::cuboid(actor_size.x.into(), actor_size.y.into()),
         Actor,
         PassThroughOneWayPlatform::ByNormal,
     ));

--- a/crates/bevy_xpbd_2d/examples/one_way_platform_2d.rs
+++ b/crates/bevy_xpbd_2d/examples/one_way_platform_2d.rs
@@ -112,7 +112,7 @@ fn setup(
                 ..default()
             },
             RigidBody::Static,
-            Position(Vector::Y * 15.0 * 6.0 * y as Scalar),
+            Position(Vector::Y * 16.0 * 6.0 * y as Scalar),
             Collider::cuboid(25.0 * 20.0, 25.0),
             OneWayPlatform::default(),
         ));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -468,7 +468,7 @@ pub struct SubstepSchedule;
 ///
 /// Empty by default.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, ScheduleLabel)]
-pub struct PostProcessCollisionsSchedule;
+pub struct PostProcessCollisions;
 
 /// High-level system sets for the main phases of the physics engine.
 /// You can use these to schedule your own systems before or after physics is run without
@@ -488,7 +488,7 @@ pub struct PostProcessCollisionsSchedule;
 /// - [`SubstepSchedule`]: Responsible for running the substepping loop in [`PhysicsStepSet::Substeps`].
 /// - [`SubstepSet`]: System sets for the steps of the substepping loop, like position integration and
 /// the constraint solver.
-/// - [`PostProcessCollisionsSchedule`]: Responsible for running the post-process collisions group in
+/// - [`PostProcessCollisions`]: Responsible for running the post-process collisions group in
 /// [`SubstepSet::PostProcessCollisions`]. Empty by default.
 #[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum PhysicsSet {
@@ -558,11 +558,11 @@ pub enum SubstepSet {
     ///
     /// See [`NarrowPhasePlugin`].
     NarrowPhase,
-    /// Responsible for running [`PostProcessCollisionsSchedule`] to allow user-defined systems
+    /// Responsible for running [`PostProcessCollisions`] to allow user-defined systems
     /// to post-process collisions, such as filtering.
     ///
     /// If you want to edit or remove collisions after [`SubstepSet::NarrowPhase`], you can
-    /// add custom systems to this set, or to [`PostProcessCollisionsSchedule`].
+    /// add custom systems to this set, or to [`PostProcessCollisions`].
     ///
     /// See [`NarrowPhasePlugin`].
     PostProcessCollisions,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -464,6 +464,12 @@ pub struct PhysicsSchedule;
 #[derive(Debug, Hash, PartialEq, Eq, Clone, ScheduleLabel)]
 pub struct SubstepSchedule;
 
+/// The schedule that runs in [`SubstepSet::PostProcessCollisions`].
+///
+/// Empty by default.
+#[derive(Debug, Hash, PartialEq, Eq, Clone, ScheduleLabel)]
+pub struct PostProcessCollisionsSchedule;
+
 /// High-level system sets for the main phases of the physics engine.
 /// You can use these to schedule your own systems before or after physics is run without
 /// having to worry about implementation details.
@@ -482,6 +488,8 @@ pub struct SubstepSchedule;
 /// - [`SubstepSchedule`]: Responsible for running the substepping loop in [`PhysicsStepSet::Substeps`].
 /// - [`SubstepSet`]: System sets for the steps of the substepping loop, like position integration and
 /// the constraint solver.
+/// - [`PostProcessCollisionsSchedule`]: Responsible for running the post-process collisions group in
+/// [`SubstepSet::PostProcessCollisions`]. Empty by default.
 #[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum PhysicsSet {
     /// Responsible for initializing [rigid bodies](RigidBody) and [colliders](Collider) and
@@ -548,6 +556,14 @@ pub enum SubstepSet {
     ///
     /// See [`NarrowPhasePlugin`].
     NarrowPhase,
+    /// An empty substep for custom post-processes that can be created by the user
+    /// such as filtering collisions.
+    ///
+    /// If you want to edit or remove collisions after [`SubstepSet::NarrowPhase`], you can
+    /// add custom systems here.
+    ///
+    /// See [`NarrowPhasePlugin`].
+    PostProcessCollisions,
     /// The [solver] iterates through [constraints] and solves them.
     ///
     /// **Note**: If you want to [create your own constraints](constraints#custom-constraints),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -542,9 +542,11 @@ pub enum PhysicsStepSet {
 /// System sets for the the steps in the inner substepping loop. These are typically run in the [`SubstepSchedule`].
 ///
 /// 1. Integrate
-/// 2. Solve positional and angular constraints
-/// 3. Update velocities
-/// 4. Solve velocity constraints (dynamic friction and restitution)
+/// 2. Narrow phase
+/// 3. Post-process collisions
+/// 4. Solve positional and angular constraints
+/// 5. Update velocities
+/// 6. Solve velocity constraints (dynamic friction and restitution)
 #[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum SubstepSet {
     /// Responsible for integrating Newton's 2nd law of motion,
@@ -556,11 +558,11 @@ pub enum SubstepSet {
     ///
     /// See [`NarrowPhasePlugin`].
     NarrowPhase,
-    /// An empty substep for custom post-processes that can be created by the user
-    /// such as filtering collisions.
+    /// Responsible for running [`PostProcessCollisionsSchedule`] to allow user-defined systems
+    /// to post-process collisions, such as filtering.
     ///
     /// If you want to edit or remove collisions after [`SubstepSet::NarrowPhase`], you can
-    /// add custom systems here.
+    /// add custom systems to this set, or to [`PostProcessCollisionsSchedule`].
     ///
     /// See [`NarrowPhasePlugin`].
     PostProcessCollisions,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -561,7 +561,7 @@ pub enum SubstepSet {
     /// Responsible for running the [`PostProcessCollisions`] schedule to allow user-defined systems
     /// to filter and modify collisions.
     ///
-    /// If you want to edit or remove collisions after [`SubstepSet::NarrowPhase`], you can
+    /// If you want to modify or remove collisions after [`SubstepSet::NarrowPhase`], you can
     /// add custom systems to this set, or to [`PostProcessCollisions`].
     ///
     /// See [`NarrowPhasePlugin`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -558,8 +558,8 @@ pub enum SubstepSet {
     ///
     /// See [`NarrowPhasePlugin`].
     NarrowPhase,
-    /// Responsible for running [`PostProcessCollisions`] to allow user-defined systems
-    /// to post-process collisions, such as filtering.
+    /// Responsible for running the [`PostProcessCollisions`] schedule to allow user-defined systems
+    /// to filter and modify collisions.
     ///
     /// If you want to edit or remove collisions after [`SubstepSet::NarrowPhase`], you can
     /// add custom systems to this set, or to [`PostProcessCollisions`].

--- a/src/plugins/narrow_phase.rs
+++ b/src/plugins/narrow_phase.rs
@@ -142,10 +142,18 @@ impl Collisions {
             })
     }
 
+    /// Retains only the collisions for which the specified predicate returns `true`.
+    /// Collisions for which the predicate returns `false` are removed from the `HashMap`.
+    pub fn retain<F>(&mut self, keep: F)
+    where
+        F: FnMut(&(Entity, Entity), &mut Contacts) -> bool,
+    {
+        self.0.retain(keep);
+    }
+
     /// Removes collisions against the given entity from the `HashMap`.
     fn remove_collisions_with_entity(&mut self, entity: Entity) {
-        self.0
-            .retain(|(entity1, entity2), _| *entity1 != entity && *entity2 != entity);
+        self.retain(|(entity1, entity2), _| *entity1 != entity && *entity2 != entity);
     }
 }
 

--- a/src/plugins/setup.rs
+++ b/src/plugins/setup.rs
@@ -28,6 +28,8 @@ use crate::prelude::*;
 /// - [`SubstepSchedule`]: Responsible for running the substepping loop in [`PhysicsStepSet::Substeps`].
 /// - [`SubstepSet`]: System sets for the steps of the substepping loop, like position integration and
 /// the constraint solver.
+/// - [`PostProcessCollisionsSchedule`]: Responsible for running collision post-processing systems.
+/// Empty by default.
 pub struct PhysicsSetupPlugin {
     schedule: Box<dyn ScheduleLabel>,
 }

--- a/src/plugins/setup.rs
+++ b/src/plugins/setup.rs
@@ -28,7 +28,7 @@ use crate::prelude::*;
 /// - [`SubstepSchedule`]: Responsible for running the substepping loop in [`PhysicsStepSet::Substeps`].
 /// - [`SubstepSet`]: System sets for the steps of the substepping loop, like position integration and
 /// the constraint solver.
-/// - [`PostProcessCollisionsSchedule`]: Responsible for running collision post-processing systems.
+/// - [`PostProcessCollisions`]: Responsible for running collision post-processing systems.
 /// Empty by default.
 pub struct PhysicsSetupPlugin {
     schedule: Box<dyn ScheduleLabel>,
@@ -196,10 +196,7 @@ impl Plugin for PhysicsSetupPlugin {
                 ..default()
             });
 
-        app.add_schedule(
-            PostProcessCollisionsSchedule,
-            post_process_collisions_schedule,
-        );
+        app.add_schedule(PostProcessCollisions, post_process_collisions_schedule);
 
         app.add_systems(
             SubstepSchedule,
@@ -325,8 +322,8 @@ fn run_substep_schedule(world: &mut World) {
     }
 }
 
-/// Runs the [`PostProcessCollisionsSchedule`].
+/// Runs the [`PostProcessCollisions`] schedule.
 fn run_post_process_collisions_schedule(world: &mut World) {
-    debug!("running PostProcessCollisionsSchedule");
-    world.run_schedule(PostProcessCollisionsSchedule);
+    debug!("running PostProcessCollisions");
+    world.run_schedule(PostProcessCollisions);
 }

--- a/src/plugins/setup.rs
+++ b/src/plugins/setup.rs
@@ -185,8 +185,8 @@ impl Plugin for PhysicsSetupPlugin {
             run_substep_schedule.in_set(PhysicsStepSet::Substeps),
         );
 
-        // Create post-process collisions schedule, the schedule that should be used to
-        // run collision post-processing systems, such as filtering.
+        // Create the PostProcessCollisions schedule for user-defined systems
+        // that filter and modify collisions.
         let mut post_process_collisions_schedule = Schedule::default();
 
         post_process_collisions_schedule


### PR DESCRIPTION
## Objective
Create a stage to allow filtering and changing collisions from user-defined systems.

This is the simplest part of #150: the Global Physics hooks via user systems only.

## Solution
- Adds `SubstepSet::PostProcessCollisions`, which is directly after `SubstepSet::NarrowPhase`
- Adds `PostProcessCollisionsSchedule`, which is run in `SubstepSet::PostProcessCollisions`
- Exposes `retain` from `Collisions` to allow direct modification of the set of collisions

Also includes a simple one-way-platform example.
