### PR TITLE
Expose `SyncConfig` fields

### DIFF
--- a/src/plugins/sync.rs
+++ b/src/plugins/sync.rs
@@ -121,10 +121,10 @@ impl Plugin for SyncPlugin {
 #[reflect(Resource)]
 pub struct SyncConfig {
     /// Updates transforms based on [`Position`] and [`Rotation`] changes. Defaults to true.
-    position_to_transform: bool,
+    pub position_to_transform: bool,
     /// Updates [`Position`] and [`Rotation`] based on transform changes,
     /// allowing you to move bodies using `Transform`. Defaults to true.
-    transform_to_position: bool,
+    pub transform_to_position: bool,
 }
 
 impl Default for SyncConfig {


### PR DESCRIPTION
# Objective

In order for `SyncConfig` to be useful, and provide some way of disabling `Transform` to `Position` synchronization. There needs to be some way to mutate it's fields.

## Solution

- Just make the fields public

---

## Changelog

- `Transform` to `Position` synchronization and vice versa can now be disabled through `SyncConfig`.