### PR TITLE
Add `ignore_self` property for `RayCaster` and `ShapeCaster`

### DIFF
--- a/crates/bevy_xpbd_3d/examples/basic_dynamic_character.rs
+++ b/crates/bevy_xpbd_3d/examples/basic_dynamic_character.rs
@@ -58,7 +58,6 @@ fn setup(
             Quaternion::default(),
             Vector::NEG_Y,
         )
-        .with_ignore_origin_penetration(true) // Don't count player's collider
         .with_max_time_of_impact(0.2)
         .with_max_hits(1),
         Restitution::new(0.0).with_combine_rule(CoefficientCombine::Min),

--- a/crates/bevy_xpbd_3d/examples/basic_kinematic_character.rs
+++ b/crates/bevy_xpbd_3d/examples/basic_kinematic_character.rs
@@ -65,7 +65,6 @@ fn setup(
             Quaternion::default(),
             Vector::NEG_Y,
         )
-        .with_ignore_origin_penetration(true) // Don't count player's collider
         .with_max_time_of_impact(0.11)
         .with_max_hits(1),
         Player,

--- a/src/plugins/spatial_query/mod.rs
+++ b/src/plugins/spatial_query/mod.rs
@@ -363,10 +363,10 @@ fn update_shape_caster_positions(
     }
 }
 
-fn raycast(mut rays: Query<(&RayCaster, &mut RayHits)>, spatial_query: SpatialQuery) {
-    for (ray, mut hits) in &mut rays {
+fn raycast(mut rays: Query<(Entity, &RayCaster, &mut RayHits)>, spatial_query: SpatialQuery) {
+    for (entity, ray, mut hits) in &mut rays {
         if ray.enabled {
-            ray.cast(&mut hits, &spatial_query.query_pipeline);
+            ray.cast(entity, &mut hits, &spatial_query.query_pipeline);
         } else if !hits.is_empty() {
             hits.clear();
         }
@@ -374,12 +374,12 @@ fn raycast(mut rays: Query<(&RayCaster, &mut RayHits)>, spatial_query: SpatialQu
 }
 
 fn shapecast(
-    mut shape_casters: Query<(&ShapeCaster, &mut ShapeHits)>,
+    mut shape_casters: Query<(Entity, &ShapeCaster, &mut ShapeHits)>,
     spatial_query: SpatialQuery,
 ) {
-    for (shape_caster, mut hits) in &mut shape_casters {
+    for (entity, shape_caster, mut hits) in &mut shape_casters {
         if shape_caster.enabled {
-            shape_caster.cast(&mut hits, &spatial_query.query_pipeline);
+            shape_caster.cast(entity, &mut hits, &spatial_query.query_pipeline);
         } else if !hits.is_empty() {
             hits.clear();
         }


### PR DESCRIPTION
# Objective

People often use ray and shape casters on entities with colliders, but don't want to count hits against those colliders. This currently requires tinkering with `ignore_origin_penetration`, `excluded_entities` or collision layers, which is very inconvenient. People expect the caster to ignore its own collider by default since you very rarely need to detect hits against it.

## Solution

Add an `ignore_self` property for `RayCaster` and `ShapeCaster`. It's true by default, but can be configured like `.with_ignore_self(false)`.