### PR TITLE
docs: Fix incorrect docs for mass component auto-initialization

### DIFF
--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -66,8 +66,8 @@ use derive_more::From;
 ///
 /// You can change any of these during initialization and runtime in order to alter the behaviour of the body.
 ///
-/// Note that by default, rigid bodies don't have any mass, so dynamic bodies can
-/// gain infinite velocity during interactions. See [mass properties](#mass-properties).
+/// By default, rigid bodies will get a mass based on their collider and density.
+/// See [mass properties](#mass-properties).
 ///
 /// ## Movement
 ///


### PR DESCRIPTION
# Objective

I was confused about what mass my bodies were getting by default. And from the docs, it seemed like they shouldn't have any.

## Solution

Fixed the incorrect documentation