### PR TITLE
Improve movement in examples

### DIFF
--- a/crates/bevy_xpbd_2d/examples/chain_2d.rs
+++ b/crates/bevy_xpbd_2d/examples/chain_2d.rs
@@ -43,7 +43,7 @@ fn setup(
             FollowMouse,
             MaterialMesh2dBundle {
                 mesh: particle_mesh.clone(),
-                material: particle_material.clone_weak(),
+                material: particle_material.clone(),
                 ..default()
             },
         ))
@@ -57,7 +57,7 @@ fn setup(
                 MassPropertiesBundle::new_computed(&Collider::ball(particle_radius), 1.0),
                 MaterialMesh2dBundle {
                     mesh: particle_mesh.clone(),
-                    material: particle_material.clone_weak(),
+                    material: particle_material.clone(),
                     transform: Transform::from_xyz(
                         0.0,
                         i as f32 * (particle_radius as f32 * 2.0 + 1.0),

--- a/crates/bevy_xpbd_2d/examples/many_shapes.rs
+++ b/crates/bevy_xpbd_2d/examples/many_shapes.rs
@@ -136,21 +136,27 @@ fn setup(
 }
 
 fn movement(
+    time: Res<Time>,
     keyboard_input: Res<Input<KeyCode>>,
     mut marbles: Query<&mut LinearVelocity, With<Controllable>>,
 ) {
+    // Precision is adjusted so that the example works with
+    // both the `f32` and `f64` features. Otherwise you don't need this.
+    let delta_time = time.delta_seconds_f64().adjust_precision();
+
     for mut linear_velocity in &mut marbles {
-        if keyboard_input.pressed(KeyCode::Up) {
-            linear_velocity.y += 50.0;
+        if keyboard_input.any_pressed([KeyCode::W, KeyCode::Up]) {
+            // Use a higher acceleration for upwards movement to overcome gravity
+            linear_velocity.y += 2500.0 * delta_time;
         }
-        if keyboard_input.pressed(KeyCode::Down) {
-            linear_velocity.y -= 10.0;
+        if keyboard_input.any_pressed([KeyCode::S, KeyCode::Down]) {
+            linear_velocity.y -= 500.0 * delta_time;
         }
-        if keyboard_input.pressed(KeyCode::Left) {
-            linear_velocity.x -= 10.0;
+        if keyboard_input.any_pressed([KeyCode::A, KeyCode::Left]) {
+            linear_velocity.x -= 500.0 * delta_time;
         }
-        if keyboard_input.pressed(KeyCode::Right) {
-            linear_velocity.x += 10.0;
+        if keyboard_input.any_pressed([KeyCode::D, KeyCode::Right]) {
+            linear_velocity.x += 500.0 * delta_time;
         }
     }
 }

--- a/crates/bevy_xpbd_2d/examples/move_marbles.rs
+++ b/crates/bevy_xpbd_2d/examples/move_marbles.rs
@@ -81,7 +81,7 @@ fn setup(
     let marble_material = materials.add(ColorMaterial::from(Color::rgb(0.2, 0.7, 0.9)));
 
     // Spawn stacks of marbles
-    for x in -21..21 {
+    for x in -20..20 {
         for y in -20..20 {
             commands.spawn((
                 MaterialMesh2dBundle {
@@ -103,21 +103,27 @@ fn setup(
 }
 
 fn movement(
+    time: Res<Time>,
     keyboard_input: Res<Input<KeyCode>>,
     mut marbles: Query<&mut LinearVelocity, With<Marble>>,
 ) {
+    // Precision is adjusted so that the example works with
+    // both the `f32` and `f64` features. Otherwise you don't need this.
+    let delta_time = time.delta_seconds_f64().adjust_precision();
+
     for mut linear_velocity in &mut marbles {
-        if keyboard_input.pressed(KeyCode::Up) {
-            linear_velocity.y += 50.0;
+        if keyboard_input.any_pressed([KeyCode::W, KeyCode::Up]) {
+            // Use a higher acceleration for upwards movement to overcome gravity
+            linear_velocity.y += 2500.0 * delta_time;
         }
-        if keyboard_input.pressed(KeyCode::Down) {
-            linear_velocity.y -= 10.0;
+        if keyboard_input.any_pressed([KeyCode::S, KeyCode::Down]) {
+            linear_velocity.y -= 500.0 * delta_time;
         }
-        if keyboard_input.pressed(KeyCode::Left) {
-            linear_velocity.x -= 10.0;
+        if keyboard_input.any_pressed([KeyCode::A, KeyCode::Left]) {
+            linear_velocity.x -= 500.0 * delta_time;
         }
-        if keyboard_input.pressed(KeyCode::Right) {
-            linear_velocity.x += 10.0;
+        if keyboard_input.any_pressed([KeyCode::D, KeyCode::Right]) {
+            linear_velocity.x += 500.0 * delta_time;
         }
     }
 }

--- a/crates/bevy_xpbd_2d/examples/one_way_platform_2d.rs
+++ b/crates/bevy_xpbd_2d/examples/one_way_platform_2d.rs
@@ -157,7 +157,7 @@ fn movement(
         let x_axis_input = right as i8 - left as i8;
 
         // Move in input direction
-        linear_velocity.x = x_axis_input as f32 * movement_speed.0;
+        linear_velocity.x = x_axis_input as Scalar * movement_speed.0;
 
         // Assume "mostly stopped" to mean "grounded".
         // You should use raycasting, shapecasting or sensor colliders

--- a/crates/bevy_xpbd_2d/examples/one_way_platform_2d.rs
+++ b/crates/bevy_xpbd_2d/examples/one_way_platform_2d.rs
@@ -154,10 +154,10 @@ fn movement(
     for (mut linear_velocity, movement_speed, jump_impulse) in &mut actors {
         let left = keyboard_input.any_pressed([KeyCode::A, KeyCode::Left]);
         let right = keyboard_input.any_pressed([KeyCode::D, KeyCode::Right]);
-        let x_axis_input = right as i8 - left as i8;
+        let horizontal = right as i8 - left as i8;
 
         // Move in input direction
-        linear_velocity.x = x_axis_input as Scalar * movement_speed.0;
+        linear_velocity.x = horizontal as Scalar * movement_speed.0;
 
         // Assume "mostly stopped" to mean "grounded".
         // You should use raycasting, shapecasting or sensor colliders

--- a/crates/bevy_xpbd_3d/examples/basic_dynamic_character.rs
+++ b/crates/bevy_xpbd_3d/examples/basic_dynamic_character.rs
@@ -7,18 +7,69 @@
 //! For a kinematic character controller, see the `basic_kinematic_character` example.
 
 use bevy::prelude::*;
-use bevy_xpbd_3d::{math::*, prelude::*, PhysicsSchedule, PhysicsStepSet};
+use bevy_xpbd_3d::{math::*, prelude::*};
 
 fn main() {
     App::new()
         .add_plugins((DefaultPlugins, PhysicsPlugins::default()))
         .add_systems(Startup, setup)
-        .add_systems(PhysicsSchedule, movement.before(PhysicsStepSet::BroadPhase))
+        .add_systems(Update, movement)
         .run();
 }
 
+/// The acceleration used for character movement.
 #[derive(Component)]
-struct Player;
+struct MovementAcceleration(Scalar);
+
+/// The damping factor used for slowing down movement.
+#[derive(Component)]
+struct MovementDampingFactor(Scalar);
+
+/// The strength of a jump.
+#[derive(Component)]
+struct JumpImpulse(Scalar);
+
+/// A bundle that contains the components needed for a basic
+/// dynamic character controller.
+#[derive(Bundle)]
+struct CharacterControllerBundle {
+    rigid_body: RigidBody,
+    collider: Collider,
+    ground_caster: ShapeCaster,
+    locked_axes: LockedAxes,
+    movement_acceleration: MovementAcceleration,
+    movement_damping: MovementDampingFactor,
+    jump_impulse: JumpImpulse,
+}
+
+impl CharacterControllerBundle {
+    fn new(
+        acceleration: Scalar,
+        damping: Scalar,
+        jump_impulse: Scalar,
+        collider: Collider,
+    ) -> Self {
+        // Create shape caster as a slightly smaller version of the collider
+        let mut caster_shape = collider.clone();
+        caster_shape.set_scale(Vector::ONE * 0.99, 10);
+
+        Self {
+            rigid_body: RigidBody::Dynamic,
+            locked_axes: LockedAxes::ROTATION_LOCKED,
+            collider,
+            ground_caster: ShapeCaster::new(
+                caster_shape,
+                Vector::ZERO,
+                Quaternion::default(),
+                Vector::NEG_Y,
+            )
+            .with_max_time_of_impact(0.2),
+            movement_acceleration: MovementAcceleration(acceleration),
+            movement_damping: MovementDampingFactor(damping),
+            jump_impulse: JumpImpulse(jump_impulse),
+        }
+    }
+}
 
 fn setup(
     mut commands: Commands,
@@ -47,22 +98,10 @@ fn setup(
             transform: Transform::from_xyz(0.0, 1.0, 0.0),
             ..default()
         },
-        RigidBody::Dynamic,
-        Collider::capsule(1.0, 0.4),
-        // Prevent the player from falling over
-        LockedAxes::new().lock_rotation_x().lock_rotation_z(),
-        // Cast the player shape downwards to detect when the player is grounded
-        ShapeCaster::new(
-            Collider::capsule(0.9, 0.35),
-            Vector::NEG_Y * 0.05,
-            Quaternion::default(),
-            Vector::NEG_Y,
-        )
-        .with_max_time_of_impact(0.2)
-        .with_max_hits(1),
-        Restitution::new(0.0).with_combine_rule(CoefficientCombine::Min),
+        CharacterControllerBundle::new(30.0, 0.9, 8.0, Collider::capsule(1.0, 0.4)),
+        Friction::ZERO.with_combine_rule(CoefficientCombine::Min),
+        Restitution::ZERO.with_combine_rule(CoefficientCombine::Min),
         GravityScale(2.0),
-        Player,
     ));
 
     // Light
@@ -84,31 +123,44 @@ fn setup(
 }
 
 fn movement(
+    time: Res<Time>,
     keyboard_input: Res<Input<KeyCode>>,
-    mut players: Query<(&mut LinearVelocity, &ShapeHits), With<Player>>,
+    mut controllers: Query<(
+        &MovementAcceleration,
+        &MovementDampingFactor,
+        &JumpImpulse,
+        &ShapeHits,
+        &mut LinearVelocity,
+    )>,
 ) {
-    for (mut linear_velocity, ground_hits) in &mut players {
-        // Directional movement
-        if keyboard_input.pressed(KeyCode::W) || keyboard_input.pressed(KeyCode::Up) {
-            linear_velocity.z -= 1.2;
-        }
-        if keyboard_input.pressed(KeyCode::S) || keyboard_input.pressed(KeyCode::Down) {
-            linear_velocity.z += 1.2;
-        }
-        if keyboard_input.pressed(KeyCode::A) || keyboard_input.pressed(KeyCode::Left) {
-            linear_velocity.x -= 1.2;
-        }
-        if keyboard_input.pressed(KeyCode::D) || keyboard_input.pressed(KeyCode::Right) {
-            linear_velocity.x += 1.2;
-        }
+    // Precision is adjusted so that the example works with
+    // both the `f32` and `f64` features. Otherwise you don't need this.
+    let delta_time = time.delta_seconds_f64().adjust_precision();
 
-        // Jump if space pressed and the player is close enough to the ground
+    for (movement_acceleration, damping_factor, jump_impulse, ground_hits, mut linear_velocity) in
+        &mut controllers
+    {
+        let up = keyboard_input.any_pressed([KeyCode::W, KeyCode::Up]);
+        let down = keyboard_input.any_pressed([KeyCode::S, KeyCode::Down]);
+        let left = keyboard_input.any_pressed([KeyCode::A, KeyCode::Left]);
+        let right = keyboard_input.any_pressed([KeyCode::D, KeyCode::Right]);
+
+        let horizontal = right as i8 - left as i8;
+        let vertical = down as i8 - up as i8;
+        let direction =
+            Vector::new(horizontal as Scalar, 0.0, vertical as Scalar).normalize_or_zero();
+
+        // Move in input direction
+        linear_velocity.x += direction.x * movement_acceleration.0 * delta_time;
+        linear_velocity.z += direction.z * movement_acceleration.0 * delta_time;
+
+        // Apply movement damping
+        linear_velocity.x *= damping_factor.0;
+        linear_velocity.z *= damping_factor.0;
+
+        // Jump if Space is pressed and the player is close enough to the ground
         if keyboard_input.just_pressed(KeyCode::Space) && !ground_hits.is_empty() {
-            linear_velocity.y += 8.0;
+            linear_velocity.y = jump_impulse.0;
         }
-
-        // Slow player down on the x and y axes
-        linear_velocity.x *= 0.8;
-        linear_velocity.z *= 0.8;
     }
 }

--- a/crates/bevy_xpbd_3d/examples/basic_dynamic_character.rs
+++ b/crates/bevy_xpbd_3d/examples/basic_dynamic_character.rs
@@ -95,7 +95,7 @@ fn setup(
                 ..default()
             })),
             material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-            transform: Transform::from_xyz(0.0, 1.0, 0.0),
+            transform: Transform::from_xyz(0.0, 1.5, 0.0),
             ..default()
         },
         CharacterControllerBundle::new(30.0, 0.9, 8.0, Collider::capsule(1.0, 0.4)),

--- a/crates/bevy_xpbd_3d/examples/basic_kinematic_character.rs
+++ b/crates/bevy_xpbd_3d/examples/basic_kinematic_character.rs
@@ -13,11 +13,7 @@ use bevy_xpbd_3d::{math::*, prelude::*, SubstepSchedule, SubstepSet};
 
 fn main() {
     App::new()
-        .add_plugins((
-            DefaultPlugins,
-            PhysicsPlugins::default(),
-            PhysicsDebugPlugin::default(),
-        ))
+        .add_plugins((DefaultPlugins, PhysicsPlugins::default()))
         .add_systems(Startup, setup)
         .add_systems(Update, movement)
         .add_systems(
@@ -111,7 +107,7 @@ fn setup(
                 ..default()
             })),
             material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
-            transform: Transform::from_xyz(0.0, 1.0, 0.0),
+            transform: Transform::from_xyz(0.0, 1.5, 0.0),
             ..default()
         },
         CharacterControllerBundle::new(

--- a/crates/bevy_xpbd_3d/examples/basic_kinematic_character.rs
+++ b/crates/bevy_xpbd_3d/examples/basic_kinematic_character.rs
@@ -9,15 +9,17 @@
 //! For a dynamic character controller, see the `basic_dynamic_character` example.
 
 use bevy::prelude::*;
-use bevy_xpbd_3d::{
-    math::*, prelude::*, PhysicsSchedule, PhysicsStepSet, SubstepSchedule, SubstepSet,
-};
+use bevy_xpbd_3d::{math::*, prelude::*, SubstepSchedule, SubstepSet};
 
 fn main() {
     App::new()
-        .add_plugins((DefaultPlugins, PhysicsPlugins::default()))
+        .add_plugins((
+            DefaultPlugins,
+            PhysicsPlugins::default(),
+            PhysicsDebugPlugin::default(),
+        ))
         .add_systems(Startup, setup)
-        .add_systems(PhysicsSchedule, movement.before(PhysicsStepSet::BroadPhase))
+        .add_systems(Update, movement)
         .add_systems(
             // Run collision handling in substep schedule
             SubstepSchedule,
@@ -26,8 +28,64 @@ fn main() {
         .run();
 }
 
+/// The acceleration used for character movement.
 #[derive(Component)]
-struct Player;
+struct MovementAcceleration(Scalar);
+
+/// The damping factor used for slowing down movement.
+#[derive(Component)]
+struct MovementDampingFactor(Scalar);
+
+/// The strength of a jump.
+#[derive(Component)]
+struct JumpImpulse(Scalar);
+
+/// The gravitational acceleration used for a character controller.
+#[derive(Component)]
+struct ControllerGravity(Vector);
+
+/// A bundle that contains the components needed for a basic
+/// kinematic character controller.
+#[derive(Bundle)]
+struct CharacterControllerBundle {
+    rigid_body: RigidBody,
+    collider: Collider,
+    ground_caster: ShapeCaster,
+    movement_acceleration: MovementAcceleration,
+    movement_damping: MovementDampingFactor,
+    jump_impulse: JumpImpulse,
+    gravity: ControllerGravity,
+}
+
+impl CharacterControllerBundle {
+    fn new(
+        acceleration: Scalar,
+        damping: Scalar,
+        jump_impulse: Scalar,
+        gravity: Vector,
+        collider: Collider,
+    ) -> Self {
+        // Create shape caster as a slightly smaller version of the collider
+        let mut caster_shape = collider.clone();
+        caster_shape.set_scale(Vector::ONE * 0.99, 10);
+
+        Self {
+            rigid_body: RigidBody::Kinematic,
+            collider,
+            ground_caster: ShapeCaster::new(
+                caster_shape,
+                Vector::ZERO,
+                Quaternion::default(),
+                Vector::NEG_Y,
+            )
+            .with_max_time_of_impact(0.2),
+            movement_acceleration: MovementAcceleration(acceleration),
+            movement_damping: MovementDampingFactor(damping),
+            jump_impulse: JumpImpulse(jump_impulse),
+            gravity: ControllerGravity(gravity),
+        }
+    }
+}
 
 fn setup(
     mut commands: Commands,
@@ -56,18 +114,14 @@ fn setup(
             transform: Transform::from_xyz(0.0, 1.0, 0.0),
             ..default()
         },
-        RigidBody::Kinematic,
-        Collider::capsule(1.0, 0.4),
-        // Cast the player shape downwards to detect when the player is grounded
-        ShapeCaster::new(
-            Collider::capsule(0.9, 0.35),
-            Vector::ZERO,
-            Quaternion::default(),
-            Vector::NEG_Y,
-        )
-        .with_max_time_of_impact(0.11)
-        .with_max_hits(1),
-        Player,
+        CharacterControllerBundle::new(
+            30.0,
+            0.9,
+            8.0,
+            // Two times the normal gravity
+            Vector::NEG_Y * 9.81 * 2.0,
+            Collider::capsule(1.0, 0.4),
+        ),
     ));
 
     // Light
@@ -89,40 +143,59 @@ fn setup(
 }
 
 fn movement(
+    time: Res<Time>,
     keyboard_input: Res<Input<KeyCode>>,
-    mut players: Query<(&mut LinearVelocity, &ShapeHits), With<Player>>,
+    mut controllers: Query<(
+        &MovementAcceleration,
+        &MovementDampingFactor,
+        &JumpImpulse,
+        &ControllerGravity,
+        &ShapeHits,
+        &mut LinearVelocity,
+    )>,
 ) {
-    for (mut linear_velocity, ground_hits) in &mut players {
+    // Precision is adjusted so that the example works with
+    // both the `f32` and `f64` features. Otherwise you don't need this.
+    let delta_time = time.delta_seconds_f64().adjust_precision();
+
+    for (
+        movement_acceleration,
+        damping_factor,
+        jump_impulse,
+        gravity,
+        ground_hits,
+        mut linear_velocity,
+    ) in &mut controllers
+    {
         // Reset vertical valocity if grounded, otherwise apply gravity
         if !ground_hits.is_empty() {
             linear_velocity.y = 0.0;
         } else {
-            linear_velocity.y -= 0.4;
+            linear_velocity.0 += gravity.0 * delta_time;
         }
 
-        // Directional movement
-        if keyboard_input.pressed(KeyCode::W) || keyboard_input.pressed(KeyCode::Up) {
-            linear_velocity.z -= 1.2;
-        }
-        if keyboard_input.pressed(KeyCode::A) || keyboard_input.pressed(KeyCode::Left) {
-            linear_velocity.x -= 1.2;
-        }
-        if keyboard_input.pressed(KeyCode::S) || keyboard_input.pressed(KeyCode::Down) {
-            linear_velocity.z += 1.2;
-        }
-        if keyboard_input.pressed(KeyCode::D) || keyboard_input.pressed(KeyCode::Right) {
-            linear_velocity.x += 1.2;
-        }
+        let up = keyboard_input.any_pressed([KeyCode::W, KeyCode::Up]);
+        let down = keyboard_input.any_pressed([KeyCode::S, KeyCode::Down]);
+        let left = keyboard_input.any_pressed([KeyCode::A, KeyCode::Left]);
+        let right = keyboard_input.any_pressed([KeyCode::D, KeyCode::Right]);
 
-        // Jump if space pressed and the player is close enough to the ground
+        let horizontal = right as i8 - left as i8;
+        let vertical = down as i8 - up as i8;
+        let direction =
+            Vector::new(horizontal as Scalar, 0.0, vertical as Scalar).normalize_or_zero();
+
+        // Move in input direction
+        linear_velocity.x += direction.x * movement_acceleration.0 * delta_time;
+        linear_velocity.z += direction.z * movement_acceleration.0 * delta_time;
+
+        // Apply movement damping
+        linear_velocity.x *= damping_factor.0;
+        linear_velocity.z *= damping_factor.0;
+
+        // Jump if Space is pressed and the player is close enough to the ground
         if keyboard_input.just_pressed(KeyCode::Space) && !ground_hits.is_empty() {
-            linear_velocity.y += 10.0;
+            linear_velocity.y = jump_impulse.0;
         }
-
-        // Slow player down
-        linear_velocity.x *= 0.8;
-        linear_velocity.y *= 0.98;
-        linear_velocity.z *= 0.8;
     }
 }
 

--- a/crates/bevy_xpbd_3d/examples/custom_constraint.rs
+++ b/crates/bevy_xpbd_3d/examples/custom_constraint.rs
@@ -104,8 +104,8 @@ fn setup(
     let static_cube = commands
         .spawn((
             PbrBundle {
-                mesh: cube_mesh.clone_weak(),
-                material: cube_material.clone_weak(),
+                mesh: cube_mesh.clone(),
+                material: cube_material.clone(),
                 ..default()
             },
             RigidBody::Static,

--- a/crates/bevy_xpbd_3d/examples/distance_joint_3d.rs
+++ b/crates/bevy_xpbd_3d/examples/distance_joint_3d.rs
@@ -23,8 +23,8 @@ fn setup(
     let static_cube = commands
         .spawn((
             PbrBundle {
-                mesh: cube_mesh.clone_weak(),
-                material: cube_material.clone_weak(),
+                mesh: cube_mesh.clone(),
+                material: cube_material.clone(),
                 ..default()
             },
             RigidBody::Static,

--- a/crates/bevy_xpbd_3d/examples/fixed_joint_3d.rs
+++ b/crates/bevy_xpbd_3d/examples/fixed_joint_3d.rs
@@ -24,8 +24,8 @@ fn setup(
     let anchor = commands
         .spawn((
             PbrBundle {
-                mesh: cube_mesh.clone_weak(),
-                material: cube_material.clone_weak(),
+                mesh: cube_mesh.clone(),
+                material: cube_material.clone(),
                 transform: Transform::from_xyz(3.0, 3.5, 0.0),
                 ..default()
             },

--- a/crates/bevy_xpbd_3d/examples/prismatic_joint_3d.rs
+++ b/crates/bevy_xpbd_3d/examples/prismatic_joint_3d.rs
@@ -24,8 +24,8 @@ fn setup(
     let anchor = commands
         .spawn((
             PbrBundle {
-                mesh: cube_mesh.clone_weak(),
-                material: cube_material.clone_weak(),
+                mesh: cube_mesh.clone(),
+                material: cube_material.clone(),
                 ..default()
             },
             RigidBody::Kinematic,

--- a/crates/bevy_xpbd_3d/examples/revolute_joint_3d.rs
+++ b/crates/bevy_xpbd_3d/examples/revolute_joint_3d.rs
@@ -24,8 +24,8 @@ fn setup(
     let anchor = commands
         .spawn((
             PbrBundle {
-                mesh: cube_mesh.clone_weak(),
-                material: cube_material.clone_weak(),
+                mesh: cube_mesh.clone(),
+                material: cube_material.clone(),
                 ..default()
             },
             RigidBody::Kinematic,


### PR DESCRIPTION
# Objective

Fixes #170.

Currently, the movement in examples like `move_marbles` and `cubes` is frame rate dependent because they are running in `Update` but don't use delta time. `basic_dynamic_character` and `basic_kinematic_character` on the other hand run in the `PhysicsSchedule`, but this can cause issues with missed inputs as reported in #170.

The character controllers are also perhaps too basic and don't reflect real usage well, and the movement code isn't great and it doesn't support WASD.

## Solution

- Put all movement systems in `Update` and use delta time (alternatively, you could send input events in `Update` and have another system handle the movement in the `PhysicsSchedule`)
- Refactor input handling to be cleaner and to support WASD as well as arrow keys
- Refactor character controller examples with `CharacterControllerBundle` and configuration options
- Fix some meshes not being rendered due to `clone_weak`