### PR TITLE
Warn about explosive behavior caused by overlapping at spawn

### DIFF
--- a/src/components/world_queries.rs
+++ b/src/components/world_queries.rs
@@ -9,7 +9,7 @@ use std::ops::{AddAssign, SubAssign};
 #[world_query(mutable)]
 pub struct RigidBodyQuery {
     pub entity: Entity,
-    pub rb: &'static mut RigidBody,
+    pub rb: Ref<'static, RigidBody>,
     pub position: &'static mut Position,
     pub rotation: &'static mut Rotation,
     pub previous_position: &'static mut PreviousPosition,

--- a/src/plugins/solver.rs
+++ b/src/plugins/solver.rs
@@ -153,6 +153,13 @@ fn penetration_constraints(
                 commands.entity(body2.entity).remove::<Sleeping>();
             }
 
+            if body1.rb.is_added() || body2.rb.is_added() {
+                warn!(
+                    "{:?} and {:?} are overlapping at spawn, which can result in explosive behavior.",
+                    body1.entity, body2.entity,
+                );
+            }
+
             // Get combined friction and restitution coefficients of the colliders
             // or the bodies they are attached to.
             let friction = collider1


### PR DESCRIPTION
# Objective

When a dynamic body is spawned overlapping another rigid body, it can gain a lot of velocity, which causes explosive behavior. This can currently be a bit unclear for users who aren't familiar with the internals of the engine.

## Solution

Print a warning when a dynamic body is overlapping with another body at spawn. The warning is in the following format:

```rust
warn!(
    "{:?} and {:?} are overlapping at spawn, which can result in explosive behavior.",
    body1.entity, body2.entity,
);
```

## Potential future work

We could have an option to make these overlapping scenarios gently move the bodies into a non-penetrating state rather than cause a large burst of velocity.