### PR TITLE
Fix system order ambiguities, and add a test for it

### DIFF
--- a/src/plugins/prepare.rs
+++ b/src/plugins/prepare.rs
@@ -45,8 +45,15 @@ impl Default for PreparePlugin {
     }
 }
 
+#[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum PrepareSet {
+    Init,
+}
+
 impl Plugin for PreparePlugin {
     fn build(&self, app: &mut App) {
+        app.configure_sets(self.schedule, PrepareSet::Init.in_set(PhysicsSet::Prepare));
+
         app.init_resource::<ColliderStorageMap>().add_systems(
             self.schedule,
             (
@@ -78,6 +85,7 @@ impl Plugin for PreparePlugin {
                 apply_deferred,
             )
                 .chain()
+                .after(PrepareSet::Init)
                 .in_set(PhysicsSet::Prepare),
         );
 

--- a/src/plugins/spatial_query/mod.rs
+++ b/src/plugins/spatial_query/mod.rs
@@ -189,7 +189,7 @@ impl Plugin for SpatialQueryPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<SpatialQueryPipeline>().add_systems(
             self.schedule,
-            (init_ray_hits, init_shape_hit).in_set(PhysicsSet::Prepare),
+            (init_ray_hits, init_shape_hit).in_set(PrepareSet::Init),
         );
 
         let physics_schedule = app


### PR DESCRIPTION
# Objective

Adding bevy_xpbd to a schedule should not cause it to report order ambiguities. This is essential for deterministic rollback to work.

## Solution

Add a test that tries to add PhysicsPlugins to a deterministic schedule, and update it once. If the schedule has ambiguitiy errors, it will panic.

False positives should be marked with `system.ambiguous_with`.

Order the init shapecast systems in prepare explicitly before the other systems, to resolve the current ambiguities.

---

## Changelog

- Fixed system order ambiguities
