### PR TITLE
Refactor character controller examples and support gamepad input

### DIFF
--- a/crates/bevy_xpbd_3d/examples/basic_dynamic_character.rs
+++ b/crates/bevy_xpbd_3d/examples/basic_dynamic_character.rs
@@ -143,7 +143,7 @@ fn keyboard_input(
     let right = keyboard_input.any_pressed([KeyCode::D, KeyCode::Right]);
 
     let horizontal = right as i8 - left as i8;
-    let vertical = down as i8 - up as i8;
+    let vertical = up as i8 - down as i8;
     let direction = Vector2::new(horizontal as Scalar, vertical as Scalar).clamp_length_max(1.0);
 
     if direction != Vector2::ZERO {
@@ -209,7 +209,7 @@ fn movement(
             match event {
                 MovementAction::Move(direction) => {
                     linear_velocity.x += direction.x * movement_acceleration.0 * delta_time;
-                    linear_velocity.z += direction.y * movement_acceleration.0 * delta_time;
+                    linear_velocity.z -= direction.y * movement_acceleration.0 * delta_time;
                 }
                 MovementAction::Jump => {
                     if !ground_hits.is_empty() {
@@ -223,6 +223,7 @@ fn movement(
 
 fn apply_damping(mut query: Query<(&MovementDampingFactor, &mut LinearVelocity)>) {
     for (damping_factor, mut linear_velocity) in &mut query {
+        // We could use `LinearDamping`, but we don't want to dampen movement along the Y axis
         linear_velocity.x *= damping_factor.0;
         linear_velocity.z *= damping_factor.0;
     }

--- a/crates/bevy_xpbd_3d/examples/basic_dynamic_character.rs
+++ b/crates/bevy_xpbd_3d/examples/basic_dynamic_character.rs
@@ -12,7 +12,7 @@ use bevy_xpbd_3d::{math::*, prelude::*};
 fn main() {
     App::new()
         .add_plugins((DefaultPlugins, PhysicsPlugins::default()))
-        .add_event::<MovementInputEvent>()
+        .add_event::<MovementAction>()
         .add_systems(Startup, setup)
         .add_systems(
             Update,
@@ -23,7 +23,7 @@ fn main() {
 
 /// An event sent for a movement input action.
 #[derive(Event)]
-enum MovementInputEvent {
+enum MovementAction {
     Move(Vector2),
     Jump,
 }
@@ -134,7 +134,7 @@ fn setup(
 }
 
 fn keyboard_input(
-    mut movement_event_writer: EventWriter<MovementInputEvent>,
+    mut movement_event_writer: EventWriter<MovementAction>,
     keyboard_input: Res<Input<KeyCode>>,
 ) {
     let up = keyboard_input.any_pressed([KeyCode::W, KeyCode::Up]);
@@ -147,16 +147,16 @@ fn keyboard_input(
     let direction = Vector2::new(horizontal as Scalar, vertical as Scalar).clamp_length_max(1.0);
 
     if direction != Vector2::ZERO {
-        movement_event_writer.send(MovementInputEvent::Move(direction));
+        movement_event_writer.send(MovementAction::Move(direction));
     }
 
     if keyboard_input.just_pressed(KeyCode::Space) {
-        movement_event_writer.send(MovementInputEvent::Jump);
+        movement_event_writer.send(MovementAction::Jump);
     }
 }
 
 fn gamepad_input(
-    mut movement_event_writer: EventWriter<MovementInputEvent>,
+    mut movement_event_writer: EventWriter<MovementAction>,
     gamepads: Res<Gamepads>,
     axes: Res<Axis<GamepadAxis>>,
     buttons: Res<Input<GamepadButton>>,
@@ -172,7 +172,7 @@ fn gamepad_input(
         };
 
         if let (Some(x), Some(y)) = (axes.get(axis_lx), axes.get(axis_ly)) {
-            movement_event_writer.send(MovementInputEvent::Move(
+            movement_event_writer.send(MovementAction::Move(
                 Vector2::new(x, y).clamp_length_max(1.0),
             ));
         }
@@ -183,14 +183,14 @@ fn gamepad_input(
         };
 
         if buttons.just_pressed(jump_button) {
-            movement_event_writer.send(MovementInputEvent::Jump);
+            movement_event_writer.send(MovementAction::Jump);
         }
     }
 }
 
 fn movement(
     time: Res<Time>,
-    mut movement_event_reader: EventReader<MovementInputEvent>,
+    mut movement_event_reader: EventReader<MovementAction>,
     mut controllers: Query<(
         &MovementAcceleration,
         &JumpImpulse,
@@ -207,11 +207,11 @@ fn movement(
             &mut controllers
         {
             match event {
-                MovementInputEvent::Move(direction) => {
+                MovementAction::Move(direction) => {
                     linear_velocity.x += direction.x * movement_acceleration.0 * delta_time;
                     linear_velocity.z += direction.y * movement_acceleration.0 * delta_time;
                 }
-                MovementInputEvent::Jump => {
+                MovementAction::Jump => {
                     if !ground_hits.is_empty() {
                         linear_velocity.y = jump_impulse.0;
                     }

--- a/crates/bevy_xpbd_3d/examples/basic_dynamic_character.rs
+++ b/crates/bevy_xpbd_3d/examples/basic_dynamic_character.rs
@@ -173,7 +173,7 @@ fn gamepad_input(
 
         if let (Some(x), Some(y)) = (axes.get(axis_lx), axes.get(axis_ly)) {
             movement_event_writer.send(MovementAction::Move(
-                Vector2::new(x, y).clamp_length_max(1.0),
+                Vector2::new(x as Scalar, y as Scalar).clamp_length_max(1.0),
             ));
         }
 

--- a/crates/bevy_xpbd_3d/examples/basic_dynamic_character.rs
+++ b/crates/bevy_xpbd_3d/examples/basic_dynamic_character.rs
@@ -6,7 +6,7 @@
 //!
 //! For a kinematic character controller, see the `basic_kinematic_character` example.
 
-use bevy::prelude::*;
+use bevy::{ecs::query::Has, prelude::*};
 use bevy_xpbd_3d::{math::*, prelude::*};
 
 fn main() {
@@ -16,7 +16,15 @@ fn main() {
         .add_systems(Startup, setup)
         .add_systems(
             Update,
-            (keyboard_input, gamepad_input, movement, apply_damping).chain(),
+            (
+                keyboard_input,
+                gamepad_input,
+                update_grounded,
+                apply_deferred,
+                movement,
+                apply_movement_damping,
+            )
+                .chain(),
         )
         .run();
 }
@@ -27,6 +35,15 @@ enum MovementAction {
     Move(Vector2),
     Jump,
 }
+
+/// A marker component indicating that an entity is using a character controller.
+#[derive(Component)]
+struct CharacterController;
+
+/// A marker component indicating that an entity is on the ground.
+#[derive(Component)]
+#[component(storage = "SparseSet")]
+struct Grounded;
 
 /// The acceleration used for character movement.
 #[derive(Component)]
@@ -44,6 +61,7 @@ struct JumpImpulse(Scalar);
 /// dynamic character controller.
 #[derive(Bundle)]
 struct CharacterControllerBundle {
+    character_controller: CharacterController,
     rigid_body: RigidBody,
     collider: Collider,
     ground_caster: ShapeCaster,
@@ -60,11 +78,12 @@ impl CharacterControllerBundle {
         jump_impulse: Scalar,
         collider: Collider,
     ) -> Self {
-        // Create shape caster as a slightly smaller version of the collider
+        // Create shape caster as a slightly smaller version of collider
         let mut caster_shape = collider.clone();
         caster_shape.set_scale(Vector::ONE * 0.99, 10);
 
         Self {
+            character_controller: CharacterController,
             rigid_body: RigidBody::Dynamic,
             locked_axes: LockedAxes::ROTATION_LOCKED,
             collider,
@@ -109,7 +128,7 @@ fn setup(
             transform: Transform::from_xyz(0.0, 1.5, 0.0),
             ..default()
         },
-        CharacterControllerBundle::new(30.0, 0.9, 8.0, Collider::capsule(1.0, 0.4)),
+        CharacterControllerBundle::new(30.0, 0.92, 8.0, Collider::capsule(1.0, 0.4)),
         Friction::ZERO.with_combine_rule(CoefficientCombine::Min),
         Restitution::ZERO.with_combine_rule(CoefficientCombine::Min),
         GravityScale(2.0),
@@ -133,6 +152,7 @@ fn setup(
     });
 }
 
+/// Sends [`MovementAction`] events based on keyboard input.
 fn keyboard_input(
     mut movement_event_writer: EventWriter<MovementAction>,
     keyboard_input: Res<Input<KeyCode>>,
@@ -155,6 +175,7 @@ fn keyboard_input(
     }
 }
 
+/// Sends [`MovementAction`] events based on gamepad input.
 fn gamepad_input(
     mut movement_event_writer: EventWriter<MovementAction>,
     gamepads: Res<Gamepads>,
@@ -188,14 +209,29 @@ fn gamepad_input(
     }
 }
 
+/// Updates the [`Grounded`] status for character controllers.
+fn update_grounded(
+    mut commands: Commands,
+    mut query: Query<(Entity, &ShapeHits), With<CharacterController>>,
+) {
+    for (entity, hits) in &mut query {
+        if !hits.is_empty() {
+            commands.entity(entity).insert(Grounded);
+        } else {
+            commands.entity(entity).remove::<Grounded>();
+        }
+    }
+}
+
+/// Responds to [`MovementAction`] events and moves character controllers accordingly.
 fn movement(
     time: Res<Time>,
     mut movement_event_reader: EventReader<MovementAction>,
     mut controllers: Query<(
         &MovementAcceleration,
         &JumpImpulse,
-        &ShapeHits,
         &mut LinearVelocity,
+        Has<Grounded>,
     )>,
 ) {
     // Precision is adjusted so that the example works with
@@ -203,7 +239,7 @@ fn movement(
     let delta_time = time.delta_seconds_f64().adjust_precision();
 
     for event in movement_event_reader.iter() {
-        for (movement_acceleration, jump_impulse, ground_hits, mut linear_velocity) in
+        for (movement_acceleration, jump_impulse, mut linear_velocity, is_grounded) in
             &mut controllers
         {
             match event {
@@ -212,7 +248,7 @@ fn movement(
                     linear_velocity.z -= direction.y * movement_acceleration.0 * delta_time;
                 }
                 MovementAction::Jump => {
-                    if !ground_hits.is_empty() {
+                    if is_grounded {
                         linear_velocity.y = jump_impulse.0;
                     }
                 }
@@ -221,7 +257,8 @@ fn movement(
     }
 }
 
-fn apply_damping(mut query: Query<(&MovementDampingFactor, &mut LinearVelocity)>) {
+/// Slows down movement in the XZ plane.
+fn apply_movement_damping(mut query: Query<(&MovementDampingFactor, &mut LinearVelocity)>) {
     for (damping_factor, mut linear_velocity) in &mut query {
         // We could use `LinearDamping`, but we don't want to dampen movement along the Y axis
         linear_velocity.x *= damping_factor.0;

--- a/crates/bevy_xpbd_3d/examples/basic_kinematic_character.rs
+++ b/crates/bevy_xpbd_3d/examples/basic_kinematic_character.rs
@@ -166,7 +166,7 @@ fn keyboard_input(
     let right = keyboard_input.any_pressed([KeyCode::D, KeyCode::Right]);
 
     let horizontal = right as i8 - left as i8;
-    let vertical = down as i8 - up as i8;
+    let vertical = up as i8 - down as i8;
     let direction = Vector2::new(horizontal as Scalar, vertical as Scalar).clamp_length_max(1.0);
 
     if direction != Vector2::ZERO {
@@ -232,7 +232,7 @@ fn movement(
             match event {
                 MovementAction::Move(direction) => {
                     linear_velocity.x += direction.x * movement_acceleration.0 * delta_time;
-                    linear_velocity.z += direction.y * movement_acceleration.0 * delta_time;
+                    linear_velocity.z -= direction.y * movement_acceleration.0 * delta_time;
                 }
                 MovementAction::Jump => {
                     if !ground_hits.is_empty() {
@@ -264,6 +264,7 @@ fn apply_gravity(
 
 fn apply_damping(mut query: Query<(&MovementDampingFactor, &mut LinearVelocity)>) {
     for (damping_factor, mut linear_velocity) in &mut query {
+        // We could use `LinearDamping`, but we don't want to dampen movement along the Y axis
         linear_velocity.x *= damping_factor.0;
         linear_velocity.z *= damping_factor.0;
     }

--- a/crates/bevy_xpbd_3d/examples/basic_kinematic_character.rs
+++ b/crates/bevy_xpbd_3d/examples/basic_kinematic_character.rs
@@ -196,7 +196,7 @@ fn gamepad_input(
 
         if let (Some(x), Some(y)) = (axes.get(axis_lx), axes.get(axis_ly)) {
             movement_event_writer.send(MovementAction::Move(
-                Vector2::new(x, y).clamp_length_max(1.0),
+                Vector2::new(x as Scalar, y as Scalar).clamp_length_max(1.0),
             ));
         }
 


### PR DESCRIPTION
# Objective

The character controller examples currently only support keyboard input and have input handling and movement in the same system. It would be good to have the examples be more complete while encouraging good practises (like separate input handling), especially since we don't have a built-in character controller.

## Solution

Split the movement system into parts. `keyboard_input` and `gamepad_input` send `MovementAction` events which are handled by the `movement` system.