### PR TITLE
Make `PreviousGlobalTransform` public and derive traits

### DIFF
--- a/src/plugins/setup.rs
+++ b/src/plugins/setup.rs
@@ -9,6 +9,8 @@ use bevy::{
 
 use crate::prelude::*;
 
+use super::sync::PreviousGlobalTransform;
+
 /// Sets up the physics engine by initializing the necessary schedules, sets and resources.
 ///
 /// This plugin does *not* initialize any other plugins or physics systems.
@@ -81,6 +83,7 @@ impl Plugin for PhysicsSetupPlugin {
             .register_type::<Rotation>()
             .register_type::<PreviousPosition>()
             .register_type::<PreviousRotation>()
+            .register_type::<PreviousGlobalTransform>()
             .register_type::<AccumulatedTranslation>()
             .register_type::<LinearVelocity>()
             .register_type::<AngularVelocity>()

--- a/src/plugins/sync.rs
+++ b/src/plugins/sync.rs
@@ -123,8 +123,9 @@ impl Default for SyncConfig {
 
 /// The global transform of a body at the end of the previous frame.
 /// Used for detecting if the transform was modified before the start of the physics schedule.
-#[derive(Component, Deref, DerefMut)]
-struct PreviousGlobalTransform(GlobalTransform);
+#[derive(Component, Reflect, Clone, Copy, Debug, Default, Deref, DerefMut, PartialEq)]
+#[reflect(Component)]
+pub struct PreviousGlobalTransform(pub GlobalTransform);
 
 type PhysicsObjectAddedFilter = Or<(Added<RigidBody>, Added<Collider>)>;
 


### PR DESCRIPTION
Closes #165, enabling better determinism in rollback-contexts when modifying transforms.