### PR TITLE
Ensure newly created bodies get simulated the frame they are added

### DIFF
--- a/crates/bevy_xpbd_2d/snapshots/bevy_xpbd_2d__tests__body_with_velocity_moves.snap
+++ b/crates/bevy_xpbd_2d/snapshots/bevy_xpbd_2d__tests__body_with_velocity_moves.snap
@@ -4,7 +4,7 @@ expression: transform
 ---
 Transform {
     translation: Vec3(
-        8.316667,
+        8.35,
         0.0,
         0.0,
     ),

--- a/crates/bevy_xpbd_3d/snapshots/bevy_xpbd_3d__tests__body_with_velocity_moves.snap
+++ b/crates/bevy_xpbd_3d/snapshots/bevy_xpbd_3d__tests__body_with_velocity_moves.snap
@@ -4,7 +4,7 @@ expression: transform
 ---
 Transform {
     translation: Vec3(
-        8.316667,
+        8.35,
         0.0,
         0.0,
     ),

--- a/src/plugins/prepare.rs
+++ b/src/plugins/prepare.rs
@@ -58,6 +58,8 @@ impl Plugin for PreparePlugin {
                 init_colliders,
                 update_mass_properties,
                 clamp_restitution,
+                // all the components we added above must exist before we can simulate the bodies
+                apply_deferred,
             )
                 .chain()
                 .in_set(PhysicsSet::Prepare),

--- a/src/plugins/setup.rs
+++ b/src/plugins/setup.rs
@@ -294,7 +294,7 @@ fn run_physics_schedule(world: &mut World) {
                 physics_loop.accumulator += dt * physics_loop.queued_steps as Scalar;
                 physics_loop.queued_steps = 0;
             } else {
-                physics_loop.accumulator += dt;
+                physics_loop.accumulator += delta_seconds * time_scale;
             }
 
             // Step the simulation until the accumulator has been consumed.

--- a/src/plugins/setup.rs
+++ b/src/plugins/setup.rs
@@ -294,7 +294,7 @@ fn run_physics_schedule(world: &mut World) {
                 physics_loop.accumulator += dt * physics_loop.queued_steps as Scalar;
                 physics_loop.queued_steps = 0;
             } else {
-                physics_loop.accumulator += delta_seconds * time_scale;
+                physics_loop.accumulator += dt;
             }
 
             // Step the simulation until the accumulator has been consumed.

--- a/src/plugins/setup.rs
+++ b/src/plugins/setup.rs
@@ -254,14 +254,14 @@ fn run_physics_schedule(world: &mut World) {
         .expect("no PhysicsLoop resource");
 
     #[cfg(feature = "f32")]
-    let delta_seconds = if physics_loop.fixed_update {
+    let mut delta_seconds = if physics_loop.fixed_update {
         world.resource::<FixedTime>().period.as_secs_f32()
     } else {
         world.resource::<Time>().delta_seconds()
     };
 
     #[cfg(feature = "f64")]
-    let delta_seconds = if physics_loop.fixed_update {
+    let mut delta_seconds = if physics_loop.fixed_update {
         world.resource::<FixedTime>().period.as_secs_f64()
     } else {
         world.resource::<Time>().delta_seconds_f64()
@@ -276,6 +276,14 @@ fn run_physics_schedule(world: &mut World) {
         PhysicsTimestep::FixedOnce(fixed_delta_seconds) => (fixed_delta_seconds, false),
         PhysicsTimestep::Variable { max_dt } => (delta_seconds.min(max_dt), true),
     };
+
+    // On the first ever call to app.update() delta_seconds would be 0.
+    // In that case, replace it with the Fixed/FixedOnce amount.
+    // With Variable timestep, the physics accumulator won't increase until the second update().
+    if world.resource::<Time>().first_update() == world.resource::<Time>().last_update() {
+        delta_seconds = raw_dt;
+    }
+
     let dt = raw_dt * time_scale;
     world.resource_mut::<DeltaTime>().0 = dt;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -91,6 +91,32 @@ fn it_loads_plugin_without_errors() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn body_with_velocity_moves_on_first_frame() {
+    let mut app = create_app();
+
+    app.insert_resource(Gravity::ZERO);
+
+    app.add_systems(Startup, |mut commands: Commands| {
+        // move right at 1 unit per second
+        commands.spawn((
+            SpatialBundle::default(),
+            RigidBody::Dynamic,
+            LinearVelocity(Vector::X),
+            Position(Vector::ZERO),
+        ));
+    });
+
+    // one tick only.
+    tick_60_fps(&mut app);
+
+    let mut app_query = app.world.query::<(&Position, &RigidBody)>();
+
+    let (pos, _body) = app_query.single(&app.world);
+
+    assert!(pos.x > 0.0);
+}
+
+#[test]
 fn body_with_velocity_moves() {
     let mut app = create_app();
 


### PR DESCRIPTION
### First commit

Added an apply_deferred to ensure all the physics components get added that frame - otherwise the body won't be simulated until commands are flushed later.

### Second commit

HOWEVER, the added test will still fail because it appears that delta_seconds is 0 for the first update here:
https://github.com/RJ/bevy_xpbd/blob/c61a90ec03ba51b74354053eca9ac8c7f09d1f59/src/plugins/setup.rs#L260


meaning the ` physics_loop.accumulator` doesn't increase on the first update, because it was referencing `delta_seconds`. I *think* it makes more sense to use `dt` there, since it's already been scaled and clamped as needed.

This fixes the test, but only because it's not using a Variable timestep, which would still fail because there is no delta_seconds on the first update. I don't think it's the fault of the manual time updating strategy; i think delta_seconds just isn't calcualted on the first ever update: https://github.com/bevyengine/bevy/blob/bb13d065d36c9b495b755aef2040b43f29a91b79/crates/bevy_time/src/time.rs#L155

It's a bit of a weird edge case, and as long as the tests don't want to use variable timesteps and have things simulated on the first ever update, it hopefully won't be an issue in future.
