### PR TITLE
Fix rotations when center of mass is offset

### DIFF
--- a/src/components/world_queries.rs
+++ b/src/components/world_queries.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)]
 
-use crate::prelude::*;
+use crate::{prelude::*, utils::get_pos_translation};
 use bevy::ecs::query::WorldQuery;
 use std::ops::{AddAssign, SubAssign};
 
@@ -69,7 +69,13 @@ impl<'w> RigidBodyQueryItem<'w> {
     /// Returns the current position of the body. This is a sum of the [`Position`] and
     /// [`AccumulatedTranslation`] components.
     pub fn current_position(&self) -> Vector {
-        self.position.0 + self.accumulated_translation.0
+        self.position.0
+            + get_pos_translation(
+                &self.accumulated_translation,
+                &self.previous_rotation,
+                &self.rotation,
+                &self.center_of_mass,
+            )
     }
 
     /// Returns the [dominance](Dominance) of the body.

--- a/src/plugins/solver.rs
+++ b/src/plugins/solver.rs
@@ -584,6 +584,7 @@ pub fn joint_damping<T: Joint>(
     }
 }
 
+#[allow(clippy::type_complexity)]
 fn apply_translation(
     mut bodies: Query<
         (

--- a/src/plugins/solver.rs
+++ b/src/plugins/solver.rs
@@ -602,10 +602,9 @@ fn apply_translation(
             continue;
         }
 
-        let prev_global_com = pos.0 + prev_rot.0.rotate(center_of_mass.0);
-        let next_global_com = prev_global_com + translation.0;
-
-        pos.0 = next_global_com - rot.rotate(center_of_mass.0);
+        // We must also account for the translation caused by rotations around the center of mass,
+        // as it may be offset from `Position`.
+        pos.0 += translation.0 + prev_rot.0.rotate(center_of_mass.0) - rot.rotate(center_of_mass.0);
         translation.0 = Vector::ZERO;
     }
 }

--- a/src/plugins/solver.rs
+++ b/src/plugins/solver.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     prelude::*,
-    utils::{compute_dynamic_friction, compute_restitution},
+    utils::{compute_dynamic_friction, compute_restitution, get_pos_translation},
 };
 use bevy::{
     ecs::query::{Has, WorldQuery},
@@ -605,7 +605,7 @@ fn apply_translation(
 
         // We must also account for the translation caused by rotations around the center of mass,
         // as it may be offset from `Position`.
-        pos.0 += translation.0 + prev_rot.0.rotate(center_of_mass.0) - rot.rotate(center_of_mass.0);
+        pos.0 += get_pos_translation(&translation, prev_rot, rot, center_of_mass);
         translation.0 = Vector::ZERO;
     }
 }

--- a/src/plugins/solver.rs
+++ b/src/plugins/solver.rs
@@ -586,16 +586,26 @@ pub fn joint_damping<T: Joint>(
 
 fn apply_translation(
     mut bodies: Query<
-        (&RigidBody, &mut Position, &mut AccumulatedTranslation),
+        (
+            &RigidBody,
+            &mut Position,
+            &Rotation,
+            &PreviousRotation,
+            &mut AccumulatedTranslation,
+            &CenterOfMass,
+        ),
         Changed<AccumulatedTranslation>,
     >,
 ) {
-    for (rb, mut pos, mut translation) in &mut bodies {
+    for (rb, mut pos, rot, prev_rot, mut translation, center_of_mass) in &mut bodies {
         if rb.is_static() {
             continue;
         }
 
-        pos.0 += translation.0;
+        let prev_global_com = pos.0 + prev_rot.0.rotate(center_of_mass.0);
+        let next_global_com = prev_global_com + translation.0;
+
+        pos.0 = next_global_com - rot.rotate(center_of_mass.0);
         translation.0 = Vector::ZERO;
     }
 }

--- a/src/plugins/sync.rs
+++ b/src/plugins/sync.rs
@@ -404,6 +404,7 @@ unsafe fn propagate_collider_transforms_recursive(
 /// This allows users to use transforms for moving and positioning bodies and colliders.
 ///
 /// To account for hierarchies, transform propagation should be run before this system.
+#[allow(clippy::type_complexity)]
 fn transform_to_position(
     mut query: Query<(
         &GlobalTransform,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -32,6 +32,17 @@ pub(crate) fn get_rotated_inertia_tensor(inertia_tensor: Matrix3, rot: Quaternio
     (rot_mat3 * inertia_tensor) * rot_mat3.transpose()
 }
 
+/// Computes translation of `Position` based on center of mass rotation and translation
+pub(crate) fn get_pos_translation(
+    com_translation: &AccumulatedTranslation,
+    previous_rotation: &Rotation,
+    rotation: &Rotation,
+    center_of_mass: &CenterOfMass,
+) -> Vector {
+    com_translation.0 + previous_rotation.rotate(center_of_mass.0)
+        - rotation.rotate(center_of_mass.0)
+}
+
 /// Computes the magnitude of the impulse caused by dynamic friction.
 pub(crate) fn compute_dynamic_friction(
     tangent_speed: Scalar,


### PR DESCRIPTION
# Objective

Fixes #246 and #244.

## Solution

If we consider `AccumulatedTranslation` to represent the translation of the center of mass (instead of the position),
it's only necessary to account for the center of mass offset when applying the translation. Since we already have access to the original position and translation, computing the change in `Position` based on the change in center of mass position and rotation is straightforward.

Usages of `AccumulatedTranslation` that assumed it refers to a translation applied directly to `Position` had to be updated. Fortunately, `AccumulatedTranslation` is often accessed through `RigidBodyQuery::current_position`, so not many changes were needed.

## Performance

There's no measurable performance impact when testing in my game with hundreds of child colliders and profiling with Tracy (external trace includes this PR, this trace is main branch):

![performance](https://github.com/Jondolf/bevy_xpbd/assets/31567043/99e759ab-b53b-4b01-bae6-482a15fb9b9e)

## Alternative solutions considered

An alternative approach is to apply the additional translation due a rotation every time we apply a rotation (during integration,  constraint solving) and take into account only the change in position of the center of mass in `update_lin_vel`. This was what I tried first, but I was unable to get it to work due to numerical inaccuracies that caused unexpected accelerations, or some other insidious bug I couldn't find :). Either way, this alternative would have required more changes, and for what it's worth I personally found it less clean as there was no longer a clean separation between updates to position and rotation (every rotation had to add a small change to the position).

## Changelog

- `AccumulatedTranslation` now refers to the translation of the center of mass, which may not equal the translation applied to `Position` when the center of mass is offset.
- Rotational motion with offset centers of mass now works as expected.
  - As a result, child colliders finally *feel* stable in my testing.