### PR TITLE
Added variant TriMeshWithFlags to ComputedCollider, fix #248

### DIFF
--- a/src/components/collider.rs
+++ b/src/components/collider.rs
@@ -892,7 +892,7 @@ pub struct AsyncCollider(pub ComputedCollider);
 ///     // Generate colliders for everything except specific meshes by name
 ///     commands.spawn((
 ///         scene,
-///         AsyncSceneCollider::new(ComputedCollider::TriMesh)
+///         AsyncSceneCollider::new(ComputedCollider::TriMeshWithFlags(TriMeshFlags::MERGE_DUPLICATE_VERTICES))
 ///             .without_shape_for_name("Tree"),
 ///     ));
 /// }
@@ -1016,6 +1016,8 @@ pub enum ComputedCollider {
     /// A triangle mesh.
     #[default]
     TriMesh,
+    /// A triangle mesh with a custom configuration.
+    TriMeshWithFlags(TriMeshFlags),
     /// A convex hull.
     ConvexHull,
     /// A compound shape obtained from a decomposition into convex parts using the specified

--- a/src/plugins/prepare.rs
+++ b/src/plugins/prepare.rs
@@ -419,6 +419,9 @@ pub fn init_async_colliders(
         if let Some(mesh) = meshes.get(mesh_handle) {
             let collider = match &async_collider.0 {
                 ComputedCollider::TriMesh => Collider::trimesh_from_mesh(mesh),
+                ComputedCollider::TriMeshWithFlags(flags) => {
+                    Collider::trimesh_from_mesh_with_config(mesh, *flags)
+                }
                 ComputedCollider::ConvexHull => Collider::convex_hull_from_mesh(mesh),
                 ComputedCollider::ConvexDecomposition(params) => {
                     Collider::convex_decomposition_from_mesh_with_config(mesh, params)
@@ -468,6 +471,9 @@ pub fn init_async_scene_colliders(
 
                     let collider = match collider_data.shape {
                         ComputedCollider::TriMesh => Collider::trimesh_from_mesh(mesh),
+                        ComputedCollider::TriMeshWithFlags(flags) => {
+                            Collider::trimesh_from_mesh_with_config(mesh, flags)
+                        }
                         ComputedCollider::ConvexHull => Collider::convex_hull_from_mesh(mesh),
                         ComputedCollider::ConvexDecomposition(params) => {
                             Collider::convex_decomposition_from_mesh_with_config(mesh, &params)


### PR DESCRIPTION
fixes #248 
adds a variant `ComputedCollider::TriMeshWithFlags` that allows for generation of Colliders with flags using AsyncCollider.