### PR TITLE
Use intradoc links rather than #method anchors.

### DIFF
--- a/src/components/collider.rs
+++ b/src/components/collider.rs
@@ -136,8 +136,8 @@ pub type TriMeshFlags = parry::shape::TriMeshFlags;
 /// Internally, `Collider` uses the shapes provided by `parry`. If you want to create a collider
 /// using these shapes, you can simply use `Collider::from(SharedShape::some_method())`.
 ///
-/// To get a reference to the internal [`SharedShape`], you can use the [`shape`](#method.shape)
-/// or [`shape_scaled`](#method.shape_scaled) method.
+/// To get a reference to the internal [`SharedShape`], you can use the [`Collider::shape()`]
+/// or [`Collider::shape_scaled()`] methods.
 #[derive(Clone, Component)]
 pub struct Collider {
     /// The raw unscaled collider shape.
@@ -290,7 +290,7 @@ impl Collider {
     /// because convex shapes typically provide more reliable results.
     ///
     /// If you want to create a compound shape from a 3D triangle mesh or 2D polyline, consider using the
-    /// [`Collider::convex_decomposition`](#method.convex_decomposition) method.
+    /// [`Collider::convex_decomposition`] method.
     pub fn compound(
         shapes: Vec<(
             impl Into<Position>,
@@ -916,7 +916,7 @@ impl AsyncSceneCollider {
     ///
     /// If the given collider type is `None`, all meshes except the ones in
     /// [`meshes_by_name`](#structfield.meshes_by_name) will be skipped.
-    /// You can add named shapes using [`with_shape_for_name`](#method.with_shape_for_name).
+    /// You can add named shapes using [`with_shape_for_name`](Self::with_shape_for_name).
     pub fn new(default_shape: Option<ComputedCollider>) -> Self {
         Self {
             default_shape,

--- a/src/components/forces.rs
+++ b/src/components/forces.rs
@@ -23,7 +23,7 @@ impl FloatZero for Scalar {
 /// use the body's rotation to [transform the local force into world space](#local-forces).
 ///
 /// By default, the force persists across frames. You can clear the force manually using
-/// [`clear`](#method.clear) or set `persistent` to false.
+/// [`clear`](Self::clear) or set `persistent` to false.
 ///
 /// ## Example
 ///
@@ -86,7 +86,7 @@ impl FloatZero for Scalar {
 ///
 /// Note that the actual force stored in `ExternalForce` is still in world space.
 /// If you want to apply a force in the same local direction every frame,
-/// consider setting `persistent` to `false` and running [`apply_force`](#method.apply_force) in a system.
+/// consider setting `persistent` to `false` and running [`apply_force`](Self::apply_force) in a system.
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, From)]
 #[reflect(Component)]
 pub struct ExternalForce {
@@ -94,10 +94,10 @@ pub struct ExternalForce {
     force: Vector,
     /// True if the force persists across frames, and false if the force is automatically cleared every physics frame.
     ///
-    /// If you clear the force manually, use the [`clear`](#method.clear) method. This will clear the force and
+    /// If you clear the force manually, use the [`clear`](Self::clear) method. This will clear the force and
     /// the torque that is applied when the force is not applied at the center of mass.
     pub persistent: bool,
-    /// The torque caused by forces applied at certain points using [`apply_force_at_point`](#method.apply_force_at_point).
+    /// The torque caused by forces applied at certain points using [`apply_force_at_point`](Self::apply_force_at_point).
     torque: Torque,
 }
 
@@ -175,7 +175,7 @@ impl ExternalForce {
     }
 
     /// Returns the torque caused by forces applied at certain points using
-    /// [`apply_force_at_point`](#method.apply_force_at_point).
+    /// [`apply_force_at_point`](Self::apply_force_at_point).
     pub fn torque(&self) -> Torque {
         self.torque
     }
@@ -197,7 +197,7 @@ impl ExternalForce {
 /// An external torque applied continuously to a dynamic [rigid body](RigidBody).
 ///
 /// By default, the torque persists across frames. You can clear the torque manually using
-/// [`clear`](#method.clear) or set `persistent` to false.
+/// [`clear`](Self::clear) or set `persistent` to false.
 ///
 /// ## Example
 ///
@@ -375,10 +375,10 @@ pub struct ExternalImpulse {
     impulse: Vector,
     /// True if the impulse persists across frames, and false if the impulse is automatically cleared every physics frame.
     ///
-    /// If you clear the impulse manually, use the [`clear`](#method.clear) method. This will clear the impulse and
+    /// If you clear the impulse manually, use the [`clear`](Self::clear) method. This will clear the impulse and
     /// the angular impulse that is applied when the impulse is not applied at the center of mass.
     pub persistent: bool,
-    /// The angular impulse caused by impulses applied at certain points using [`apply_impulse_at_point`](#method.apply_impulse_at_point).
+    /// The angular impulse caused by impulses applied at certain points using [`apply_impulse_at_point`](Self::apply_impulse_at_point).
     angular_impulse: Torque,
 }
 
@@ -459,7 +459,7 @@ impl ExternalImpulse {
     }
 
     /// Returns the angular impulse caused by impulses applied at certain points using
-    /// [`apply_impulse_at_point`](#method.apply_impulse_at_point).
+    /// [`apply_impulse_at_point`](Self::apply_impulse_at_point).
     pub fn angular_impulse(&self) -> Torque {
         self.angular_impulse
     }

--- a/src/components/layers.rs
+++ b/src/components/layers.rs
@@ -36,15 +36,15 @@ impl<L: PhysicsLayer> PhysicsLayer for &L {
 ///
 /// ## Creation
 ///
-/// The easiest way to build a [`CollisionLayers`] configuration is to use the [`CollisionLayers::new()`](#method.new) method
+/// The easiest way to build a [`CollisionLayers`] configuration is to use the [`CollisionLayers::new()`] method
 /// that takes in a list of groups and masks. Additional groups and masks can be added and removed by calling methods like
-/// [`add_groups`](#method.add_groups), [`add_masks`](#method.add_masks), [`remove_groups`](#method.remove_groups) and
-/// [`remove_masks`](#method.remove_masks).
+/// [`add_groups`](Self::add_groups), [`add_masks`](Self::add_masks), [`remove_groups`](Self::remove_groups) and
+/// [`remove_masks`](Self::remove_masks).
 ///
 /// These methods require the layers to implement [`PhysicsLayer`]. The easiest way to define the physics layers is to
 /// create an enum with `#[derive(PhysicsLayer)]`.
 ///
-/// Internally, the groups and masks are represented as bitmasks, so you can also use [`CollisionLayers::from_bits()`](#method.from_bits)
+/// Internally, the groups and masks are represented as bitmasks, so you can also use [`CollisionLayers::from_bits()`]
 /// to create collision layers.
 ///
 /// ## Example

--- a/src/components/locked_axes.rs
+++ b/src/components/locked_axes.rs
@@ -6,8 +6,8 @@ use crate::prelude::*;
 /// A component that specifies which translational and rotational axes of a [rigid body](RigidBody) are locked.
 ///
 /// The axes are represented using a total of six bits, one for each axis. The easiest way to lock or unlock
-/// specific axes is to use methods like [`lock_translation_x`](#method.lock_translation_x), but you can also
-/// use bits directly with the [`from_bits`](#method.from_bits) and [`to_bits`](#method.to_bits) methods.
+/// specific axes is to use methods like [`lock_translation_x`](Self::lock_translation_x), but you can also
+/// use bits directly with the [`from_bits`](Self::from_bits) and [`to_bits`](Self::to_bits) methods.
 ///
 /// ## Example
 ///

--- a/src/components/mass_properties.rs
+++ b/src/components/mass_properties.rs
@@ -192,7 +192,7 @@ impl CenterOfMass {
 ///
 /// ## Example
 ///
-/// The easiest way to create a new bundle is to use the [`new_computed`](#method.new_computed) method
+/// The easiest way to create a new bundle is to use the [`new_computed`](Self::new_computed) method
 /// that computes the mass properties based on a given [`Collider`] and density.
 ///
 /// ```

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -161,7 +161,7 @@ use derive_more::From;
 ///
 /// If you don't want to add a collider, you can instead add a [`MassPropertiesBundle`]
 /// with the mass properties computed from a collider shape using the
-/// [`MassPropertiesBundle::new_computed`](MassPropertiesBundle#method.new_computed) method.
+/// [`MassPropertiesBundle::new_computed`](MassPropertiesBundle::new_computed) method.
 ///
 /// ```
 /// # use bevy::prelude::*;

--- a/src/plugins/collision/mod.rs
+++ b/src/plugins/collision/mod.rs
@@ -40,11 +40,11 @@ use indexmap::IndexMap;
 ///
 /// The following methods can be used for querying existing collisions:
 ///
-/// - [`get`](#method.get) and [`get_mut`](#method.get_mut)
-/// - [`iter`](#method.iter) and [`iter_mut`](#method.iter_mut)
-/// - [`contains`](#method.contains)
-/// - [`collisions_with_entity`](#method.collisions_with_entity) and
-/// [`collisions_with_entity_mut`](#method.collisions_with_entity_mut)
+/// - [`get`](Self::get) and [`get_mut`](Self::get_mut)
+/// - [`iter`](Self::iter) and [`iter_mut`](Self::iter_mut)
+/// - [`contains`](Self::contains)
+/// - [`collisions_with_entity`](Self::collisions_with_entity) and
+/// [`collisions_with_entity_mut`](Self::collisions_with_entity_mut)
 ///
 /// The collisions can be accessed at any time, but modifications to contacts should be performed
 /// in the [`PostProcessCollisions`] schedule. Otherwise, the physics solver will use the old contact data.
@@ -53,9 +53,9 @@ use indexmap::IndexMap;
 ///
 /// The following methods can be used for filtering or removing existing collisions:
 ///
-/// - [`retain`](#method.retain)
-/// - [`remove_collision_pair`](#method.remove_collision_pair)
-/// - [`remove_collisions_with_entity`](#method.remove_collisions_with_entity)
+/// - [`retain`](Self::retain)
+/// - [`remove_collision_pair`](Self::remove_collision_pair)
+/// - [`remove_collisions_with_entity`](Self::remove_collisions_with_entity)
 ///
 /// Collision filtering and removal should be done in the [`PostProcessCollisions`] schedule.
 /// Otherwise, the physics solver will use the old contact data.
@@ -64,8 +64,8 @@ use indexmap::IndexMap;
 ///
 /// The following methods can be used for adding new collisions:
 ///
-/// - [`insert_collision_pair`](#method.insert_collision_pair)
-/// - [`extend`](#method.extend)
+/// - [`insert_collision_pair`](Self::insert_collision_pair)
+/// - [`extend`](Self::extend)
 ///
 /// The most convenient place for adding new collisions is in the [`PostProcessCollisions`] schedule.
 /// Otherwise, the physics solver might not have access to them in time.
@@ -76,7 +76,7 @@ use indexmap::IndexMap;
 /// and the previous frame, which is used for things like [collision events](ContactReportingPlugin#collision-events).
 ///
 /// However, the public methods only use the current frame's collisions. To access the internal data structure,
-/// you can use [`get_internal`](#method.get_internal) or [`get_internal_mut`](#method.get_internal_mut).
+/// you can use [`get_internal`](Self::get_internal) or [`get_internal_mut`](Self::get_internal_mut).
 #[derive(Resource, Clone, Debug, Default, PartialEq)]
 pub struct Collisions(IndexMap<(Entity, Entity), Contacts, fxhash::FxBuildHasher>);
 
@@ -184,8 +184,8 @@ impl Collisions {
     /// and the old value will be returned. Otherwise, `None` is returned.
     ///
     /// **Note**: Manually inserting collisions can be error prone and should generally be avoided.
-    /// If you simply want to modify existing collisions, consider using methods like [`get_mut`](#method.get_mut)
-    /// or [`iter_mut`](#method.iter_mut).
+    /// If you simply want to modify existing collisions, consider using methods like [`get_mut`](Self::get_mut)
+    /// or [`iter_mut`](Self::iter_mut).
     pub fn insert_collision_pair(&mut self, contacts: Contacts) -> Option<Contacts> {
         // TODO: We might want to order the data by Entity ID so that entity1, point1 etc. are for the "smaller"
         // entity ID. This requires changes elsewhere as well though.
@@ -195,7 +195,7 @@ impl Collisions {
 
     /// Extends [`Collisions`] with all collision pairs in the given iterable.
     ///
-    /// This is mostly equivalent to calling [`insert_collision_pair`](#method.insert_collision_pair)
+    /// This is mostly equivalent to calling [`insert_collision_pair`](Self::insert_collision_pair)
     /// for each of the collision pairs.
     pub fn extend<I: IntoIterator<Item = Contacts>>(&mut self, collisions: I) {
         // (Note: this is a copy of `std`/`hashbrown`/`indexmap`'s reservation logic.)

--- a/src/plugins/spatial_query/mod.rs
+++ b/src/plugins/spatial_query/mod.rs
@@ -25,8 +25,8 @@
 //! in the [`RayHits`] component every frame. It uses local coordinates, so it will automatically follow the entity
 //! it's attached to or its parent.
 //! 2. When you need more control or don't want to cast every frame, use the raycasting methods provided by
-//! [`SpatialQuery`], like [`cast_ray`](SpatialQuery#method.cast_ray), [`ray_hits`](SpatialQuery#method.ray_hits) or
-//! [`ray_hits_callback`](SpatialQuery#method.ray_hits_callback).
+//! [`SpatialQuery`], like [`cast_ray`](SpatialQuery::cast_ray), [`ray_hits`](SpatialQuery::ray_hits) or
+//! [`ray_hits_callback`](SpatialQuery::ray_hits_callback).
 //!
 //! See the documentation of the components and methods for more information.
 //!
@@ -80,8 +80,8 @@
 //! in the [`ShapeHits`] component every frame. It uses local coordinates, so it will automatically follow the entity
 //! it's attached to or its parent.
 //! 2. When you need more control or don't want to cast every frame, use the shapecasting methods provided by
-//! [`SpatialQuery`], like [`cast_shape`](SpatialQuery#method.cast_shape), [`shape_hits`](SpatialQuery#method.shape_hits) or
-//! [`shape_hits_callback`](SpatialQuery#method.shape_hits_callback).
+//! [`SpatialQuery`], like [`cast_shape`](SpatialQuery::cast_shape), [`shape_hits`](SpatialQuery::shape_hits) or
+//! [`shape_hits_callback`](SpatialQuery::shape_hits_callback).
 //!
 //! See the documentation of the components and methods for more information.
 //!
@@ -122,7 +122,7 @@
 //! **Point projection** is a spatial query that projects a point on the closest collider. It returns the collider's
 //! entity, the projected point, and whether the point is inside of the collider.
 //!
-//! Point projection can be done with the [`project_point`](SpatialQuery#method.project_point) method of the [`SpatialQuery`]
+//! Point projection can be done with the [`project_point`](SpatialQuery::project_point) method of the [`SpatialQuery`]
 //! system parameter. See its documentation for more information.
 //!
 //! To specify which colliders should be considered in the query, use a [spatial query filter](`SpatialQueryFilter`).
@@ -135,11 +135,11 @@
 //! There are three types of intersection tests. They are all methods of the [`SpatialQuery`] system parameter,
 //! and they all have callback variants that call a given callback on each intersection.
 //!
-//! - [`point_intersections`](SpatialQuery#method.point_intersections): Finds all entities with a collider that contains
+//! - [`point_intersections`](SpatialQuery::point_intersections): Finds all entities with a collider that contains
 //! the given point.
-//! - [`aabb_intersections_with_aabb`](SpatialQuery#method.aabb_intersections_with_aabb):
+//! - [`aabb_intersections_with_aabb`](SpatialQuery::aabb_intersections_with_aabb):
 //! Finds all entities with a [`ColliderAabb`] that is intersecting the given [`ColliderAabb`].
-//! - [`shape_intersections`](SpatialQuery#method.shape_intersections): Finds all entities with a [collider](Collider)
+//! - [`shape_intersections`](SpatialQuery::shape_intersections): Finds all entities with a [collider](Collider)
 //! that is intersecting the given shape.
 //!
 //! See the documentation of the components and methods for more information.

--- a/src/plugins/spatial_query/ray_caster.rs
+++ b/src/plugins/spatial_query/ray_caster.rs
@@ -22,7 +22,7 @@ use parry::query::{
 /// ## Hit count and order
 ///
 /// The results of a raycast are in an arbitrary order by default. You can iterate over them in the order of
-/// time of impact with the [`RayHits::iter_sorted`](RayHits#method.iter_sorted) method.
+/// time of impact with the [`RayHits::iter_sorted`] method.
 ///
 /// You can configure the maximum amount of hits for a ray using `max_hits`. By default this is unbounded,
 /// so you will get all hits. When the number or complexity of colliders is large, this can be very

--- a/src/plugins/spatial_query/system_param.rs
+++ b/src/plugins/spatial_query/system_param.rs
@@ -5,18 +5,18 @@ use bevy::{ecs::system::SystemParam, prelude::*};
 ///
 /// ## Methods
 ///
-/// - [Raycasting](spatial_query#raycasting): [`cast_ray`](SpatialQuery#method.cast_ray),
-/// [`ray_hits`](SpatialQuery#method.ray_hits), [`ray_hits_callback`](SpatialQuery#method.ray_hits_callback)
-/// - [Shapecasting](spatial_query#shapecasting): [`cast_shape`](SpatialQuery#method.cast_shape),
-/// [`shape_hits`](SpatialQuery#method.shape_hits), [`shape_hits_callback`](SpatialQuery#method.shape_hits_callback)
-/// - [Point projection](spatial_query#point-projection): [`project_point`](SpatialQuery#method.project_point)
+/// - [Raycasting](spatial_query#raycasting): [`cast_ray`](SpatialQuery::cast_ray),
+/// [`ray_hits`](SpatialQuery::ray_hits), [`ray_hits_callback`](SpatialQuery::ray_hits_callback)
+/// - [Shapecasting](spatial_query#shapecasting): [`cast_shape`](SpatialQuery::cast_shape),
+/// [`shape_hits`](SpatialQuery::shape_hits), [`shape_hits_callback`](SpatialQuery::shape_hits_callback)
+/// - [Point projection](spatial_query#point-projection): [`project_point`](SpatialQuery::project_point)
 /// - [Intersection tests](spatial_query#intersection-tests)
-///     - Point intersections: [`point_intersections`](SpatialQuery#method.point_intersections),
-/// [`point_intersections_callback`](SpatialQuery#method.point_intersections_callback)
-///     - AABB intersections: [`aabb_intersections_with_aabb`](SpatialQuery#method.aabb_intersections_with_aabb),
-/// [`aabb_intersections_with_aabb_callback`](SpatialQuery#method.aabb_intersections_with_aabb_callback)
-///     - Shape intersections: [`shape_intersections`](SpatialQuery#method.shape_intersections)
-/// [`shape_intersections_callback`](SpatialQuery#method.shape_intersections_callback)
+///     - Point intersections: [`point_intersections`](SpatialQuery::point_intersections),
+/// [`point_intersections_callback`](SpatialQuery::point_intersections_callback)
+///     - AABB intersections: [`aabb_intersections_with_aabb`](SpatialQuery::aabb_intersections_with_aabb),
+/// [`aabb_intersections_with_aabb_callback`](SpatialQuery::aabb_intersections_with_aabb_callback)
+///     - Shape intersections: [`shape_intersections`](SpatialQuery::shape_intersections)
+/// [`shape_intersections_callback`](SpatialQuery::shape_intersections_callback)
 ///
 /// For simple raycasts and shapecasts, consider using the [`RayCaster`] and [`ShapeCaster`] components that
 /// provide a more ECS-based approach and perform casts on every frame.


### PR DESCRIPTION
# Objective

- Use intradoc links correctly rather than a mix of the old HTML link syntax.
- Hopefully get warnings when something is wrong in the future.

## Solution

- Replace all instances of `#method.*` with better syntax.
