### PR TITLE
Enable bevy's png feature in the 3d examples

### DIFF
--- a/crates/examples_common_3d/Cargo.toml
+++ b/crates/examples_common_3d/Cargo.toml
@@ -16,6 +16,7 @@ bevy = { version = "0.11", default-features = false, features = [
     "default_font",
     "tonemapping_luts",
     "ktx2",
+    "png",
     "zstd",
     "bevy_winit",
     "x11",                # github actions runners don't have libxkbcommon installed, so can't use wayland


### PR DESCRIPTION
# Objective

When running the async colliders example, the following warnings are printed, and Ferris does not appear.

```
2023-10-27T23:27:51.794954Z  WARN bevy_gltf::loader: Error loading glTF texture: You may need to add the feature for the file format: failed to load an image: The image format Png is not supported
2023-10-27T23:27:51.794964Z  WARN bevy_gltf::loader: Error loading glTF texture: You may need to add the feature for the file format: failed to load an image: The image format Png is not supported
2023-10-27T23:27:51.794967Z  WARN bevy_gltf::loader: Error loading glTF texture: You may need to add the feature for the file format: failed to load an image: The image format Png is not supported
```

## Solution

- Enable bevy's png feature in the 3d examples