### PR TITLE
Add `Dominance`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,23 +28,24 @@ Below are some of the current features of Bevy XPBD.
 
 - Dynamic, kinematic and static rigid bodies
 - Colliders powered by [parry](https://parry.rs)
-    - Collision events: `Collision`, `CollisionStarted`, `CollisionEnded`
-    - Access to colliding entities with `CollidingEntities`
-    - Sensor colliders
-    - Collision layers
-    - Filtering and modifying collisions with custom systems
+  - Collision events: `Collision`, `CollisionStarted`, `CollisionEnded`
+  - Access to colliding entities with `CollidingEntities`
+  - Sensor colliders
+  - Collision layers
+  - Filtering and modifying collisions with custom systems
 - Material properties like restitution and friction
 - Linear and angular velocity damping for simulating drag
 - External forces, torque and impulses
 - Gravity and gravity scale for specific entities
+- Locking translational and rotational axes with `LockedAxes`
+- Rigid body dominance
 - Joints
 - Built-in constraints and support for custom constraints
 - Spatial queries
-    - Ray casting
-    - Shape casting
-    - Point projection
-    - Intersection tests
-- Locking translational and rotational axes with `LockedAxes`
+  - Ray casting
+  - Shape casting
+  - Point projection
+  - Intersection tests
 - Debug rendering colliders, AABBs, contacts, joints and axes
 - Automatically deactivating bodies with `Sleeping`
 - Configurable timesteps and substepping
@@ -131,7 +132,7 @@ fn setup(
 }
 ```
 
-https://user-images.githubusercontent.com/57632562/230185604-b40441a2-48d8-4566-9b9e-be4825f4877e.mp4
+<https://user-images.githubusercontent.com/57632562/230185604-b40441a2-48d8-4566-9b9e-be4825f4877e.mp4>
 
 ## More examples
 
@@ -143,7 +144,7 @@ In actual usage these are not needed, so you can just use `f32` or `f64` types d
 By default the examples use `f32`. To run the `f64` versions, you need to disable default features and manually choose the dimension
 and precision:
 
-```
+```shell
 cargo run --example cubes --no-default-features --features "3d f64"
 ```
 
@@ -180,7 +181,7 @@ where you can find me as `Jondolf`.
 
 Bevy XPBD is free and open source. All code in this repository is dual-licensed under either:
 
-- MIT License ([LICENSE-MIT](/LICENSE-MIT) or http://opensource.org/licenses/MIT)
-- Apache License, Version 2.0 ([LICENSE-APACHE](/LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT License ([LICENSE-MIT](/LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- Apache License, Version 2.0 ([LICENSE-APACHE](/LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
 
 at your option.

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -547,6 +547,20 @@ pub struct LinearDamping(pub Scalar);
 #[reflect(Component)]
 pub struct AngularDamping(pub Scalar);
 
+/// **Dominance** allows [dynamic rigid bodies](RigidBody::Dynamic) to dominate
+/// each other during physical interactions.
+/// 
+/// The body with a higher dominance acts as if it had infinite mass, and will be unaffected during
+/// collisions and other interactions, while the other body will be affected normally.
+/// 
+/// The dominance must be between `-127` and `127`, and the default value is `0`.
+/// Note that static and kinematic rigid bodies will always have a higher dominance value
+/// than dynamic bodies regardless of the value of this component.
+#[rustfmt::skip]
+#[derive(Component, Reflect, Debug, Clone, Copy, Default, Deref, DerefMut, From, PartialEq, PartialOrd, Eq, Ord)]
+#[reflect(Component)]
+pub struct Dominance(pub i8);
+
 #[cfg(test)]
 mod tests {
     use crate::prelude::*;

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -554,8 +554,27 @@ pub struct AngularDamping(pub Scalar);
 /// collisions and other interactions, while the other body will be affected normally.
 /// 
 /// The dominance must be between `-127` and `127`, and the default value is `0`.
-/// Note that static and kinematic rigid bodies will always have a higher dominance value
+/// Note that static and kinematic bodies will always have a higher dominance value
 /// than dynamic bodies regardless of the value of this component.
+/// 
+/// ## Example
+/// 
+/// ```
+/// use bevy::prelude::*;
+/// # #[cfg(feature = "2d")]
+/// # use bevy_xpbd_2d::prelude::*;
+/// # #[cfg(feature = "3d")]
+/// use bevy_xpbd_3d::prelude::*;
+///
+/// // Player dominates all dynamic bodies with a dominance lower than 5
+/// fn spawn_player(mut commands: Commands) {
+///     commands.spawn((
+///         RigidBody::Dynamic,
+///         Collider::capsule(1.0, 0.4),
+///         Dominance(5),
+///     ));
+/// }
+/// ```
 #[rustfmt::skip]
 #[derive(Component, Reflect, Debug, Clone, Copy, Default, Deref, DerefMut, From, PartialEq, PartialOrd, Eq, Ord)]
 #[reflect(Component)]

--- a/src/components/world_queries.rs
+++ b/src/components/world_queries.rs
@@ -73,7 +73,9 @@ impl<'w> RigidBodyQueryItem<'w> {
     }
 
     /// Returns the [dominance](Dominance) of the body.
-    /// If it isn't specified, the default of `0` is returned.
+    ///
+    /// If it isn't specified, the default of `0` is returned for dynamic bodies.
+    /// For static and kinematic bodies, `i8::MAX` (`127`) is always returned instead.
     pub fn dominance(&self) -> i8 {
         if !self.rb.is_dynamic() {
             i8::MAX

--- a/src/components/world_queries.rs
+++ b/src/components/world_queries.rs
@@ -27,6 +27,7 @@ pub struct RigidBodyQuery {
     pub friction: &'static mut Friction,
     pub restitution: &'static mut Restitution,
     pub locked_axes: Option<&'static LockedAxes>,
+    pub dominance: Option<&'static Dominance>,
 }
 
 impl<'w> RigidBodyQueryItem<'w> {
@@ -69,6 +70,16 @@ impl<'w> RigidBodyQueryItem<'w> {
     /// [`AccumulatedTranslation`] components.
     pub fn current_position(&self) -> Vector {
         self.position.0 + self.accumulated_translation.0
+    }
+
+    /// Returns the [dominance](Dominance) of the body.
+    /// If it isn't specified, the default of `0` is returned.
+    pub fn dominance(&self) -> i8 {
+        if !self.rb.is_dynamic() {
+            i8::MAX
+        } else {
+            self.dominance.map_or(0, |dominance| dominance.0)
+        }
     }
 }
 

--- a/src/constraints/angular_constraint.rs
+++ b/src/constraints/angular_constraint.rs
@@ -30,10 +30,10 @@ pub trait AngularConstraint: XpbdConstraint<2> {
         let inv_inertia2 = body2.effective_world_inv_inertia();
 
         // Apply rotational updates
-        if body1.rb.is_dynamic() {
+        if body1.rb.is_dynamic() && body1.dominance() <= body2.dominance() {
             *body1.rotation += Self::get_delta_rot(rot1, inv_inertia1, p);
         }
-        if body2.rb.is_dynamic() {
+        if body2.rb.is_dynamic() && body2.dominance() <= body1.dominance() {
             *body2.rotation -= Self::get_delta_rot(rot2, inv_inertia2, p);
         }
 

--- a/src/constraints/position_constraint.rs
+++ b/src/constraints/position_constraint.rs
@@ -31,11 +31,11 @@ pub trait PositionConstraint: XpbdConstraint<2> {
         let inv_inertia2 = body2.effective_world_inv_inertia();
 
         // Apply positional and rotational updates
-        if body1.rb.is_dynamic() {
+        if body1.rb.is_dynamic() && body1.dominance() <= body2.dominance() {
             body1.accumulated_translation.0 += p * inv_mass1;
             *body1.rotation += Self::get_delta_rot(rot1, inv_inertia1, r1, p);
         }
-        if body2.rb.is_dynamic() {
+        if body2.rb.is_dynamic() && body2.dominance() <= body1.dominance() {
             body2.accumulated_translation.0 -= p * inv_mass2;
             *body2.rotation -= Self::get_delta_rot(rot2, inv_inertia2, r2, p);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,10 +28,11 @@
 //!     - [Contact and time of impact queries](narrow_phase::contact_query)
 //! - Material properties like [restitution](Restitution) and [friction](Friction)
 //! - [Linear damping](LinearDamping) and [angular damping](AngularDamping) for simulating drag
-//! - [Gravity] and [gravity scale](GravityScale)
 //! - External [forces](ExternalForce), [torque](ExternalTorque), [impulses](ExternalImpulse) and
 //! [angular impulses](ExternalAngularImpulse)
+//! - [Gravity] and [gravity scale](GravityScale)
 //! - [Locking](LockedAxes) translational and rotational axes
+//! - [Dominance]
 //! - [Joints](joints)
 //! - Built-in [constraints] and support for [custom constraints](constraints#custom-constraints)
 //! - [Spatial queries](spatial_query)

--- a/src/plugins/setup.rs
+++ b/src/plugins/setup.rs
@@ -104,6 +104,7 @@ impl Plugin for PhysicsSetupPlugin {
             .register_type::<InverseInertia>()
             .register_type::<CenterOfMass>()
             .register_type::<LockedAxes>()
+            .register_type::<Dominance>()
             .register_type::<CollisionLayers>()
             .register_type::<CollidingEntities>()
             .register_type::<CoefficientCombine>()


### PR DESCRIPTION
# Objective

Closes #177.

Many physics engines like Rapier and PhysX support specifying the *dominance* of a dynamic rigid body. Bodies with a higher dominance act as if they had infinite mass during interactions, which can be useful for things like players pushing objects or cameras that collide with objects but don't exert forces on them.

## Solution

Add a `Dominance` component with an `i8` that controls the dominance of a body. The default dominance is `0`, but static and kinematic bodies will always have a higher dominance than dynamic bodies.

```rust
use bevy::prelude::*;
use bevy_xpbd_3d::prelude::*;

// Player dominates all dynamic bodies with a dominance lower than 5
fn spawn_player(mut commands: Commands) {
    commands.spawn((
        RigidBody::Dynamic,
        Collider::capsule(1.0, 0.4),
        Dominance(5),
    ));
}
```

## Todo

- [x] Test different configurations to make sure everything behaves correctly
- [x] Add code example(s)
- [x] Add docs