### PR TITLE
Make `debug-plugin` a default feature and improve docs

### DIFF
--- a/crates/bevy_xpbd_2d/Cargo.toml
+++ b/crates/bevy_xpbd_2d/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["gamedev", "physics", "simulation", "xpbd", "bevy"]
 categories = ["game-development", "science", "simulation"]
 
 [features]
-default = ["2d", "f32", "parallel"]
+default = ["2d", "f32", "debug-plugin", "parallel"]
 2d = []
 f32 = ["dep:parry2d"]
 f64 = ["dep:parry2d-f64"]

--- a/crates/bevy_xpbd_3d/Cargo.toml
+++ b/crates/bevy_xpbd_3d/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["gamedev", "physics", "simulation", "xpbd", "bevy"]
 categories = ["game-development", "science", "simulation"]
 
 [features]
-default = ["3d", "f32", "async-collider", "parallel"]
+default = ["3d", "f32", "async-collider", "debug-plugin", "parallel"]
 3d = []
 f32 = ["dep:parry3d"]
 f64 = ["dep:parry3d-f64"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@
     feature = "3d",
     doc = "| `async-collider`       | Allows you to generate [`Collider`]s from mesh handles and scenes.                                                               | Yes                     |"
 )]
-//! | `debug-plugin`         | Enables the `PhysicsDebugPlugin` used for rendering physics objects and properties.                                              | No                      |
+//! | `debug-plugin`         | Enables physics debug rendering using the [`PhysicsDebugPlugin`]. The plugin must be added separately.                           | Yes                     |
 //! | `enhanced-determinism` | Enables increased determinism.                                                                                                   | No                      |
 //! | `parallel`             | Enables some extra multithreading, which improves performance for larger simulations but can add some overhead for smaller ones. | Yes                     |
 //! | `simd`                 | Enables [SIMD] optimizations.                                                                                                    | No                      |
@@ -167,6 +167,7 @@
 //! - [Physics timestep](PhysicsTimestep)
 //! - [Speed up or slow down time](PhysicsTimescale)
 //! - [Configure simulation fidelity with substeps](SubstepCount)
+//! - [Render physics objects for debugging](PhysicsDebugPlugin)
 //!
 //! ### Scheduling
 //!

--- a/src/plugins/debug/configuration.rs
+++ b/src/plugins/debug/configuration.rs
@@ -1,9 +1,38 @@
 use crate::prelude::*;
 use bevy::prelude::*;
 
-/// Controls the global physics debug configuration.
+/// Controls the global physics debug configuration. See [`PhysicsDebugPlugin`]
 ///
 /// To configure the debug rendering of specific entities, use the [`DebugRender`] component.
+///
+/// ## Example
+///
+/// ```no_run
+/// use bevy::prelude::*;
+#[cfg_attr(feature = "2d", doc = "use bevy_xpbd_2d::prelude::*;")]
+#[cfg_attr(feature = "3d", doc = "use bevy_xpbd_3d::prelude::*;")]
+
+/// fn main() {
+///     App::new()
+///         .add_plugins((
+///             DefaultPlugins,
+///             PhysicsPlugins::default(),
+///             // Enables debug rendering
+///             PhysicsDebugPlugin::default(),
+///         ))
+///         // Overwrite default debug configuration (optional)
+///         .insert_resource(PhysicsDebugConfig {
+///             aabb_color: Some(Color::WHITE),
+///             ..default()
+///         })
+///         .run();
+/// }
+///
+/// fn setup(mut commands: Commands) {
+///     // This rigid body and its collider and AABB will get rendered
+///     commands.spawn((RigidBody::Dynamic, Collider::ball(0.5)));
+/// }
+/// ```
 #[derive(Reflect, Resource)]
 #[reflect(Resource)]
 pub struct PhysicsDebugConfig {
@@ -287,9 +316,38 @@ impl PhysicsDebugConfig {
     }
 }
 
-/// A component for the debug render configuration of an entity.
+/// A component for the debug render configuration of an entity. See [`PhysicsDebugPlugin`].
 ///
 /// This overwrites the global [`PhysicsDebugConfig`] for this specific entity.
+///
+/// ## Example
+///
+/// ```no_run
+/// use bevy::prelude::*;
+#[cfg_attr(feature = "2d", doc = "use bevy_xpbd_2d::prelude::*;")]
+#[cfg_attr(feature = "3d", doc = "use bevy_xpbd_3d::prelude::*;")]
+///
+/// fn main() {
+///     App::new()
+///         .add_plugins((
+///             DefaultPlugins,
+///             PhysicsPlugins::default(),
+///             // Enables debug rendering
+///             PhysicsDebugPlugin::default(),
+///         ))
+///         .run();
+/// }
+///
+/// fn setup(mut commands: Commands) {
+///     // This rigid body and its collider and AABB will get rendered
+///     commands.spawn((
+///         RigidBody::Dynamic,
+///         Collider::ball(0.5),
+///         // Overwrite default collider color (optional)
+///         DebugRender::default().with_collider_color(Color::RED),
+///     ));
+/// }
+/// ```
 #[derive(Component, Reflect, Clone, Copy, PartialEq)]
 #[reflect(Component)]
 pub struct DebugRender {

--- a/src/plugins/debug/mod.rs
+++ b/src/plugins/debug/mod.rs
@@ -11,23 +11,58 @@ pub use renderer::*;
 use crate::prelude::*;
 use bevy::{ecs::query::Has, prelude::*};
 
-/// Renders physics objects and properties for debugging purposes.
+/// A plugin that renders physics objects and properties for debugging purposes.
+/// It is not enabled by default and must be added manually.
 ///
 /// Currently, the following are supported for debug rendering:
 ///
-/// - Entity axes
+/// - The axes and center of mass of [rigid bodies](RigidBody)
 /// - [AABBs](ColliderAabb)
 /// - [Collider] wireframes
-/// - Use different colors for [sleeping](Sleeping) bodies
+/// - Using different colors for [sleeping](Sleeping) bodies
 /// - [Contacts]
 /// - [Joints](joints)
 /// - [`RayCaster`]
 /// - [`ShapeCaster`]
 /// - Changing the visibility of entities to only show debug rendering
 ///
-/// By default, only axes, colliders and joints are debug rendered. You can use the [`PhysicsDebugConfig`]
-/// resource for the global configuration and the [`DebugRender`] component
-/// for entity-level configuration.
+/// By default, [AABBs](ColliderAabb) and [contacts](Contacts) are not debug rendered.
+/// You can use the [`PhysicsDebugConfig`] resource for the global configuration and the
+/// [`DebugRender`] component for entity-level configuration.
+///
+/// ## Example
+///
+/// ```no_run
+/// use bevy::prelude::*;
+#[cfg_attr(feature = "2d", doc = "use bevy_xpbd_2d::prelude::*;")]
+#[cfg_attr(feature = "3d", doc = "use bevy_xpbd_3d::prelude::*;")]
+///
+/// fn main() {
+///     App::new()
+///         .add_plugins((
+///             DefaultPlugins,
+///             PhysicsPlugins::default(),
+///             // Enables debug rendering
+///             PhysicsDebugPlugin::default(),
+///         ))
+///         // Overwrite default debug configuration (optional)
+///         .insert_resource(PhysicsDebugConfig {
+///             aabb_color: Some(Color::WHITE),
+///             ..default()
+///         })
+///         .run();
+/// }
+///
+/// fn setup(mut commands: Commands) {
+///     // This rigid body and its collider and AABB will get rendered
+///     commands.spawn((
+///         RigidBody::Dynamic,
+///         Collider::ball(0.5),
+///         // Overwrite default collider color (optional)
+///         DebugRender::default().with_collider_color(Color::RED),
+///     ));
+/// }
+/// ```
 pub struct PhysicsDebugPlugin {
     schedule: Box<dyn ScheduleLabel>,
 }

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -215,15 +215,7 @@ impl Default for PhysicsPlugins {
 
 impl PluginGroup for PhysicsPlugins {
     fn build(self) -> PluginGroupBuilder {
-        #[allow(unused_mut)]
-        let mut builder = PluginGroupBuilder::start::<Self>();
-
-        #[cfg(feature = "debug-plugin")]
-        {
-            builder = builder.add(PhysicsDebugPlugin::default());
-        }
-
-        builder
+        PluginGroupBuilder::start::<Self>()
             .add(PhysicsSetupPlugin::new(self.schedule.dyn_clone()))
             .add(PreparePlugin::new(self.schedule.dyn_clone()))
             .add(BroadPhasePlugin)


### PR DESCRIPTION
# Objective

Currently, the `PhysicsDebugPlugin` is behind a feature flag that isn't enabled by default. Because of this, it also isn't linked nicely in the docs, and we can't have a debug rendering example without requiring users to add feature flags manually. This makes it a bit less discoverable and a bit inconvenient.

## Solution

Make `debug-plugin` a default feature and improve the debug rendering docs, also adding code examples. Debug rendering can now be enabled by adding the `PhysicsDebugPlugin`.

---

## Migration Guide

If you want to enable debug rendering, just having the `debug-render` feature enabled isn't enough. You also need to add `PhysicsDebugPlugin` manually.