### PR TITLE
Map entities

### DIFF
--- a/crates/bevy_xpbd_3d/examples/custom_constraint.rs
+++ b/crates/bevy_xpbd_3d/examples/custom_constraint.rs
@@ -1,4 +1,7 @@
-use bevy::prelude::*;
+use bevy::{
+    ecs::entity::{EntityMapper, MapEntities},
+    prelude::*,
+};
 use bevy_xpbd_3d::{math::*, prelude::*, SubstepSchedule, SubstepSet};
 
 fn main() {
@@ -79,6 +82,13 @@ impl XpbdConstraint<2> for CustomDistanceConstraint {
 
         // Apply positional correction (method from PositionConstraint)
         self.apply_positional_correction(body1, body2, delta_lagrange, n, r1, r2);
+    }
+}
+
+impl MapEntities for CustomDistanceConstraint {
+    fn map_entities(&mut self, entity_mapper: &mut EntityMapper) {
+        self.entity1 = entity_mapper.get_or_reserve(self.entity1);
+        self.entity2 = entity_mapper.get_or_reserve(self.entity2);
     }
 }
 

--- a/src/constraints/joints/distance.rs
+++ b/src/constraints/joints/distance.rs
@@ -1,12 +1,16 @@
 //! [`DistanceJoint`] component.
 
 use crate::prelude::*;
-use bevy::{ecs::entity::MapEntities, prelude::*};
+use bevy::{
+    ecs::{entity::MapEntities, reflect::ReflectMapEntities},
+    prelude::*,
+};
 
 /// A distance joint keeps the attached bodies at a certain distance from each other while while allowing rotation around all axes.
 ///
 /// Distance joints can be useful for things like springs, muscles, and mass-spring networks.
-#[derive(Component, Clone, Copy, Debug, PartialEq)]
+#[derive(Component, Clone, Copy, Debug, PartialEq, Reflect)]
+#[reflect(MapEntities)]
 pub struct DistanceJoint {
     /// First entity constrained by the joint.
     pub entity1: Entity,

--- a/src/constraints/joints/distance.rs
+++ b/src/constraints/joints/distance.rs
@@ -1,7 +1,7 @@
 //! [`DistanceJoint`] component.
 
 use crate::prelude::*;
-use bevy::prelude::*;
+use bevy::{ecs::entity::MapEntities, prelude::*};
 
 /// A distance joint keeps the attached bodies at a certain distance from each other while while allowing rotation around all axes.
 ///
@@ -193,3 +193,10 @@ impl DistanceJoint {
 impl PositionConstraint for DistanceJoint {}
 
 impl AngularConstraint for DistanceJoint {}
+
+impl MapEntities for DistanceJoint {
+    fn map_entities(&mut self, entity_mapper: &mut bevy::ecs::entity::EntityMapper) {
+        self.entity1 = entity_mapper.get_or_reserve(self.entity1);
+        self.entity2 = entity_mapper.get_or_reserve(self.entity2);
+    }
+}

--- a/src/constraints/joints/distance.rs
+++ b/src/constraints/joints/distance.rs
@@ -2,7 +2,10 @@
 
 use crate::prelude::*;
 use bevy::{
-    ecs::{entity::MapEntities, reflect::ReflectMapEntities},
+    ecs::{
+        entity::{EntityMapper, MapEntities},
+        reflect::ReflectMapEntities,
+    },
     prelude::*,
 };
 
@@ -199,7 +202,7 @@ impl PositionConstraint for DistanceJoint {}
 impl AngularConstraint for DistanceJoint {}
 
 impl MapEntities for DistanceJoint {
-    fn map_entities(&mut self, entity_mapper: &mut bevy::ecs::entity::EntityMapper) {
+    fn map_entities(&mut self, entity_mapper: &mut EntityMapper) {
         self.entity1 = entity_mapper.get_or_reserve(self.entity1);
         self.entity2 = entity_mapper.get_or_reserve(self.entity2);
     }

--- a/src/constraints/joints/fixed.rs
+++ b/src/constraints/joints/fixed.rs
@@ -1,7 +1,7 @@
 //! [`FixedJoint`] component.
 
 use crate::prelude::*;
-use bevy::prelude::*;
+use bevy::{ecs::entity::MapEntities, prelude::*};
 
 /// A fixed joint prevents any relative movement of the attached bodies.
 ///
@@ -152,3 +152,10 @@ impl FixedJoint {
 impl PositionConstraint for FixedJoint {}
 
 impl AngularConstraint for FixedJoint {}
+
+impl MapEntities for FixedJoint {
+    fn map_entities(&mut self, entity_mapper: &mut bevy::ecs::entity::EntityMapper) {
+        self.entity1 = entity_mapper.get_or_reserve(self.entity1);
+        self.entity2 = entity_mapper.get_or_reserve(self.entity2);
+    }
+}

--- a/src/constraints/joints/fixed.rs
+++ b/src/constraints/joints/fixed.rs
@@ -1,7 +1,10 @@
 //! [`FixedJoint`] component.
 
 use crate::prelude::*;
-use bevy::{ecs::entity::MapEntities, prelude::*};
+use bevy::{
+    ecs::entity::{EntityMapper, MapEntities},
+    prelude::*,
+};
 
 /// A fixed joint prevents any relative movement of the attached bodies.
 ///
@@ -154,7 +157,7 @@ impl PositionConstraint for FixedJoint {}
 impl AngularConstraint for FixedJoint {}
 
 impl MapEntities for FixedJoint {
-    fn map_entities(&mut self, entity_mapper: &mut bevy::ecs::entity::EntityMapper) {
+    fn map_entities(&mut self, entity_mapper: &mut EntityMapper) {
         self.entity1 = entity_mapper.get_or_reserve(self.entity1);
         self.entity2 = entity_mapper.get_or_reserve(self.entity2);
     }

--- a/src/constraints/joints/mod.rs
+++ b/src/constraints/joints/mod.rs
@@ -96,10 +96,10 @@ pub use revolute::*;
 pub use spherical::*;
 
 use crate::prelude::*;
-use bevy::prelude::*;
+use bevy::{ecs::entity::MapEntities, prelude::*};
 
 /// A trait for [joints].
-pub trait Joint: Component + PositionConstraint + AngularConstraint {
+pub trait Joint: Component + PositionConstraint + AngularConstraint + MapEntities {
     /// Creates a new joint between two entities.
     fn new(entity1: Entity, entity2: Entity) -> Self;
 

--- a/src/constraints/joints/mod.rs
+++ b/src/constraints/joints/mod.rs
@@ -96,10 +96,10 @@ pub use revolute::*;
 pub use spherical::*;
 
 use crate::prelude::*;
-use bevy::{ecs::entity::MapEntities, prelude::*};
+use bevy::prelude::*;
 
 /// A trait for [joints].
-pub trait Joint: Component + PositionConstraint + AngularConstraint + MapEntities {
+pub trait Joint: Component + PositionConstraint + AngularConstraint {
     /// Creates a new joint between two entities.
     fn new(entity1: Entity, entity2: Entity) -> Self;
 

--- a/src/constraints/joints/mod.rs
+++ b/src/constraints/joints/mod.rs
@@ -233,7 +233,7 @@ pub trait Joint: Component + PositionConstraint + AngularConstraint {
 }
 
 /// A limit that indicates that the distance between two points should be between `min` and `max`.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Reflect)]
 pub struct DistanceLimit {
     /// The minimum distance between two points.
     pub min: Scalar,

--- a/src/constraints/joints/prismatic.rs
+++ b/src/constraints/joints/prismatic.rs
@@ -1,7 +1,10 @@
 //! [`PrismaticJoint`] component.
 
 use crate::prelude::*;
-use bevy::{ecs::entity::MapEntities, prelude::*};
+use bevy::{
+    ecs::entity::{EntityMapper, MapEntities},
+    prelude::*,
+};
 
 /// A prismatic joint prevents relative movement of the attached bodies, except for translation along one `free_axis`.
 ///
@@ -250,7 +253,7 @@ impl PositionConstraint for PrismaticJoint {}
 impl AngularConstraint for PrismaticJoint {}
 
 impl MapEntities for PrismaticJoint {
-    fn map_entities(&mut self, entity_mapper: &mut bevy::ecs::entity::EntityMapper) {
+    fn map_entities(&mut self, entity_mapper: &mut EntityMapper) {
         self.entity1 = entity_mapper.get_or_reserve(self.entity1);
         self.entity2 = entity_mapper.get_or_reserve(self.entity2);
     }

--- a/src/constraints/joints/prismatic.rs
+++ b/src/constraints/joints/prismatic.rs
@@ -1,7 +1,7 @@
 //! [`PrismaticJoint`] component.
 
 use crate::prelude::*;
-use bevy::prelude::*;
+use bevy::{ecs::entity::MapEntities, prelude::*};
 
 /// A prismatic joint prevents relative movement of the attached bodies, except for translation along one `free_axis`.
 ///
@@ -248,3 +248,10 @@ impl PrismaticJoint {
 impl PositionConstraint for PrismaticJoint {}
 
 impl AngularConstraint for PrismaticJoint {}
+
+impl MapEntities for PrismaticJoint {
+    fn map_entities(&mut self, entity_mapper: &mut bevy::ecs::entity::EntityMapper) {
+        self.entity1 = entity_mapper.get_or_reserve(self.entity1);
+        self.entity2 = entity_mapper.get_or_reserve(self.entity2);
+    }
+}

--- a/src/constraints/joints/revolute.rs
+++ b/src/constraints/joints/revolute.rs
@@ -1,7 +1,10 @@
 //! [`RevoluteJoint`] component.
 
 use crate::prelude::*;
-use bevy::{ecs::entity::MapEntities, prelude::*};
+use bevy::{
+    ecs::entity::{EntityMapper, MapEntities},
+    prelude::*,
+};
 
 /// A revolute joint prevents relative movement of the attached bodies, except for rotation around one `aligned_axis`.
 ///
@@ -220,7 +223,7 @@ impl PositionConstraint for RevoluteJoint {}
 impl AngularConstraint for RevoluteJoint {}
 
 impl MapEntities for RevoluteJoint {
-    fn map_entities(&mut self, entity_mapper: &mut bevy::ecs::entity::EntityMapper) {
+    fn map_entities(&mut self, entity_mapper: &mut EntityMapper) {
         self.entity1 = entity_mapper.get_or_reserve(self.entity1);
         self.entity2 = entity_mapper.get_or_reserve(self.entity2);
     }

--- a/src/constraints/joints/revolute.rs
+++ b/src/constraints/joints/revolute.rs
@@ -1,7 +1,7 @@
 //! [`RevoluteJoint`] component.
 
 use crate::prelude::*;
-use bevy::prelude::*;
+use bevy::{ecs::entity::MapEntities, prelude::*};
 
 /// A revolute joint prevents relative movement of the attached bodies, except for rotation around one `aligned_axis`.
 ///
@@ -218,3 +218,10 @@ impl RevoluteJoint {
 impl PositionConstraint for RevoluteJoint {}
 
 impl AngularConstraint for RevoluteJoint {}
+
+impl MapEntities for RevoluteJoint {
+    fn map_entities(&mut self, entity_mapper: &mut bevy::ecs::entity::EntityMapper) {
+        self.entity1 = entity_mapper.get_or_reserve(self.entity1);
+        self.entity2 = entity_mapper.get_or_reserve(self.entity2);
+    }
+}

--- a/src/constraints/joints/spherical.rs
+++ b/src/constraints/joints/spherical.rs
@@ -1,7 +1,10 @@
 //! [`SphericalJoint`] component.
 
 use crate::prelude::*;
-use bevy::{ecs::entity::MapEntities, prelude::*};
+use bevy::{
+    ecs::entity::{EntityMapper, MapEntities},
+    prelude::*,
+};
 
 /// A spherical joint prevents relative translation of the attached bodies while allowing rotation around all axes.
 ///
@@ -261,7 +264,7 @@ impl PositionConstraint for SphericalJoint {}
 impl AngularConstraint for SphericalJoint {}
 
 impl MapEntities for SphericalJoint {
-    fn map_entities(&mut self, entity_mapper: &mut bevy::ecs::entity::EntityMapper) {
+    fn map_entities(&mut self, entity_mapper: &mut EntityMapper) {
         self.entity1 = entity_mapper.get_or_reserve(self.entity1);
         self.entity2 = entity_mapper.get_or_reserve(self.entity2);
     }

--- a/src/constraints/joints/spherical.rs
+++ b/src/constraints/joints/spherical.rs
@@ -1,7 +1,7 @@
 //! [`SphericalJoint`] component.
 
 use crate::prelude::*;
-use bevy::prelude::*;
+use bevy::{ecs::entity::MapEntities, prelude::*};
 
 /// A spherical joint prevents relative translation of the attached bodies while allowing rotation around all axes.
 ///
@@ -259,3 +259,10 @@ impl SphericalJoint {
 impl PositionConstraint for SphericalJoint {}
 
 impl AngularConstraint for SphericalJoint {}
+
+impl MapEntities for SphericalJoint {
+    fn map_entities(&mut self, entity_mapper: &mut bevy::ecs::entity::EntityMapper) {
+        self.entity1 = entity_mapper.get_or_reserve(self.entity1);
+        self.entity2 = entity_mapper.get_or_reserve(self.entity2);
+    }
+}

--- a/src/constraints/mod.rs
+++ b/src/constraints/mod.rs
@@ -207,9 +207,10 @@ pub use penetration::*;
 pub use position_constraint::PositionConstraint;
 
 use crate::prelude::*;
+use bevy::ecs::entity::MapEntities;
 
 /// A trait for all XPBD [constraints].
-pub trait XpbdConstraint<const ENTITY_COUNT: usize> {
+pub trait XpbdConstraint<const ENTITY_COUNT: usize>: MapEntities {
     /// The entities participating in the constraint.
     fn entities(&self) -> [Entity; ENTITY_COUNT];
 

--- a/src/constraints/penetration.rs
+++ b/src/constraints/penetration.rs
@@ -1,7 +1,10 @@
 //! Penetration constraint.
 
 use crate::prelude::*;
-use bevy::{ecs::entity::MapEntities, prelude::*};
+use bevy::{
+    ecs::entity::{EntityMapper, MapEntities},
+    prelude::*,
+};
 
 /// A constraint between two bodies that prevents overlap with a given compliance.
 ///
@@ -184,7 +187,7 @@ impl PenetrationConstraint {
 impl PositionConstraint for PenetrationConstraint {}
 
 impl MapEntities for PenetrationConstraint {
-    fn map_entities(&mut self, entity_mapper: &mut bevy::ecs::entity::EntityMapper) {
+    fn map_entities(&mut self, entity_mapper: &mut EntityMapper) {
         self.entity1 = entity_mapper.get_or_reserve(self.entity1);
         self.entity2 = entity_mapper.get_or_reserve(self.entity2);
     }

--- a/src/constraints/penetration.rs
+++ b/src/constraints/penetration.rs
@@ -1,7 +1,7 @@
 //! Penetration constraint.
 
 use crate::prelude::*;
-use bevy::prelude::*;
+use bevy::{ecs::entity::MapEntities, prelude::*};
 
 /// A constraint between two bodies that prevents overlap with a given compliance.
 ///
@@ -182,3 +182,10 @@ impl PenetrationConstraint {
 }
 
 impl PositionConstraint for PenetrationConstraint {}
+
+impl MapEntities for PenetrationConstraint {
+    fn map_entities(&mut self, entity_mapper: &mut bevy::ecs::entity::EntityMapper) {
+        self.entity1 = entity_mapper.get_or_reserve(self.entity1);
+        self.entity2 = entity_mapper.get_or_reserve(self.entity2);
+    }
+}

--- a/src/plugins/spatial_query/ray_caster.rs
+++ b/src/plugins/spatial_query/ray_caster.rs
@@ -1,5 +1,8 @@
 use crate::prelude::*;
-use bevy::prelude::*;
+use bevy::{
+    ecs::entity::{EntityMapper, MapEntities},
+    prelude::*,
+};
 use parry::query::{
     details::RayCompositeShapeToiAndNormalBestFirstVisitor, visitors::RayIntersectionsVisitor,
 };
@@ -345,6 +348,14 @@ impl RayHits {
     }
 }
 
+impl MapEntities for RayHits {
+    fn map_entities(&mut self, entity_mapper: &mut EntityMapper) {
+        for hit in &mut self.vector {
+            hit.map_entities(entity_mapper);
+        }
+    }
+}
+
 /// Data related to a hit during a [ray cast](spatial_query#ray-casting).
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RayHitData {
@@ -354,4 +365,10 @@ pub struct RayHitData {
     pub time_of_impact: Scalar,
     /// The normal at the point of intersection.
     pub normal: Vector,
+}
+
+impl MapEntities for RayHitData {
+    fn map_entities(&mut self, entity_mapper: &mut EntityMapper) {
+        self.entity = entity_mapper.get_or_reserve(self.entity);
+    }
 }

--- a/src/plugins/spatial_query/shape_caster.rs
+++ b/src/plugins/spatial_query/shape_caster.rs
@@ -1,5 +1,8 @@
 use crate::prelude::*;
-use bevy::prelude::*;
+use bevy::{
+    ecs::entity::{EntityMapper, MapEntities},
+    prelude::*,
+};
 use parry::query::details::TOICompositeShapeShapeBestFirstVisitor;
 
 /// A component used for [shape casting](spatial_query#shape-casting).
@@ -363,6 +366,14 @@ impl ShapeHits {
     }
 }
 
+impl MapEntities for ShapeHits {
+    fn map_entities(&mut self, entity_mapper: &mut EntityMapper) {
+        for hit in &mut self.vector {
+            hit.map_entities(entity_mapper);
+        }
+    }
+}
+
 /// Data related to a hit during a [shape cast](spatial_query#shape-casting).
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ShapeHitData {
@@ -383,4 +394,10 @@ pub struct ShapeHitData {
     /// The outward normal on the collider that was hit by the shape cast, at the time of impact,
     /// expressed in the local space of the collider shape.
     pub normal2: Vector,
+}
+
+impl MapEntities for ShapeHitData {
+    fn map_entities(&mut self, entity_mapper: &mut EntityMapper) {
+        self.entity = entity_mapper.get_or_reserve(self.entity);
+    }
 }


### PR DESCRIPTION
# Objective

For bevy_ggrs and other snapshot/save/load/scenes functionality to work the `MapEntities` trait is needed in order to fix entity ids after loading.

## Solution

Implement `MapEntities` for the components that have `Entity`s as fields.

---

## Changelog

- Components now implement `MapEntities`

## Migration Guide

- The `XpbdConstraint` trait now requires `MapEntities` if you implemented custom `XpbdConstraint`s you should now implement the `MapEntities` trait on your types.