### PR TITLE
Take child collider rotation into account for contact normals

### DIFF
--- a/src/plugins/solver.rs
+++ b/src/plugins/solver.rs
@@ -183,6 +183,12 @@ fn penetration_constraints(
                         point2: collider2.transform.map_or(contact.point2, |t| {
                             t.rotation.rotate(contact.point2) + t.translation
                         }),
+                        normal1: collider1
+                            .transform
+                            .map_or(contact.normal1, |t| t.rotation.rotate(contact.normal1)),
+                        normal2: collider2
+                            .transform
+                            .map_or(contact.normal2, |t| t.rotation.rotate(contact.normal2)),
                         ..*contact
                     };
 


### PR DESCRIPTION
# Objective

Currently, local contact normals are only rotated by the rotation of each body, but the rotation of child colliders is not taken into account. This causes collision stability issues and incorrect behavior when child colliders are rotated.

For example, with the code below, the cube falls through the ground as reported by `@mbreac` on the Bevy Discord:

```rust
fn main() {
    App::new()
        .add_plugins((DefaultPlugins, PhysicsPlugins::default()))
        .add_systems(Startup, setup)
        .run();
}

fn setup(
    mut commands: Commands,
    mut materials: ResMut<Assets<StandardMaterial>>,
    mut meshes: ResMut<Assets<Mesh>>,
) {
    // floor
    commands
        .spawn(PbrBundle {
            mesh: meshes.add(shape::Box::new(4., 0.3, 4.).into()),
            material: materials.add(Color::WHITE.into()),
            ..default()
        })
        .insert(RigidBody::Static)
        .with_children(|b| {
            b.spawn(SpatialBundle {
                transform: Transform::from_rotation(Quat::from_rotation_x(FRAC_PI_2)),
                ..default()
            })
            .insert(Collider::cuboid(4., 4., 0.3));
        });

    // cube
    commands
        .spawn(PbrBundle {
            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
            material: materials.add(Color::RED.into()),
            transform: Transform::from_xyz(0.0, 3.5, 0.0),
            ..default()
        })
        .insert(RigidBody::Dynamic)
        .insert(Collider::cuboid(1., 1., 1.));
}
```

## Solution

Rotate the contact normals passed to the solver by the rotation of the participating child collider. This fixes the issues.