### PR TITLE
docs: Use more backticks.

### DIFF
--- a/crates/bevy_xpbd_3d/examples/trimesh_shapes_3d.rs
+++ b/crates/bevy_xpbd_3d/examples/trimesh_shapes_3d.rs
@@ -1,4 +1,4 @@
-//! This example is a version of Bevy's 3d_shapes example that uses trimesh colliders for the shapes.
+//! This example is a version of Bevy's `3d_shapes` example that uses trimesh colliders for the shapes.
 //!
 //! You could also use convex decomposition to generate compound shapes from Bevy meshes.
 //! The decomposition algorithm can be slow, but the generated colliders are often faster and more robust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,7 @@
 //! Rapier is the biggest and most used physics engine in the Rust ecosystem, and it is currently
 //! the most mature and feature-rich option.
 //!
-//! bevy_rapier is a great physics integration for Bevy, but it does have several problems:
+//! `bevy_rapier` is a great physics integration for Bevy, but it does have several problems:
 //!
 //! - It has to maintain a separate physics world and synchronize a ton of data with Bevy each frame
 //! - The source code is difficult to inspect, as the vast majority of it is glue code and wrappers
@@ -235,7 +235,7 @@
 //! rapidly, and it is already pretty close to feature-parity with Rapier.
 //!
 //! At the end of the day, both engines are very solid options. If you are looking for a more mature and tested
-//! physics integration, bevy_rapier is the better choice, but if you prefer an engine with less overhead
+//! physics integration, `bevy_rapier` is the better choice, but if you prefer an engine with less overhead
 //! and a more native Bevy integration, consider using Bevy XPBD. Their core APIs are also quite similar,
 //! so switching between them should be straightforward.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -446,7 +446,7 @@
 //! [^5]: [`SubstepSet`]
 
 #![allow(rustdoc::invalid_rust_codeblocks)]
-#![warn(missing_docs)]
+#![warn(clippy::doc_markdown, missing_docs)]
 
 #[cfg(all(feature = "f32", feature = "f64"))]
 compile_error!("feature \"f32\" and feature \"f64\" cannot be enabled at the same time");

--- a/src/plugins/collision/mod.rs
+++ b/src/plugins/collision/mod.rs
@@ -1,6 +1,6 @@
 //! Collision detection is used to detect and compute intersections between [`Collider`]s.
 //!
-//! In bevy_xpbd, collision detection is split into three plugins:
+//! In `bevy_xpbd`, collision detection is split into three plugins:
 //!
 //! - [`BroadPhasePlugin`]: Collects pairs of potentially colliding entities into [`BroadCollisionPairs`].
 //! - [`NarrowPhasePlugin`]: Computes contacts for broad phase collision pairs and adds them to [`Collisions`].

--- a/src/plugins/spatial_query/pipeline.rs
+++ b/src/plugins/spatial_query/pipeline.rs
@@ -42,7 +42,7 @@ impl Default for SpatialQueryPipeline {
 }
 
 impl SpatialQueryPipeline {
-    /// Creates a new [SpatialQueryPipeline].
+    /// Creates a new [`SpatialQueryPipeline`].
     pub fn new() -> SpatialQueryPipeline {
         SpatialQueryPipeline::default()
     }
@@ -145,7 +145,7 @@ impl SpatialQueryPipeline {
     /// Otherwise, the collider will be treated as hollow, and the hit point will be at the collider's boundary.
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     ///
-    /// See also: [SpatialQuery::cast_ray]
+    /// See also: [`SpatialQuery::cast_ray`]
     pub fn cast_ray(
         &self,
         origin: Vector,
@@ -187,7 +187,7 @@ impl SpatialQueryPipeline {
     /// Otherwise, the collider will be treated as hollow, and the hit point will be at the collider's boundary.
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     ///
-    /// See also: [SpatialQuery::ray_hits]
+    /// See also: [`SpatialQuery::ray_hits`]
     pub fn ray_hits(
         &self,
         origin: Vector,
@@ -227,7 +227,7 @@ impl SpatialQueryPipeline {
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     /// - `callback`: A callback function called for each hit.
     ///
-    /// See also: [SpatialQuery::ray_hits_callback]
+    /// See also: [`SpatialQuery::ray_hits_callback`]
     pub fn ray_hits_callback(
         &self,
         origin: Vector,
@@ -286,7 +286,7 @@ impl SpatialQueryPipeline {
     /// hit will be returned.
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     ///
-    /// See also: [SpatialQuery::cast_shape]
+    /// See also: [`SpatialQuery::cast_shape`]
     #[allow(clippy::too_many_arguments)]
     pub fn cast_shape(
         &self,
@@ -350,7 +350,7 @@ impl SpatialQueryPipeline {
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     /// - `callback`: A callback function called for each hit.
     ///
-    /// See also: [SpatialQuery::shape_hits]
+    /// See also: [`SpatialQuery::shape_hits`]
     #[allow(clippy::too_many_arguments)]
     pub fn shape_hits(
         &self,
@@ -397,7 +397,7 @@ impl SpatialQueryPipeline {
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     /// - `callback`: A callback function called for each hit.
     ///
-    /// See also: [SpatialQuery::shape_hits_callback]
+    /// See also: [`SpatialQuery::shape_hits_callback`]
     #[allow(clippy::too_many_arguments)]
     pub fn shape_hits_callback(
         &self,
@@ -468,7 +468,7 @@ impl SpatialQueryPipeline {
     /// Otherwise, the collider will be treated as hollow, and the projection will be at the collider's boundary.
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     ///
-    /// See also: [SpatialQuery::project_point]
+    /// See also: [`SpatialQuery::project_point`]
     pub fn project_point(
         &self,
         point: Vector,
@@ -497,7 +497,7 @@ impl SpatialQueryPipeline {
     /// - `point`: The point that intersections are tested against.
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     ///
-    /// See also: [SpatialQuery::point_intersections]
+    /// See also: [`SpatialQuery::point_intersections`]
     pub fn point_intersections(
         &self,
         point: Vector,
@@ -521,7 +521,7 @@ impl SpatialQueryPipeline {
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     /// - `callback`: A callback function called for each intersection.
     ///
-    /// See also: [SpatialQuery::point_intersections_callback]
+    /// See also: [`SpatialQuery::point_intersections_callback`]
     pub fn point_intersections_callback(
         &self,
         point: Vector,
@@ -549,7 +549,7 @@ impl SpatialQueryPipeline {
     /// An [intersection test](spatial_query#intersection-tests) that finds all entities with a [`ColliderAabb`]
     /// that is intersecting the given `aabb`.
     ///
-    /// See also: [SpatialQuery::point_intersections_callback]
+    /// See also: [`SpatialQuery::point_intersections_callback`]
     pub fn aabb_intersections_with_aabb(&self, aabb: ColliderAabb) -> Vec<Entity> {
         let mut intersections = vec![];
         self.aabb_intersections_with_aabb_callback(aabb, |e| {
@@ -563,7 +563,7 @@ impl SpatialQueryPipeline {
     /// that is intersecting the given `aabb`, calling `callback` for each intersection.
     /// The search stops when `callback` returns `false` or all intersections have been found.
     ///
-    /// See also: [SpatialQuery::aabb_intersections_with_aabb_callback]
+    /// See also: [`SpatialQuery::aabb_intersections_with_aabb_callback`]
     pub fn aabb_intersections_with_aabb_callback(
         &self,
         aabb: ColliderAabb,
@@ -588,7 +588,7 @@ impl SpatialQueryPipeline {
     /// - `shape_rotation`: The rotation of the shape.
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     ///
-    /// See also: [SpatialQuery::shape_intersections]
+    /// See also: [`SpatialQuery::shape_intersections`]
     pub fn shape_intersections(
         &self,
         shape: &Collider,
@@ -622,7 +622,7 @@ impl SpatialQueryPipeline {
     /// - `query_filter`: A [`SpatialQueryFilter`] that determines which colliders are taken into account in the query.
     /// - `callback`: A callback function called for each intersection.
     ///
-    /// See also: [SpatialQuery::shape_intersections_callback]
+    /// See also: [`SpatialQuery::shape_intersections_callback`]
     pub fn shape_intersections_callback(
         &self,
         shape: &Collider,


### PR DESCRIPTION
# Objective

- Don't have warnings from `clippy::doc_markdown`.
- Have nicely formatted API docs.

## Solution

- Use backticks more!
