### PR TITLE
Skip re-writing the same values to components, to satisfy bevy's change detection.

### DIFF
--- a/src/plugins/integrator.rs
+++ b/src/plugins/integrator.rs
@@ -92,12 +92,14 @@ fn integrate_pos(
             let gravitation_force =
                 effective_mass * gravity.0 * gravity_scale.map_or(1.0, |scale| scale.0);
             let external_forces = gravitation_force + external_force.force();
-            lin_vel.0 += sub_dt.0 * external_forces * effective_inv_mass;
+            let delta_linvel = sub_dt.0 * external_forces * effective_inv_mass;
+            // avoid triggering bevy's change detection unnecessarily
+            if delta_linvel != Vector::ZERO {
+                lin_vel.0 += delta_linvel;
+            }
         }
-        // avoid triggering bevy's change detection unnecessarily
-        let delta = locked_axes.apply_to_vec(sub_dt.0 * lin_vel.0);
-        if delta != Vector::ZERO {
-            translation.0 += delta;
+        if lin_vel.0 != Vector::ZERO {
+            translation.0 += locked_axes.apply_to_vec(sub_dt.0 * lin_vel.0);
         }
     }
 }
@@ -147,15 +149,22 @@ fn integrate_rot(
         if rb.is_dynamic() {
             // Apply damping
             if let Some(damping) = ang_damping {
-                ang_vel.0 *= 1.0 / (1.0 + sub_dt.0 * damping.0);
+                // avoid triggering bevy's change detection unnecessarily
+                if ang_vel.0 != 0.0 && damping.0 != 0.0 {
+                    ang_vel.0 *= 1.0 / (1.0 + sub_dt.0 * damping.0);
+                }
             }
 
             let effective_inv_inertia = locked_axes.apply_to_rotation(inv_inertia.0);
 
             // Apply external torque
-            ang_vel.0 += sub_dt.0
+            let delta_ang_vel = sub_dt.0
                 * effective_inv_inertia
                 * (external_torque.torque() + external_force.torque());
+            // avoid triggering bevy's change detection unnecessarily
+            if delta_ang_vel != 0.0 {
+                ang_vel.0 += delta_ang_vel;
+            }
         }
         // avoid triggering bevy's change detection unnecessarily
         let delta = locked_axes.apply_to_angular_velocity(sub_dt.0 * ang_vel.0);
@@ -197,7 +206,10 @@ fn integrate_rot(
         if rb.is_dynamic() {
             // Apply damping
             if let Some(damping) = ang_damping {
-                ang_vel.0 *= 1.0 / (1.0 + sub_dt.0 * damping.0);
+                // avoid triggering bevy's change detection unnecessarily
+                if ang_vel.0 != Vector::ZERO && damping.0 != 0.0 {
+                    ang_vel.0 *= 1.0 / (1.0 + sub_dt.0 * damping.0);
+                }
             }
 
             let effective_inertia = locked_axes.apply_to_rotation(inertia.rotated(&rot).0);
@@ -208,7 +220,10 @@ fn integrate_rot(
                 * effective_inv_inertia
                 * ((external_torque.torque() + external_force.torque())
                     - ang_vel.0.cross(effective_inertia * ang_vel.0));
-            ang_vel.0 += delta_ang_vel;
+            // avoid triggering bevy's change detection unnecessarily
+            if delta_ang_vel != Vector::ZERO {
+                ang_vel.0 += delta_ang_vel;
+            }
         }
 
         let q = Quaternion::from_vec4(ang_vel.0.extend(0.0)) * rot.0;
@@ -257,8 +272,22 @@ fn apply_impulses(mut bodies: Query<ImpulseQueryComponents, Without<Sleeping>>) 
         let effective_inv_mass = locked_axes.apply_to_vec(Vector::splat(inv_mass.0));
         let effective_inv_inertia = locked_axes.apply_to_rotation(inv_inertia.rotated(rotation).0);
 
-        lin_vel.0 += impulse.impulse() * effective_inv_mass;
-        ang_vel.0 += effective_inv_inertia * (ang_impulse.impulse() + impulse.angular_impulse());
+        // avoid triggering bevy's change detection unnecessarily
+        let delta_lin_vel = impulse.impulse() * effective_inv_mass;
+        let delta_ang_vel =
+            effective_inv_inertia * (ang_impulse.impulse() + impulse.angular_impulse());
+
+        if delta_lin_vel != Vector::ZERO {
+            lin_vel.0 += delta_lin_vel;
+        }
+        #[cfg(feature = "3d")]
+        if delta_ang_vel != Vector::ZERO {
+            ang_vel.0 += delta_ang_vel;
+        }
+        #[cfg(feature = "2d")]
+        if delta_ang_vel != 0.0 {
+            ang_vel.0 += delta_ang_vel;
+        }
     }
 }
 

--- a/src/plugins/sleeping.rs
+++ b/src/plugins/sleeping.rs
@@ -23,7 +23,11 @@ impl Plugin for SleepingPlugin {
         app.get_schedule_mut(PhysicsSchedule)
             .expect("add PhysicsSchedule first")
             .add_systems(
-                (mark_sleeping_bodies, wake_up_bodies, gravity_wake_up_bodies)
+                (
+                    mark_sleeping_bodies,
+                    wake_up_bodies,
+                    wake_all_sleeping_bodies.run_if(resource_changed::<Gravity>()),
+                )
                     .chain()
                     .in_set(PhysicsStepSet::Sleeping),
             );
@@ -105,16 +109,14 @@ fn wake_up_bodies(
     }
 }
 
-/// Removes the [`Sleeping`] component from sleeping bodies when [`Gravity`] is changed.
-fn gravity_wake_up_bodies(
+/// Removes the [`Sleeping`] component from all sleeping bodies.
+/// Triggered automatically when [`Gravity`] is changed.
+fn wake_all_sleeping_bodies(
     mut commands: Commands,
     mut bodies: Query<(Entity, &mut TimeSleeping), With<Sleeping>>,
-    gravity: Res<Gravity>,
 ) {
-    if gravity.is_changed() {
-        for (entity, mut time_sleeping) in &mut bodies {
-            commands.entity(entity).remove::<Sleeping>();
-            time_sleeping.0 = 0.0;
-        }
+    for (entity, mut time_sleeping) in &mut bodies {
+        commands.entity(entity).remove::<Sleeping>();
+        time_sleeping.0 = 0.0;
     }
 }


### PR DESCRIPTION
At the moment, a dynamic body (that isn't sleeping) with zero Linear and Angular velocity will still get its Position, Rotation, LinearVelocity, and AngularVelocity updated every tick (re-set to the same values).

This shows up if you use a `Query<Entity, Changed<Position>>` query filter, for example.

These commits guard against updating the components unless the value will actually change.

I noticed this while debugging some netcode that serializes and sends changed component values.