### PR TITLE
Add PR template

### DIFF
--- a/.github/workflows/pull_request_template.md
+++ b/.github/workflows/pull_request_template.md
@@ -1,0 +1,27 @@
+# Objective
+
+- Describe the objective or issue this PR addresses.
+- If you're fixing a specific issue, say "Fixes #X".
+
+## Solution
+
+- Describe the solution used to achieve the objective above.
+
+---
+
+## Changelog
+
+> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.
+
+- What changed as a result of this PR?
+- If applicable, organize changes under "Added", "Changed", or "Fixed" sub-headings
+- Stick to one or two sentences. If more detail is needed for a particular change, consider adding it to the "Solution" section
+  - If you can't summarize the work, your change may be unreasonably large / unrelated. Consider splitting your PR to make it easier to review and merge!
+
+## Migration Guide
+
+> This section is optional. If there are no breaking changes, you can delete this section.
+
+- If this PR is a breaking change (relative to the last release), describe how a user might need to migrate their code to support these changes.
+- Simply adding new functionality is not a breaking change.
+- Fixing behavior that was definitely a bug, rather than a questionable design choice is not a breaking change.


### PR DESCRIPTION
# Objective

Currently, there is no template for pull requests. It would be good to have a rough structure to follow to make reviewing changes easier.

## Solution

This PR adds a PR template that is mostly a copy of Bevy's PR template.