### PR TITLE
Fix compute_lagrange_update at very high masses

### DIFF
--- a/src/constraints/mod.rs
+++ b/src/constraints/mod.rs
@@ -253,15 +253,12 @@ pub trait XpbdConstraint<const ENTITY_COUNT: usize> {
         dt: Scalar,
     ) -> Scalar {
         // Compute the sum of all inverse masses multiplied by the squared lengths of the corresponding gradients.
+        // Don't go below EPSILON to avoid dividing by zero.
         let w_sum = inverse_masses
             .iter()
             .enumerate()
-            .fold(0.0, |acc, (i, w)| acc + *w * gradients[i].length_squared());
-
-        // Avoid division by zero
-        if w_sum <= Scalar::EPSILON {
-            return 0.0;
-        }
+            .fold(0.0, |acc, (i, w)| acc + *w * gradients[i].length_squared())
+            .min(Scalar::EPSILON);
 
         // tilde_a = a/h^2
         let tilde_compliance = compliance / dt.powi(2);


### PR DESCRIPTION
With very dense colliders / very small inverse masses, the inverse mass sum was < EPSILON, and I was getting no collision response.

Slow dynamic bodies with a high mass and inertia were passing through static bodies.

This sets a minimum inverse_mass amount so there's still a response.

I've no idea if this is correct, I have only verified that it solved the problem I was seeing in 2d.