### PR TITLE
Add Serde serialization with `serialize` feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Run cargo test
-        run: cargo test --no-default-features --features enhanced-determinism,collider-from-mesh,bevy_xpbd_2d/2d,bevy_xpbd_3d/3d,bevy_xpbd_2d/f64,bevy_xpbd_3d/f64
+        run: cargo test --no-default-features --features enhanced-determinism,collider-from-mesh,serialize,bevy_xpbd_2d/2d,bevy_xpbd_3d/3d,bevy_xpbd_2d/f64,bevy_xpbd_3d/f64
 
   lints:
     name: Lints

--- a/crates/bevy_xpbd_2d/Cargo.toml
+++ b/crates/bevy_xpbd_2d/Cargo.toml
@@ -24,6 +24,12 @@ enhanced-determinism = [
     "parry2d-f64?/enhanced-determinism",
     "glam/libm",
 ]
+serialize = [
+    "dep:serde",
+    "bevy/serialize",
+    "parry2d?/serde-serialize",
+    "parry2d-f64?/serde-serialize",
+]
 
 [lib]
 name = "bevy_xpbd_2d"
@@ -37,6 +43,7 @@ parry2d = { version = "0.13", optional = true }
 parry2d-f64 = { version = "0.13", optional = true }
 nalgebra = { version = "0.32", features = ["convert-glam024"] }
 glam = { version = "0.24", features = ["approx"] }
+serde = { version = "1", features = ["derive"], optional = true }
 derive_more = "0.99"
 indexmap = "2.0.0"
 fxhash = "0.2.1"

--- a/crates/bevy_xpbd_3d/Cargo.toml
+++ b/crates/bevy_xpbd_3d/Cargo.toml
@@ -26,6 +26,12 @@ enhanced-determinism = [
 ]
 collider-from-mesh = ["bevy/bevy_render"]
 async-collider = ["bevy/bevy_scene", "bevy/bevy_gltf", "collider-from-mesh"]
+serialize = [
+    "dep:serde",
+    "bevy/serialize",
+    "parry3d?/serde-serialize",
+    "parry3d-f64?/serde-serialize",
+]
 
 [lib]
 name = "bevy_xpbd_3d"
@@ -39,6 +45,7 @@ parry3d = { version = "0.13", optional = true }
 parry3d-f64 = { version = "0.13", optional = true }
 nalgebra = { version = "0.32", features = ["convert-glam024"] }
 glam = { version = "0.24", features = ["approx"] }
+serde = { version = "1", features = ["derive"], optional = true }
 derive_more = "0.99"
 indexmap = "2.0.0"
 fxhash = "0.2.1"

--- a/src/components/collider.rs
+++ b/src/components/collider.rs
@@ -139,6 +139,7 @@ pub type TriMeshFlags = parry::shape::TriMeshFlags;
 /// To get a reference to the internal [`SharedShape`], you can use the [`Collider::shape()`]
 /// or [`Collider::shape_scaled()`] methods.
 #[derive(Clone, Component)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Collider {
     /// The raw unscaled collider shape.
     shape: SharedShape,
@@ -1050,6 +1051,7 @@ pub enum ComputedCollider {
 /// }
 /// ```
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct ColliderParent(pub(crate) Entity);
 
 impl ColliderParent {
@@ -1066,6 +1068,7 @@ impl ColliderParent {
 /// without having to traverse deeply nested hierarchies. It's updated automatically,
 /// so you shouldn't modify it manually.
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct ColliderTransform {
     /// The translation of a collider in a rigid body's frame of reference.
     pub translation: Vector,
@@ -1133,11 +1136,13 @@ impl From<Transform> for ColliderTransform {
 /// ```
 #[doc(alias = "Trigger")]
 #[derive(Reflect, Clone, Component, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct Sensor;
 
 /// The Axis-Aligned Bounding Box of a [collider](Collider).
 #[derive(Clone, Copy, Component, Debug, Deref, DerefMut, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct ColliderAabb(pub Aabb);
 
 impl ColliderAabb {
@@ -1176,5 +1181,6 @@ impl Default for ColliderAabb {
 /// }
 /// ```
 #[derive(Reflect, Clone, Component, Debug, Default, Deref, DerefMut, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct CollidingEntities(pub HashSet<Entity>);

--- a/src/components/forces.rs
+++ b/src/components/forces.rs
@@ -88,6 +88,7 @@ impl FloatZero for Scalar {
 /// If you want to apply a force in the same local direction every frame,
 /// consider setting `persistent` to `false` and running [`apply_force`](Self::apply_force) in a system.
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, From)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct ExternalForce {
     /// The total external force that will be applied.
@@ -226,6 +227,7 @@ impl ExternalForce {
 /// }
 /// ```
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, From)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct ExternalTorque {
     /// The total external torque that will be applied.
@@ -369,6 +371,7 @@ impl ExternalTorque {
 /// }
 /// ```
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, From)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct ExternalImpulse {
     /// The total external impulse that will be applied.
@@ -510,6 +513,7 @@ impl ExternalImpulse {
 /// }
 /// ```
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, From)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 #[doc(alias = "ExternalTorqueImpulse")]
 pub struct ExternalAngularImpulse {

--- a/src/components/layers.rs
+++ b/src/components/layers.rs
@@ -70,6 +70,7 @@ impl<L: PhysicsLayer> PhysicsLayer for &L {
 /// }
 /// ```
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct CollisionLayers {
     groups: u32,

--- a/src/components/locked_axes.rs
+++ b/src/components/locked_axes.rs
@@ -26,6 +26,7 @@ use crate::prelude::*;
 /// }
 /// ```
 #[derive(Component, Reflect, Clone, Copy, Debug, Default, From)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct LockedAxes(u8);
 

--- a/src/components/mass_properties.rs
+++ b/src/components/mass_properties.rs
@@ -6,6 +6,7 @@ use crate::utils::get_rotated_inertia_tensor;
 
 /// The mass of a body.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct Mass(pub Scalar);
 
@@ -16,6 +17,7 @@ impl Mass {
 
 /// The inverse mass of a body.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct InverseMass(pub Scalar);
 
@@ -27,6 +29,7 @@ impl InverseMass {
 /// The moment of inertia of a body. This represents the torque needed for a desired angular acceleration.
 #[cfg(feature = "2d")]
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct Inertia(pub Scalar);
 
@@ -39,6 +42,7 @@ pub struct Inertia(pub Scalar);
 /// use the associated `rotated` method. Note that this operation is quite expensive, so use it sparingly.
 #[cfg(feature = "3d")]
 #[derive(Reflect, Clone, Copy, Component, Debug, Deref, DerefMut, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct Inertia(pub Matrix3);
 
@@ -116,6 +120,7 @@ impl Inertia {
 /// the torque needed for a desired angular acceleration.
 #[cfg(feature = "2d")]
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct InverseInertia(pub Scalar);
 
@@ -128,6 +133,7 @@ pub struct InverseInertia(pub Scalar);
 /// use the associated `rotated` method. Note that this operation is quite expensive, so use it sparingly.
 #[cfg(feature = "3d")]
 #[derive(Reflect, Clone, Copy, Component, Debug, Deref, DerefMut, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct InverseInertia(pub Matrix3);
 
@@ -180,6 +186,7 @@ impl From<Inertia> for InverseInertia {
 
 /// The local center of mass of a body.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct CenterOfMass(pub Vector);
 
@@ -209,6 +216,7 @@ impl CenterOfMass {
 /// ```
 #[allow(missing_docs)]
 #[derive(Bundle, Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct MassPropertiesBundle {
     pub mass: Mass,
     pub inverse_mass: InverseMass,
@@ -258,6 +266,7 @@ impl MassPropertiesBundle {
 /// }
 /// ```
 #[derive(Reflect, Clone, Copy, Component, Debug, Deref, DerefMut, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct ColliderDensity(pub Scalar);
 
@@ -305,6 +314,7 @@ impl Default for ColliderDensity {
 /// }
 /// ```
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct ColliderMassProperties {
     /// Mass given by collider.

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -208,6 +208,7 @@ use derive_more::From;
 /// - [Dominance]
 /// - [Automatic deactivation with sleeping](Sleeping)
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub enum RigidBody {
     /// Dynamic bodies are bodies that are affected by forces, velocity and collisions.
@@ -259,6 +260,7 @@ impl RigidBody {
 /// Sleeping can be disabled for specific entities with the [`SleepingDisabled`] component,
 /// or for all entities by setting the [`SleepingThreshold`] to a negative value.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, Eq, From)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct Sleeping;
 
@@ -267,11 +269,13 @@ pub struct Sleeping;
 ///
 /// See [`Sleeping`] for further information.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, From)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct TimeSleeping(pub Scalar);
 
 /// Indicates that the body can not be deactivated by the physics engine. See [`Sleeping`] for information about sleeping.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, Eq, From)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct SleepingDisabled;
 
@@ -304,6 +308,7 @@ pub struct SleepingDisabled;
 /// }
 /// ```
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct Position(pub Vector);
 
@@ -328,6 +333,7 @@ impl Position {
 
 /// The position of a [rigid body](RigidBody) at the start of a substep.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct PreviousPosition(pub Vector);
 
@@ -339,6 +345,7 @@ pub struct PreviousPosition(pub Vector);
 ///
 /// After each substep, actual [`Position`] is updated during [`SubstepSet::ApplyTranslation`].
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct AccumulatedTranslation(pub Vector);
 
@@ -358,6 +365,7 @@ pub struct AccumulatedTranslation(pub Vector);
 /// }
 /// ```
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct LinearVelocity(pub Vector);
 
@@ -368,6 +376,7 @@ impl LinearVelocity {
 
 /// The linear velocity of a [rigid body](RigidBody) before the velocity solve is performed.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub(crate) struct PreSolveLinearVelocity(pub Vector);
 
@@ -388,6 +397,7 @@ pub(crate) struct PreSolveLinearVelocity(pub Vector);
 /// ```
 #[cfg(feature = "2d")]
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, From)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct AngularVelocity(pub Scalar);
 
@@ -408,6 +418,7 @@ pub struct AngularVelocity(pub Scalar);
 /// ```
 #[cfg(feature = "3d")]
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct AngularVelocity(pub Vector);
 
@@ -457,6 +468,7 @@ pub(crate) struct PreSolveAngularVelocity(pub Vector);
 #[derive(
     Component, Reflect, Debug, Clone, Copy, PartialEq, PartialOrd, Default, Deref, DerefMut, From,
 )]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct GravityScale(pub Scalar);
 
@@ -466,6 +478,7 @@ pub struct GravityScale(pub Scalar);
 /// When combine rules clash with each other, the following priority order is used:
 /// `Max > Multiply > Min > Average`.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum CoefficientCombine {
     // The discriminants allow priority ordering to work automatically via comparison methods
     /// Coefficients are combined by computing their average.
@@ -520,6 +533,7 @@ pub enum CoefficientCombine {
 #[doc(alias = "Bounciness")]
 #[doc(alias = "Elasticity")]
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct Restitution {
     /// The [coefficient of restitution](https://en.wikipedia.org/wiki/Coefficient_of_restitution).
@@ -654,6 +668,7 @@ impl From<Scalar> for Restitution {
 /// );
 /// ```
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct Friction {
     /// Coefficient of dynamic friction.
@@ -772,6 +787,7 @@ impl From<Scalar> for Friction {
 #[derive(
     Component, Reflect, Debug, Clone, Copy, PartialEq, PartialOrd, Default, Deref, DerefMut, From,
 )]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct LinearDamping(pub Scalar);
 
@@ -797,6 +813,7 @@ pub struct LinearDamping(pub Scalar);
 #[derive(
     Component, Reflect, Debug, Clone, Copy, PartialEq, PartialOrd, Default, Deref, DerefMut, From,
 )]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct AngularDamping(pub Scalar);
 
@@ -828,6 +845,7 @@ pub struct AngularDamping(pub Scalar);
 /// ```
 #[rustfmt::skip]
 #[derive(Component, Reflect, Debug, Clone, Copy, Default, Deref, DerefMut, From, PartialEq, PartialOrd, Eq, Ord)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct Dominance(pub i8);
 

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -435,6 +435,7 @@ impl AngularVelocity {
 /// the velocity solve is performed. Positive values will result in counterclockwise rotation.
 #[cfg(feature = "2d")]
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, From)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub(crate) struct PreSolveAngularVelocity(pub Scalar);
 
@@ -442,6 +443,7 @@ pub(crate) struct PreSolveAngularVelocity(pub Scalar);
 /// multiplied by the angular speed in radians per second, before the velocity solve is performed.
 #[cfg(feature = "3d")]
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub(crate) struct PreSolveAngularVelocity(pub Vector);
 

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -376,7 +376,6 @@ impl LinearVelocity {
 
 /// The linear velocity of a [rigid body](RigidBody) before the velocity solve is performed.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub(crate) struct PreSolveLinearVelocity(pub Vector);
 
@@ -435,7 +434,6 @@ impl AngularVelocity {
 /// the velocity solve is performed. Positive values will result in counterclockwise rotation.
 #[cfg(feature = "2d")]
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, From)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub(crate) struct PreSolveAngularVelocity(pub Scalar);
 
@@ -443,7 +441,6 @@ pub(crate) struct PreSolveAngularVelocity(pub Scalar);
 /// multiplied by the angular speed in radians per second, before the velocity solve is performed.
 #[cfg(feature = "3d")]
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub(crate) struct PreSolveAngularVelocity(pub Vector);
 

--- a/src/components/rotation.rs
+++ b/src/components/rotation.rs
@@ -46,6 +46,7 @@ pub(crate) type RotationValue = Quaternion;
 /// ```
 #[cfg(feature = "2d")]
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct Rotation {
     /// The cosine of the rotation angle in radians.
@@ -81,6 +82,7 @@ pub struct Rotation {
 /// ```
 #[cfg(feature = "3d")]
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct Rotation(pub Quaternion);
 
@@ -324,5 +326,6 @@ impl From<Rotation> for Matrix3x1<Scalar> {
 
 /// The previous rotation of a body. See [`Rotation`].
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct PreviousRotation(pub Rotation);

--- a/src/constraints/joints/distance.rs
+++ b/src/constraints/joints/distance.rs
@@ -13,6 +13,7 @@ use bevy::{
 ///
 /// Distance joints can be useful for things like springs, muscles, and mass-spring networks.
 #[derive(Component, Clone, Copy, Debug, PartialEq, Reflect)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(MapEntities)]
 pub struct DistanceJoint {
     /// First entity constrained by the joint.

--- a/src/constraints/joints/fixed.rs
+++ b/src/constraints/joints/fixed.rs
@@ -11,6 +11,7 @@ use bevy::{
 /// You should generally prefer using a single body instead of multiple bodies fixed together,
 /// but fixed joints can be useful for things like rigid structures where a force can dynamically break the joints connecting individual bodies.
 #[derive(Component, Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct FixedJoint {
     /// First entity constrained by the joint.
     pub entity1: Entity,

--- a/src/constraints/joints/mod.rs
+++ b/src/constraints/joints/mod.rs
@@ -230,6 +230,7 @@ pub trait Joint: Component + PositionConstraint + AngularConstraint {
 
 /// A limit that indicates that the distance between two points should be between `min` and `max`.
 #[derive(Clone, Copy, Debug, PartialEq, Reflect)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct DistanceLimit {
     /// The minimum distance between two points.
     pub min: Scalar,
@@ -289,6 +290,7 @@ impl DistanceLimit {
 
 /// A limit that indicates that angles should be between `alpha` and `beta`.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct AngleLimit {
     /// The minimum angle.
     pub alpha: Scalar,

--- a/src/constraints/joints/prismatic.rs
+++ b/src/constraints/joints/prismatic.rs
@@ -10,6 +10,7 @@ use bevy::{
 ///
 /// Prismatic joints can be useful for things like elevators, pistons, sliding doors and moving platforms.
 #[derive(Component, Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrismaticJoint {
     /// First entity constrained by the joint.
     pub entity1: Entity,

--- a/src/constraints/joints/revolute.rs
+++ b/src/constraints/joints/revolute.rs
@@ -10,6 +10,7 @@ use bevy::{
 ///
 /// Revolute joints can be useful for things like wheels, fans, revolving doors etc.
 #[derive(Component, Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct RevoluteJoint {
     /// First entity constrained by the joint.
     pub entity1: Entity,

--- a/src/constraints/joints/spherical.rs
+++ b/src/constraints/joints/spherical.rs
@@ -10,6 +10,7 @@ use bevy::{
 ///
 /// Spherical joints can be useful for things like pendula, chains, ragdolls etc.
 #[derive(Component, Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct SphericalJoint {
     /// First entity constrained by the joint.
     pub entity1: Entity,

--- a/src/constraints/penetration.rs
+++ b/src/constraints/penetration.rs
@@ -10,6 +10,7 @@ use bevy::{
 ///
 /// A compliance of 0.0 resembles a constraint with infinite stiffness, so the bodies should not have any overlap.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct PenetrationConstraint {
     /// First entity in the constraint.
     pub entity1: Entity,

--- a/src/plugins/collision/broad_phase.rs
+++ b/src/plugins/collision/broad_phase.rs
@@ -159,7 +159,6 @@ type IsBodyInactive = bool;
 
 /// Entities with [`ColliderAabb`]s sorted along an axis by their extents.
 #[derive(Resource, Default)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 struct AabbIntervals(
     Vec<(
         Entity,

--- a/src/plugins/collision/broad_phase.rs
+++ b/src/plugins/collision/broad_phase.rs
@@ -38,6 +38,7 @@ impl Plugin for BroadPhasePlugin {
 
 /// A list of entity pairs for potential collisions collected during the broad phase.
 #[derive(Reflect, Resource, Default, Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Resource)]
 pub struct BroadCollisionPairs(pub Vec<(Entity, Entity)>);
 
@@ -158,6 +159,7 @@ type IsBodyInactive = bool;
 
 /// Entities with [`ColliderAabb`]s sorted along an axis by their extents.
 #[derive(Resource, Default)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 struct AabbIntervals(
     Vec<(
         Entity,

--- a/src/plugins/collision/contact_query.rs
+++ b/src/plugins/collision/contact_query.rs
@@ -469,7 +469,6 @@ pub type TimeOfImpactStatus = parry::query::details::TOIStatus;
 
 /// The result of a [time of impact](time_of_impact) computation between two moving [`Collider`]s.
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct TimeOfImpact {
     /// The time at which the colliders come into contact.
     pub time_of_impact: Scalar,

--- a/src/plugins/collision/contact_query.rs
+++ b/src/plugins/collision/contact_query.rs
@@ -219,6 +219,7 @@ pub fn contact_manifolds(
 ///
 /// The closest points can be computed using [`closest_points`].
 #[derive(Reflect, Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum ClosestPoints {
     /// The two shapes are intersecting each other.
     Intersecting,
@@ -468,6 +469,7 @@ pub type TimeOfImpactStatus = parry::query::details::TOIStatus;
 
 /// The result of a [time of impact](time_of_impact) computation between two moving [`Collider`]s.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct TimeOfImpact {
     /// The time at which the colliders come into contact.
     pub time_of_impact: Scalar,

--- a/src/plugins/collision/contact_reporting.rs
+++ b/src/plugins/collision/contact_reporting.rs
@@ -83,6 +83,7 @@ impl Plugin for ContactReportingPlugin {
 /// }
 /// ```
 #[derive(Event, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Collision(pub Contacts);
 
 /// A [collision event](ContactReportingPlugin#collision-events)
@@ -113,6 +114,7 @@ pub struct Collision(pub Contacts);
 /// }
 /// ```
 #[derive(Event, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct CollisionStarted(pub Entity, pub Entity);
 
 /// A [collision event](ContactReportingPlugin#collision-events)
@@ -143,6 +145,7 @@ pub struct CollisionStarted(pub Entity, pub Entity);
 /// }
 /// ```
 #[derive(Event, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct CollisionEnded(pub Entity, pub Entity);
 
 /// Sends collision events and updates [`CollidingEntities`].

--- a/src/plugins/collision/mod.rs
+++ b/src/plugins/collision/mod.rs
@@ -78,7 +78,6 @@ use indexmap::IndexMap;
 /// However, the public methods only use the current frame's collisions. To access the internal data structure,
 /// you can use [`get_internal`](Self::get_internal) or [`get_internal_mut`](Self::get_internal_mut).
 #[derive(Resource, Clone, Debug, Default, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Collisions(IndexMap<(Entity, Entity), Contacts, fxhash::FxBuildHasher>);
 
 impl Collisions {

--- a/src/plugins/collision/mod.rs
+++ b/src/plugins/collision/mod.rs
@@ -78,6 +78,7 @@ use indexmap::IndexMap;
 /// However, the public methods only use the current frame's collisions. To access the internal data structure,
 /// you can use [`get_internal`](Self::get_internal) or [`get_internal_mut`](Self::get_internal_mut).
 #[derive(Resource, Clone, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Collisions(IndexMap<(Entity, Entity), Contacts, fxhash::FxBuildHasher>);
 
 impl Collisions {
@@ -250,6 +251,7 @@ pub(super) struct PreviousCollisions(Collisions);
 /// Each manifold contains one or more contact points, and each contact
 /// in a given manifold shares the same contact normal.
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Contacts {
     /// First entity in the contact.
     pub entity1: Entity,
@@ -270,6 +272,7 @@ pub struct Contacts {
 /// A contact manifold between two colliders, containing a set of contact points.
 /// Each contact in a manifold shares the same contact normal.
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct ContactManifold {
     /// The contacts in this manifold.
     pub contacts: Vec<ContactData>,
@@ -295,6 +298,7 @@ impl ContactManifold {
 
 /// Data related to a contact between two bodies.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct ContactData {
     /// Contact point on the first entity in local coordinates.
     pub point1: Vector,

--- a/src/plugins/collision/narrow_phase.rs
+++ b/src/plugins/collision/narrow_phase.rs
@@ -55,6 +55,7 @@ impl Plugin for NarrowPhasePlugin {
 
 /// A resource for configuring the [narrow phase](NarrowPhasePlugin).
 #[derive(Resource, Reflect, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Resource)]
 pub struct NarrowPhaseConfig {
     /// The maximum separation distance allowed for a collision to be accepted.

--- a/src/plugins/debug/configuration.rs
+++ b/src/plugins/debug/configuration.rs
@@ -34,6 +34,7 @@ use bevy::prelude::*;
 /// }
 /// ```
 #[derive(Reflect, Resource)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Resource)]
 pub struct PhysicsDebugConfig {
     /// Determines if debug rendering is enabled.
@@ -349,6 +350,7 @@ impl PhysicsDebugConfig {
 /// }
 /// ```
 #[derive(Component, Reflect, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct DebugRender {
     /// The lengths of the axes drawn for the entity at the center of mass.

--- a/src/plugins/prepare.rs
+++ b/src/plugins/prepare.rs
@@ -104,7 +104,6 @@ impl Plugin for PreparePlugin {
 }
 
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub(crate) struct PreviousColliderTransform(ColliderTransform);
 
@@ -118,7 +117,6 @@ pub(crate) struct PreviousColliderTransform(ColliderTransform);
 /// Ideally, we would just have some entity removal event or callback, but that doesn't
 /// exist yet, and `RemovedComponents` only returns entities, not component data.
 #[derive(Resource, Reflect, Clone, Debug, Default, Deref, DerefMut, PartialEq)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Resource)]
 pub(crate) struct ColliderStorageMap(
     HashMap<Entity, (ColliderParent, ColliderMassProperties, ColliderTransform)>,

--- a/src/plugins/prepare.rs
+++ b/src/plugins/prepare.rs
@@ -104,6 +104,7 @@ impl Plugin for PreparePlugin {
 }
 
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub(crate) struct PreviousColliderTransform(ColliderTransform);
 
@@ -117,6 +118,7 @@ pub(crate) struct PreviousColliderTransform(ColliderTransform);
 /// Ideally, we would just have some entity removal event or callback, but that doesn't
 /// exist yet, and `RemovedComponents` only returns entities, not component data.
 #[derive(Resource, Reflect, Clone, Debug, Default, Deref, DerefMut, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Resource)]
 pub(crate) struct ColliderStorageMap(
     HashMap<Entity, (ColliderParent, ColliderMassProperties, ColliderTransform)>,

--- a/src/plugins/setup/time.rs
+++ b/src/plugins/setup/time.rs
@@ -8,6 +8,7 @@ use crate::prelude::*;
 
 /// The type of timestep used for the [`Time<Physics>`](Physics) clock.
 #[derive(Reflect, Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum TimestepMode {
     /// **Fixed timestep**: The physics simulation will be advanced by a fixed `delta`
     /// amount of time every frame until the accumulated `overstep` value has been consumed.
@@ -214,6 +215,7 @@ impl Default for TimestepMode {
 /// independence, but it's still recommended so that the physical units are more logical.
 
 #[derive(Reflect, Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Physics {
     timestep_mode: TimestepMode,
     paused: bool,

--- a/src/plugins/solver.rs
+++ b/src/plugins/solver.rs
@@ -76,6 +76,7 @@ impl Plugin for SolverPlugin {
 
 /// Stores penetration constraints for colliding entity pairs.
 #[derive(Resource, Debug, Default)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct PenetrationConstraints(pub Vec<PenetrationConstraint>);
 
 /// A [`WorldQuery`] to make code handling colliders in collisions cleaner.

--- a/src/plugins/spatial_query/pipeline.rs
+++ b/src/plugins/spatial_query/pipeline.rs
@@ -717,6 +717,7 @@ impl<'a> TypedSimdCompositeShape for QueryPipelineAsCompositeShape<'a> {
 
 /// The result of a [point projection](spatial_query#point-projection) on a [collider](Collider).
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct PointProjection {
     /// The entity of the collider that the point was projected onto.
     pub entity: Entity,

--- a/src/plugins/spatial_query/query_filter.rs
+++ b/src/plugins/spatial_query/query_filter.rs
@@ -24,6 +24,7 @@ use crate::prelude::*;
 /// }
 /// ```
 #[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct SpatialQueryFilter {
     /// Specifies which [collision groups](CollisionLayers) will be included in a [spatial query](crate::spatial_query).
     pub masks: u32,

--- a/src/plugins/spatial_query/ray_caster.rs
+++ b/src/plugins/spatial_query/ray_caster.rs
@@ -63,6 +63,7 @@ use parry::query::{
 /// }
 /// ```
 #[derive(Component)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct RayCaster {
     /// Controls if the ray caster is enabled.
     pub enabled: bool,
@@ -324,6 +325,7 @@ impl RayCaster {
 /// }
 /// ```
 #[derive(Component, Clone, Default)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct RayHits {
     pub(crate) vector: Vec<RayHitData>,
     /// The number of hits.
@@ -380,6 +382,7 @@ impl MapEntities for RayHits {
 
 /// Data related to a hit during a [raycast](spatial_query#raycasting).
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct RayHitData {
     /// The entity of the collider that was hit by the ray.
     pub entity: Entity,

--- a/src/plugins/spatial_query/shape_caster.rs
+++ b/src/plugins/spatial_query/shape_caster.rs
@@ -50,6 +50,7 @@ use parry::query::details::TOICompositeShapeShapeBestFirstVisitor;
 /// }
 /// ```
 #[derive(Component)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct ShapeCaster {
     /// Controls if the shape caster is enabled.
     pub enabled: bool,
@@ -353,6 +354,7 @@ impl ShapeCaster {
 /// }
 /// ```
 #[derive(Component, Clone, Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct ShapeHits {
     pub(crate) vector: Vec<ShapeHitData>,
     pub(crate) count: u32,
@@ -397,6 +399,7 @@ impl MapEntities for ShapeHits {
 
 /// Data related to a hit during a [shapecast](spatial_query#shapecasting).
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct ShapeHitData {
     /// The entity of the collider that was hit by the shape.
     pub entity: Entity,

--- a/src/plugins/sync.rs
+++ b/src/plugins/sync.rs
@@ -118,6 +118,7 @@ impl Plugin for SyncPlugin {
 
 /// Configures what physics data is synchronized by the [`SyncPlugin`] and how.
 #[derive(Resource, Reflect, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Resource)]
 pub struct SyncConfig {
     /// Updates transforms based on [`Position`] and [`Rotation`] changes. Defaults to true.
@@ -139,6 +140,7 @@ impl Default for SyncConfig {
 /// The global transform of a body at the end of the previous frame.
 /// Used for detecting if the transform was modified before the start of the physics schedule.
 #[derive(Component, Reflect, Clone, Copy, Debug, Default, Deref, DerefMut, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct PreviousGlobalTransform(pub GlobalTransform);
 

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -31,6 +31,7 @@ use crate::prelude::*;
 /// }
 /// ```
 #[derive(Reflect, Resource, Clone, Copy)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Resource)]
 pub struct SubstepCount(pub u32);
 
@@ -46,6 +47,7 @@ impl Default for SubstepCount {
 ///
 /// See [`Sleeping`] for further information about sleeping.
 #[derive(Reflect, Resource, Clone, Copy, PartialEq, PartialOrd, Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Resource)]
 pub struct SleepingThreshold {
     /// The maximum linear velocity allowed for a body to be marked as sleeping.
@@ -68,6 +70,7 @@ impl Default for SleepingThreshold {
 ///
 /// See [`Sleeping`] for further information about sleeping.
 #[derive(Reflect, Resource, Clone, Copy, PartialEq, PartialOrd, Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Resource)]
 pub struct DeactivationTime(pub Scalar);
 
@@ -113,6 +116,7 @@ impl Default for DeactivationTime {
 ///
 /// You can also modify gravity while the app is running.
 #[derive(Reflect, Resource, Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Resource)]
 pub struct Gravity(pub Vector);
 


### PR DESCRIPTION
# Objective

Fixes #243.

People commonly need to use Serde for serialization and deserialization, but it's not currently derived for any types.

## Solution

Add `serialize` feature flag that derives `Serialize` and `Deserialize` for bevy_xpbd's types.

---

## Changelog

- Added `serialize` feature
    - Added `serde`
    - Derived `Serialize` and `Deserialize` for types