### PR TITLE
Improve `Collisions` API and docs

### DIFF
--- a/src/components/collider.rs
+++ b/src/components/collider.rs
@@ -50,9 +50,6 @@ pub type TriMeshFlags = parry::shape::TriMeshFlags;
 /// ## Collision events
 ///
 /// There are currently three different collision events: [`Collision`], [`CollisionStarted`] and [`CollisionEnded`].
-/// You can listen to these events as you normally would.
-///
-/// For example, you could read [contacts](Contact) like this:
 ///
 /// ```
 /// use bevy::prelude::*;
@@ -67,6 +64,13 @@ pub type TriMeshFlags = parry::shape::TriMeshFlags;
 ///     }
 /// }
 /// ```
+///
+/// ## Querying and modifying contacts
+///
+/// The [`Collisions`] resource grants access to all collisions.
+/// It can be used to get, modify, filter and add collisions.
+///
+/// See [`Collisions`] for more details.
 ///
 /// ## Advanced usage
 ///

--- a/src/plugins/narrow_phase/contact_data.rs
+++ b/src/plugins/narrow_phase/contact_data.rs
@@ -1,0 +1,297 @@
+use crate::prelude::*;
+use bevy::prelude::*;
+use indexmap::IndexMap;
+
+// Collisions are stored in an `IndexMap` that uses fxhash.
+// It should have faster iteration than a `HashMap` while mostly retaining other performance characteristics.
+//
+// `IndexMap` also preserves insertion order. This can be good or bad depending on the situation,
+// but it can make spawned stacks appear more consistent and uniform, for example in the `move_marbles` example.
+// ==========================================
+/// A resource that stores all collision pairs.
+///
+/// Each colliding entity pair is associated with [`Contacts`] that can be accessed and modified
+/// using the various associated methods.
+///
+/// ## Querying collisions
+///
+/// The following methods can be used for querying existing collisions:
+///
+/// - [`get`](#method.get) and [`get_mut`](#method.get_mut)
+/// - [`iter`](#method.iter) and [`iter_mut`](#method.iter_mut)
+/// - [`contains`](#method.contains)
+/// - [`collisions_with_entity`](#method.collisions_with_entity) and
+/// [`collisions_with_entity_mut`](#method.collisions_with_entity_mut)
+///
+/// The collisions can be accessed at any time, but modifications to contacts should be performed
+/// in the [`PostProcessCollisions`] schedule. Otherwise, the physics solver will use the old contact data.
+///
+/// ## Filtering and removing collisions
+///
+/// The following methods can be used for filtering or removing existing collisions:
+///
+/// - [`retain`](#method.retain)
+/// - [`remove_collision_pair`](#method.remove_collision_pair)
+/// - [`remove_collisions_with_entity`](#method.remove_collisions_with_entity)
+///
+/// Collision filtering and removal should be done in the [`PostProcessCollisions`] schedule.
+/// Otherwise, the physics solver will use the old contact data.
+///
+/// ## Adding new collisions
+///
+/// The following methods can be used for adding new collisions:
+///
+/// - [`insert_collision_pair`](#method.insert_collision_pair)
+/// - [`extend`](#method.extend)
+///
+/// The most convenient place for adding new collisions is in the [`PostProcessCollisions`] schedule.
+/// Otherwise, the physics solver might not have access to them in time.
+///
+/// ## Implementation details
+///
+/// Internally, the collisions are stored in an `IndexMap` that contains collisions from both the current frame
+/// and the previous frame, which is used for things like [collision events](Collider#collision-events).
+///
+/// However, the public methods only use the current frame's collisions. To access the internal data structure,
+/// you can use [`get_internal`](#method.get_internal) or [`get_internal_mut`](#method.get_internal_mut).
+#[derive(Resource, Clone, Debug, Default, PartialEq)]
+pub struct Collisions(IndexMap<(Entity, Entity), Contacts, fxhash::FxBuildHasher>);
+
+impl Collisions {
+    /// Returns a reference to the internal `IndexMap`.
+    pub fn get_internal(&self) -> &IndexMap<(Entity, Entity), Contacts, fxhash::FxBuildHasher> {
+        &self.0
+    }
+
+    /// Returns a mutable reference to the internal `IndexMap`.
+    pub fn get_internal_mut(
+        &mut self,
+    ) -> &mut IndexMap<(Entity, Entity), Contacts, fxhash::FxBuildHasher> {
+        &mut self.0
+    }
+
+    /// Returns a reference to the [contacts](Contacts) stored for the given entity pair if they are colliding,
+    /// else returns `None`.
+    ///
+    /// The order of the entities does not matter.
+    pub fn get(&self, entity1: Entity, entity2: Entity) -> Option<&Contacts> {
+        self.0
+            .get(&(entity1, entity2))
+            .filter(|contacts| contacts.during_current_frame)
+            .or_else(|| {
+                self.0
+                    .get(&(entity2, entity1))
+                    .filter(|contacts| contacts.during_current_frame)
+            })
+    }
+
+    /// Returns a mutable reference to the [contacts](Contacts) stored for the given entity pair if they are colliding,
+    /// else returns `None`.
+    ///
+    /// The order of the entities does not matter.
+    pub fn get_mut(&mut self, entity1: Entity, entity2: Entity) -> Option<&mut Contacts> {
+        // For lifetime reasons, the mutable borrows can't be in the same scope,
+        // so we check if the key exists first (there's probably a better way though)
+        if self.0.contains_key(&(entity1, entity2)) {
+            self.0
+                .get_mut(&(entity1, entity2))
+                .filter(|contacts| contacts.during_current_frame)
+        } else {
+            self.0
+                .get_mut(&(entity2, entity1))
+                .filter(|contacts| contacts.during_current_frame)
+        }
+    }
+
+    /// Returns `true` if the given entities have been in contact during this frame.
+    ///
+    /// The order of the entities does not matter.
+    pub fn contains(&self, entity1: Entity, entity2: Entity) -> bool {
+        // We can't use `contains` directly because we only want to
+        // count collisions that happened during this frame.
+        self.get(entity1, entity2).is_some()
+    }
+
+    /// Returns an iterator over the current collisions that have happened during the current physics frame.
+    pub fn iter(&self) -> impl Iterator<Item = &Contacts> {
+        self.0
+            .values()
+            .filter(|collision| collision.during_current_frame)
+    }
+
+    /// Returns a mutable iterator over the collisions that have happened during the current physics frame.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Contacts> {
+        self.0
+            .values_mut()
+            .filter(|collision| collision.during_current_frame)
+    }
+
+    /// Returns an iterator over all collisions with a given entity.
+    pub fn collisions_with_entity(&self, entity: Entity) -> impl Iterator<Item = &Contacts> {
+        self.0
+            .iter()
+            .filter_map(move |((entity1, entity2), contacts)| {
+                if contacts.during_current_frame && (*entity1 == entity || *entity2 == entity) {
+                    Some(contacts)
+                } else {
+                    None
+                }
+            })
+    }
+
+    /// Returns an iterator over all collisions with a given entity.
+    pub fn collisions_with_entity_mut(
+        &mut self,
+        entity: Entity,
+    ) -> impl Iterator<Item = &mut Contacts> {
+        self.0
+            .iter_mut()
+            .filter_map(move |((entity1, entity2), contacts)| {
+                if contacts.during_current_frame && (*entity1 == entity || *entity2 == entity) {
+                    Some(contacts)
+                } else {
+                    None
+                }
+            })
+    }
+
+    /// Inserts contact data for a collision between two entities.
+    ///
+    /// If a collision entry with the same entities already exists, it will be overwritten,
+    /// and the old value will be returned. Otherwise, `None` is returned.
+    ///
+    /// **Note**: Manually inserting collisions can be error prone and should generally be avoided.
+    /// If you simply want to modify existing collisions, consider using methods like [`get_mut`](#method.get_mut)
+    /// or [`iter_mut`](#method.iter_mut).
+    pub fn insert_collision_pair(&mut self, contacts: Contacts) -> Option<Contacts> {
+        // Todo: We might want to order the data by Entity ID so that entity1, point1 etc. are for the "smaller"
+        // entity ID. This requires changes elsewhere as well though.
+        // Todo: Handle during_previous_frame nicer
+        self.0
+            .insert((contacts.entity1, contacts.entity2), contacts)
+    }
+
+    /// Extends [`Collisions`] with all collision pairs in the given iterable.
+    ///
+    /// This is mostly equivalent to calling [`insert_collision_pair`](#method.insert_collision_pair)
+    /// for each of the collision pairs.
+    pub fn extend<I: IntoIterator<Item = Contacts>>(&mut self, collisions: I) {
+        // (Note: this is a copy of `std`/`hashbrown`/`indexmap`'s reservation logic.)
+        // Keys may be already present or show multiple times in the iterator.
+        // Reserve the entire hint lower bound if the map is empty.
+        // Otherwise reserve half the hint (rounded up), so the map
+        // will only resize twice in the worst case.
+        let iter = collisions.into_iter();
+        let reserve = if self.get_internal().is_empty() {
+            iter.size_hint().0
+        } else {
+            (iter.size_hint().0 + 1) / 2
+        };
+        self.get_internal_mut().reserve(reserve);
+        iter.for_each(move |contacts| {
+            self.insert_collision_pair(contacts);
+        });
+    }
+
+    /// Retains only the collisions for which the specified predicate returns `true`.
+    /// Collisions for which the predicate returns `false` are removed.
+    pub fn retain<F>(&mut self, mut keep: F)
+    where
+        F: FnMut(&mut Contacts) -> bool,
+    {
+        self.0.retain(|_, contacts| keep(contacts));
+    }
+
+    /// Removes a collision between two entites and returns its value.
+    ///
+    /// The order of the entities does not matter.
+    pub fn remove_collision_pair(&mut self, entity1: Entity, entity2: Entity) -> Option<Contacts> {
+        self.0
+            .remove(&(entity1, entity2))
+            .or_else(|| self.0.remove(&(entity2, entity1)))
+    }
+
+    /// Removes all collisions that involve the given entity.
+    pub fn remove_collisions_with_entity(&mut self, entity: Entity) {
+        self.retain(|contacts| contacts.entity1 != entity && contacts.entity2 != entity);
+    }
+}
+
+/// Stores the collision pairs from the previous frame.
+/// This is used for detecting when collisions have started or ended.
+#[derive(Resource, Clone, Debug, Default, Deref, DerefMut, PartialEq)]
+pub(super) struct PreviousCollisions(Collisions);
+
+/// All contacts between two colliders.
+///
+/// The contacts are stored in contact manifolds.
+/// Each manifold contains one or more contact points, and each contact
+/// in a given manifold shares the same contact normal.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Contacts {
+    /// First entity in the contact.
+    pub entity1: Entity,
+    /// Second entity in the contact.
+    pub entity2: Entity,
+    /// A list of contact manifolds between two colliders.
+    /// Each manifold contains one or more contact points, but each contact
+    /// in a given manifold shares the same contact normal.
+    pub manifolds: Vec<ContactManifold>,
+    /// True if the bodies have been in contact during this frame.
+    pub during_current_frame: bool,
+    /// True if the bodies have been in contact during this substep.
+    pub during_current_substep: bool,
+}
+
+/// A contact manifold between two colliders, containing a set of contact points.
+/// Each contact in a manifold shares the same contact normal.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ContactManifold {
+    /// The contacts in this manifold.
+    pub contacts: Vec<ContactData>,
+    /// A contact normal shared by all contacts in this manifold,
+    /// expressed in the local space of the first entity.
+    pub normal1: Vector,
+    /// A contact normal shared by all contacts in this manifold,
+    /// expressed in the local space of the second entity.
+    pub normal2: Vector,
+}
+
+/// Data related to a contact between two bodies.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ContactData {
+    /// Contact point on the first entity in local coordinates.
+    pub point1: Vector,
+    /// Contact point on the second entity in local coordinates.
+    pub point2: Vector,
+    /// A contact normal expressed in the local space of the first entity.
+    pub normal1: Vector,
+    /// A contact normal expressed in the local space of the second entity.
+    pub normal2: Vector,
+    /// Penetration depth.
+    pub penetration: Scalar,
+}
+
+impl ContactData {
+    /// Returns the global contact point on the first entity,
+    /// transforming the local point by the given entity position and rotation.
+    pub fn global_point1(&self, position: &Position, rotation: &Rotation) -> Vector {
+        position.0 + rotation.rotate(self.point1)
+    }
+
+    /// Returns the global contact point on the second entity,
+    /// transforming the local point by the given entity position and rotation.
+    pub fn global_point2(&self, position: &Position, rotation: &Rotation) -> Vector {
+        position.0 + rotation.rotate(self.point2)
+    }
+
+    /// Returns the world-space contact normal pointing towards the exterior of the first entity.
+    pub fn global_normal1(&self, rotation: &Rotation) -> Vector {
+        rotation.rotate(self.normal1)
+    }
+
+    /// Returns the world-space contact normal pointing towards the exterior of the second entity.
+    pub fn global_normal2(&self, rotation: &Rotation) -> Vector {
+        rotation.rotate(self.normal2)
+    }
+}

--- a/src/plugins/narrow_phase/mod.rs
+++ b/src/plugins/narrow_phase/mod.rs
@@ -2,15 +2,16 @@
 //!
 //! See [`NarrowPhasePlugin`].
 
+mod contact_data;
 pub mod contact_query;
 
+pub use contact_data::*;
 pub use contact_query::*;
 
 use crate::prelude::*;
 use bevy::prelude::*;
 #[cfg(feature = "parallel")]
 use bevy::tasks::{ComputeTaskPool, ParallelSlice};
-use indexmap::IndexMap;
 
 /// Computes contacts between entities and sends collision events.
 ///
@@ -88,226 +89,6 @@ impl Default for NarrowPhaseConfig {
         }
     }
 }
-
-// Collisions are stored in an `IndexMap` that uses fxhash.
-// It should have faster iteration than a `HashMap` while mostly retaining other performance characteristics.
-//
-// `IndexMap` also preserves insertion order. This can be good or bad depending on the situation,
-// but it can make spawned stacks appear more consistent and uniform, for example in the `move_marbles` example.
-// ==========================================
-/// A resource that stores all collision pairs.
-///
-/// Each colliding entity pair is associated with [`Contacts`] that can be accessed and modified
-/// using the various associated methods.
-///
-/// ## Querying collisions
-///
-/// The following methods can be used for querying existing collisions:
-///
-/// - [`get`](#method.get) and [`get_mut`](#method.get_mut)
-/// - [`iter`](#method.iter) and [`iter_mut`](#method.iter_mut)
-/// - [`contains`](#method.contains)
-/// - [`collisions_with_entity`](#method.collisions_with_entity) and
-/// [`collisions_with_entity_mut`](#method.collisions_with_entity_mut)
-///
-/// The collisions can be accessed at any time, but modifications to contacts should be performed
-/// in the [`PostProcessCollisions`] schedule. Otherwise, the physics solver will use the old contact data.
-///
-/// ## Filtering and removing collisions
-///
-/// The following methods can be used for filtering or removing existing collisions:
-///
-/// - [`retain`](#method.retain)
-/// - [`remove_collision_pair`](#method.remove_collision_pair)
-/// - [`remove_collisions_with_entity`](#method.remove_collisions_with_entity)
-///
-/// Collision filtering and removal should be done in the [`PostProcessCollisions`] schedule.
-/// Otherwise, the physics solver will use the old contact data.
-///
-/// ## Adding new collisions
-///
-/// The following methods can be used for adding new collisions:
-///
-/// - [`insert_collision_pair`](#method.insert_collision_pair)
-/// - [`extend`](#method.extend)
-///
-/// The most convenient place for adding new collisions is in the [`PostProcessCollisions`] schedule.
-/// Otherwise, the physics solver might not have access to them in time.
-///
-/// ## Implementation details
-///
-/// Internally, the collisions are stored in an `IndexMap` that contains collisions from both the current frame
-/// and the previous frame, which is used for things like [collision events](Collider#collision-events).
-///
-/// However, the public methods only use the current frame's collisions. To access the internal data structure,
-/// you can use [`get_internal`](#method.get_internal) or [`get_internal_mut`](#method.get_internal_mut).
-#[derive(Resource, Clone, Debug, Default, PartialEq)]
-pub struct Collisions(IndexMap<(Entity, Entity), Contacts, fxhash::FxBuildHasher>);
-
-impl Collisions {
-    /// Returns a reference to the internal `IndexMap`.
-    pub fn get_internal(&self) -> &IndexMap<(Entity, Entity), Contacts, fxhash::FxBuildHasher> {
-        &self.0
-    }
-
-    /// Returns a mutable reference to the internal `IndexMap`.
-    pub fn get_internal_mut(
-        &mut self,
-    ) -> &mut IndexMap<(Entity, Entity), Contacts, fxhash::FxBuildHasher> {
-        &mut self.0
-    }
-
-    /// Returns a reference to the [contacts](Contacts) stored for the given entity pair if they are colliding,
-    /// else returns `None`.
-    ///
-    /// The order of the entities does not matter.
-    pub fn get(&self, entity1: Entity, entity2: Entity) -> Option<&Contacts> {
-        self.0
-            .get(&(entity1, entity2))
-            .filter(|contacts| contacts.during_current_frame)
-            .or_else(|| {
-                self.0
-                    .get(&(entity2, entity1))
-                    .filter(|contacts| contacts.during_current_frame)
-            })
-    }
-
-    /// Returns a mutable reference to the [contacts](Contacts) stored for the given entity pair if they are colliding,
-    /// else returns `None`.
-    ///
-    /// The order of the entities does not matter.
-    pub fn get_mut(&mut self, entity1: Entity, entity2: Entity) -> Option<&mut Contacts> {
-        // For lifetime reasons, the mutable borrows can't be in the same scope,
-        // so we check if the key exists first (there's probably a better way though)
-        if self.0.contains_key(&(entity1, entity2)) {
-            self.0
-                .get_mut(&(entity1, entity2))
-                .filter(|contacts| contacts.during_current_frame)
-        } else {
-            self.0
-                .get_mut(&(entity2, entity1))
-                .filter(|contacts| contacts.during_current_frame)
-        }
-    }
-
-    /// Returns `true` if the given entities have been in contact during this frame.
-    ///
-    /// The order of the entities does not matter.
-    pub fn contains(&self, entity1: Entity, entity2: Entity) -> bool {
-        // We can't use `contains` directly because we only want to
-        // count collisions that happened during this frame.
-        self.get(entity1, entity2).is_some()
-    }
-
-    /// Returns an iterator over the current collisions that have happened during the current physics frame.
-    pub fn iter(&self) -> impl Iterator<Item = &Contacts> {
-        self.0
-            .values()
-            .filter(|collision| collision.during_current_frame)
-    }
-
-    /// Returns a mutable iterator over the collisions that have happened during the current physics frame.
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Contacts> {
-        self.0
-            .values_mut()
-            .filter(|collision| collision.during_current_frame)
-    }
-
-    /// Returns an iterator over all collisions with a given entity.
-    pub fn collisions_with_entity(&self, entity: Entity) -> impl Iterator<Item = &Contacts> {
-        self.0
-            .iter()
-            .filter_map(move |((entity1, entity2), contacts)| {
-                if contacts.during_current_frame && (*entity1 == entity || *entity2 == entity) {
-                    Some(contacts)
-                } else {
-                    None
-                }
-            })
-    }
-
-    /// Returns an iterator over all collisions with a given entity.
-    pub fn collisions_with_entity_mut(
-        &mut self,
-        entity: Entity,
-    ) -> impl Iterator<Item = &mut Contacts> {
-        self.0
-            .iter_mut()
-            .filter_map(move |((entity1, entity2), contacts)| {
-                if contacts.during_current_frame && (*entity1 == entity || *entity2 == entity) {
-                    Some(contacts)
-                } else {
-                    None
-                }
-            })
-    }
-
-    /// Inserts contact data for a collision between two entities.
-    ///
-    /// If a collision entry with the same entities already exists, it will be overwritten,
-    /// and the old value will be returned. Otherwise, `None` is returned.
-    ///
-    /// **Note**: Manually inserting collisions can be error prone and should generally be avoided.
-    /// If you simply want to modify existing collisions, consider using methods like [`get_mut`](#method.get_mut)
-    /// or [`iter_mut`](#method.iter_mut).
-    pub fn insert_collision_pair(&mut self, contacts: Contacts) -> Option<Contacts> {
-        // Todo: We might want to order the data by Entity ID so that entity1, point1 etc. are for the "smaller"
-        // entity ID. This requires changes elsewhere as well though.
-        // Todo: Handle during_previous_frame nicer
-        self.0
-            .insert((contacts.entity1, contacts.entity2), contacts)
-    }
-
-    /// Extends [`Collisions`] with all collision pairs in the given iterable.
-    ///
-    /// This is mostly equivalent to calling [`insert_collision_pair`](#method.insert_collision_pair)
-    /// for each of the collision pairs.
-    pub fn extend<I: IntoIterator<Item = Contacts>>(&mut self, collisions: I) {
-        // (Note: this is a copy of `std`/`hashbrown`/`indexmap`'s reservation logic.)
-        // Keys may be already present or show multiple times in the iterator.
-        // Reserve the entire hint lower bound if the map is empty.
-        // Otherwise reserve half the hint (rounded up), so the map
-        // will only resize twice in the worst case.
-        let iter = collisions.into_iter();
-        let reserve = if self.get_internal().is_empty() {
-            iter.size_hint().0
-        } else {
-            (iter.size_hint().0 + 1) / 2
-        };
-        self.get_internal_mut().reserve(reserve);
-        iter.for_each(move |contacts| {
-            self.insert_collision_pair(contacts);
-        });
-    }
-
-    /// Retains only the collisions for which the specified predicate returns `true`.
-    /// Collisions for which the predicate returns `false` are removed from the `HashMap`.
-    pub fn retain<F>(&mut self, mut keep: F)
-    where
-        F: FnMut(&mut Contacts) -> bool,
-    {
-        self.0.retain(|_, contacts| keep(contacts));
-    }
-
-    /// Removes a collision between two entites and returns its value.
-    ///
-    /// The order of the entities does not matter.
-    pub fn remove_collision_pair(&mut self, entity1: Entity, entity2: Entity) -> Option<Contacts> {
-        self.0
-            .remove(&(entity1, entity2))
-            .or_else(|| self.0.remove(&(entity2, entity1)))
-    }
-
-    /// Removes collisions against the given entity from the `HashMap`.
-    fn remove_collisions_with_entity(&mut self, entity: Entity) {
-        self.retain(|contacts| contacts.entity1 != entity && contacts.entity2 != entity);
-    }
-}
-
-/// Stores the collision pairs from the previous frame.
-/// This is used for detecting when collisions have started or ended.
-#[derive(Resource, Clone, Debug, Default, Deref, DerefMut, PartialEq)]
-struct PreviousCollisions(Collisions);
 
 /// A [collision event](Collider#collision-events) that is sent for each contact pair during the narrow phase.
 #[derive(Event, Clone, Debug, PartialEq)]
@@ -482,7 +263,7 @@ fn check_collision_validity(
 }
 
 fn reset_substep_collision_states(mut collisions: ResMut<Collisions>) {
-    for contacts in collisions.0.values_mut() {
+    for contacts in collisions.get_internal_mut().values_mut() {
         contacts.during_current_substep = false;
     }
 }
@@ -499,7 +280,7 @@ fn send_collision_events(
     mut collision_started_ev_writer: EventWriter<CollisionStarted>,
     mut collision_ended_ev_writer: EventWriter<CollisionEnded>,
 ) {
-    for ((entity1, entity2), contacts) in collisions.0.iter_mut() {
+    for ((entity1, entity2), contacts) in collisions.get_internal_mut().iter_mut() {
         let penetrating = contacts.manifolds.iter().any(|manifold| {
             manifold
                 .contacts
@@ -574,79 +355,5 @@ fn send_collision_events(
     }
 
     // Clear collisions at the end of each frame to avoid unnecessary iteration and memory usage
-    collisions.0.clear();
-}
-
-/// All contacts between two colliders.
-///
-/// The contacts are stored in contact manifolds.
-/// Each manifold contains one or more contact points, and each contact
-/// in a given manifold shares the same contact normal.
-#[derive(Clone, Debug, PartialEq)]
-pub struct Contacts {
-    /// First entity in the contact.
-    pub entity1: Entity,
-    /// Second entity in the contact.
-    pub entity2: Entity,
-    /// A list of contact manifolds between two colliders.
-    /// Each manifold contains one or more contact points, but each contact
-    /// in a given manifold shares the same contact normal.
-    pub manifolds: Vec<ContactManifold>,
-    /// True if the bodies have been in contact during this frame.
-    pub during_current_frame: bool,
-    /// True if the bodies have been in contact during this substep.
-    pub during_current_substep: bool,
-}
-
-/// A contact manifold between two colliders, containing a set of contact points.
-/// Each contact in a manifold shares the same contact normal.
-#[derive(Clone, Debug, PartialEq)]
-pub struct ContactManifold {
-    /// The contacts in this manifold.
-    pub contacts: Vec<ContactData>,
-    /// A contact normal shared by all contacts in this manifold,
-    /// expressed in the local space of the first entity.
-    pub normal1: Vector,
-    /// A contact normal shared by all contacts in this manifold,
-    /// expressed in the local space of the second entity.
-    pub normal2: Vector,
-}
-
-/// Data related to a contact between two bodies.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct ContactData {
-    /// Contact point on the first entity in local coordinates.
-    pub point1: Vector,
-    /// Contact point on the second entity in local coordinates.
-    pub point2: Vector,
-    /// A contact normal expressed in the local space of the first entity.
-    pub normal1: Vector,
-    /// A contact normal expressed in the local space of the second entity.
-    pub normal2: Vector,
-    /// Penetration depth.
-    pub penetration: Scalar,
-}
-
-impl ContactData {
-    /// Returns the global contact point on the first entity,
-    /// transforming the local point by the given entity position and rotation.
-    pub fn global_point1(&self, position: &Position, rotation: &Rotation) -> Vector {
-        position.0 + rotation.rotate(self.point1)
-    }
-
-    /// Returns the global contact point on the second entity,
-    /// transforming the local point by the given entity position and rotation.
-    pub fn global_point2(&self, position: &Position, rotation: &Rotation) -> Vector {
-        position.0 + rotation.rotate(self.point2)
-    }
-
-    /// Returns the world-space contact normal pointing towards the exterior of the first entity.
-    pub fn global_normal1(&self, rotation: &Rotation) -> Vector {
-        rotation.rotate(self.normal1)
-    }
-
-    /// Returns the world-space contact normal pointing towards the exterior of the second entity.
-    pub fn global_normal2(&self, rotation: &Rotation) -> Vector {
-        rotation.rotate(self.normal2)
-    }
+    collisions.get_internal_mut().clear();
 }

--- a/src/plugins/solver.rs
+++ b/src/plugins/solver.rs
@@ -88,7 +88,7 @@ fn penetration_constraints(
     penetration_constraints.0.clear();
 
     for ((entity1, entity2), contacts) in collisions
-        .0
+        .get_internal()
         .iter()
         .filter(|(_, contacts)| contacts.during_current_substep)
     {


### PR DESCRIPTION
# Objective

The API for the `Collisions` resource is still lacking some important methods, and it doesn't have any high-level docs.

## Solution

I added the following methods for `Collisions`:

- `get_internal`/`get_internal_mut`
- `contains`
- `insert_collision_pair`
- `extend`
- `remove_collision_pair`

I also moved `Collisions`, `Contacts`, `ContactManifold` and `ContactData` into a new module since they were making the narrow phase module a bit verbose and difficult to follow.

`Collisions` is also much more documented now.