### PR TITLE
Move x comparison in broad phase up to early-out as soon as possible

### DIFF
--- a/src/plugins/collision/broad_phase.rs
+++ b/src/plugins/collision/broad_phase.rs
@@ -211,14 +211,14 @@ fn sweep_and_prune(
     // Find potential collisions by checking for AABB intersections along all axes.
     for (i, (ent1, aabb1, layers1, inactive1)) in intervals.0.iter().enumerate() {
         for (ent2, aabb2, layers2, inactive2) in intervals.0.iter().skip(i + 1) {
+            // x doesn't intersect; check this first so we can discard as soon as possible
+            if aabb2.mins.x > aabb1.maxs.x {
+                break;
+            }
+
             // No collisions between bodies that haven't moved or colliders with incompatible layers
             if (*inactive1 && *inactive2) || !layers1.interacts_with(*layers2) {
                 continue;
-            }
-
-            // x doesn't intersect
-            if aabb2.mins.x > aabb1.maxs.x {
-                break;
             }
 
             // y doesn't intersect


### PR DESCRIPTION
# Objective

- At around 13,000 colliders, none of which could collide with each other, I was seeing the broad phase alone taking ~20ms
- Wanting to bring it down to something more manageable, I experimented with various ways to potentially speed up the broad phase

## Solution

- Believe it or not, the biggest gain I found was to simply break out of the loop sooner
    - Move the `aabb2.mins.x > aabb1.maxs.x` check that can break out of the loop to the very top, before the inactive/layer checks
    - This resulted in the 13,000 colliders going from taking ~20ms to just ~2ms
    - I've understood this to be caused by the layer check causing the `continue` to be triggered, preventing the loop from ever hitting the early `break` branch