### PR TITLE
Fix fixed timestep using `max_delta_overstep`

### DIFF
--- a/src/plugins/setup/mod.rs
+++ b/src/plugins/setup/mod.rs
@@ -239,23 +239,25 @@ fn run_physics_schedule(world: &mut World, mut is_first_run: Local<IsFirstRun>) 
         // For `TimestepMode::Fixed`, this is computed using the accumulated overstep.
         let mut queued_steps = 1;
 
-        if let TimestepMode::Fixed {
-            delta,
-            overstep,
-            max_delta_overstep,
-        } = world.resource_mut::<Time<Physics>>().timestep_mode_mut()
-        {
-            // If paused, add the `Physics` delta time, otherwise add real time.
-            if is_paused {
-                *overstep += old_delta;
-            } else {
-                *overstep += real_delta.min(*max_delta_overstep);
-            }
+        if !is_first_run.0 {
+            if let TimestepMode::Fixed {
+                delta,
+                overstep,
+                max_delta_overstep,
+            } = world.resource_mut::<Time<Physics>>().timestep_mode_mut()
+            {
+                // If paused, add the `Physics` delta time, otherwise add real time.
+                if is_paused {
+                    *overstep += old_delta;
+                } else {
+                    *overstep += real_delta.min(*max_delta_overstep);
+                }
 
-            // Consume as many steps as possible with the fixed `delta`.
-            queued_steps = (overstep.as_secs_f64() / delta.as_secs_f64()) as usize;
-            *overstep -= delta.mul_f64(queued_steps as f64);
-        };
+                // Consume as many steps as possible with the fixed `delta`.
+                queued_steps = (overstep.as_secs_f64() / delta.as_secs_f64()) as usize;
+                *overstep -= delta.mul_f64(queued_steps as f64);
+            }
+        }
 
         // Advance physics clock by timestep if not paused.
         if !is_paused {

--- a/src/plugins/setup/mod.rs
+++ b/src/plugins/setup/mod.rs
@@ -239,16 +239,17 @@ fn run_physics_schedule(world: &mut World, mut is_first_run: Local<IsFirstRun>) 
         // For `TimestepMode::Fixed`, this is computed using the accumulated overstep.
         let mut queued_steps = 1;
 
-        if let TimestepMode::Fixed { delta, overstep } =
-            world.resource_mut::<Time<Physics>>().timestep_mode_mut()
+        if let TimestepMode::Fixed {
+            delta,
+            overstep,
+            max_delta_overstep,
+        } = world.resource_mut::<Time<Physics>>().timestep_mode_mut()
         {
             // If paused, add the `Physics` delta time, otherwise add real time.
             if is_paused {
                 *overstep += old_delta;
             } else {
-                // TODO: This should probably use real time and not the fixed timestep,
-                //       but it seems to quickly lag and fall into the "spiral of death".
-                *overstep += timestep;
+                *overstep += real_delta.min(*max_delta_overstep);
             }
 
             // Consume as many steps as possible with the fixed `delta`.


### PR DESCRIPTION
# Objective

Fixes #223.

In the migration to Bevy 0.12, the time resources were changed to use Bevy's unified `Time` APIs. However, the fixed timestep broke, as it now runs once every frame with the same timestep, which causes frame rate dependent behavior where bodies seem to move faster at higher frame rates.

## Solution

Add a `max_delta_overstep` property to `TimestepMode::Fixed` that limits how much time can be added to the accumulated `overstep` during a single frame. This is mostly equivalent to getting the elapsed time using `Time<Virtual>` with some `max_delta`, but for now, it's nice to keep the `Time<Physics>` behavior separate from the virtual clock.