### PR TITLE
Use any_orthogonal_vector to get orthogonal vector

### DIFF
--- a/src/constraints/joints/prismatic.rs
+++ b/src/constraints/joints/prismatic.rs
@@ -173,7 +173,7 @@ impl PrismaticJoint {
         }
         #[cfg(feature = "3d")]
         {
-            let axis2 = axis1.cross(Vector::Y);
+            let axis2 = axis1.any_orthogonal_vector();
             let axis3 = axis1.cross(axis2);
 
             delta_x += zero_distance_limit.compute_correction_along_axis(


### PR DESCRIPTION
Using Vector::Y here doesn't work if axis1 is parallel with Y (or close to it due to precision issues).