### PR TITLE
Preserve collisions between inactive entities, add sensor example

### DIFF
--- a/crates/bevy_xpbd_2d/examples/sensor.rs
+++ b/crates/bevy_xpbd_2d/examples/sensor.rs
@@ -1,0 +1,219 @@
+use bevy::{prelude::*, sprite::MaterialMesh2dBundle};
+use bevy_xpbd_2d::{math::*, prelude::*};
+use examples_common_2d::XpbdExamplePlugin;
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, XpbdExamplePlugin))
+        .insert_resource(ClearColor(Color::rgb(0.05, 0.05, 0.1)))
+        .insert_resource(Gravity(Vector::ZERO))
+        .add_event::<MovementAction>()
+        .add_systems(Startup, setup)
+        .add_systems(
+            Update,
+            (
+                keyboard_input,
+                apply_deferred,
+                movement.run_if(has_movement), // don't mutably access the character if there is no movement
+                apply_movement_damping,
+                apply_pressure_plate_colour,
+                update_velocity_text,
+                log_events,
+            )
+                .chain(),
+        )
+        .run();
+}
+
+#[derive(Component, Default, Reflect)]
+struct Character;
+
+#[derive(Component, Default, Reflect)]
+struct PressurePlate;
+
+#[derive(Component, Default, Reflect)]
+struct CharacterVelocityText;
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+) {
+    commands.spawn((
+        MaterialMesh2dBundle {
+            mesh: meshes
+                .add(
+                    shape::Capsule {
+                        radius: 12.5,
+                        depth: 20.0,
+                        ..default()
+                    }
+                    .into(),
+                )
+                .into(),
+            material: materials.add(ColorMaterial::from(Color::rgb(0.2, 0.7, 0.9))),
+            transform: Transform::from_xyz(0.0, -100.0, 0.0),
+            ..default()
+        },
+        Character,
+        RigidBody::Dynamic,
+        Collider::capsule(20.0, 12.5),
+        Name::new("Character"),
+    ));
+
+    commands.spawn((
+        SpriteBundle {
+            transform: Transform::from_xyz(0.0, 150.0, 0.0),
+            sprite: Sprite {
+                color: Color::WHITE,
+                custom_size: Some(Vec2::new(100.0, 100.0)),
+                ..default()
+            },
+            ..default()
+        },
+        PressurePlate,
+        Sensor,
+        RigidBody::Static,
+        Collider::cuboid(100.0, 100.0),
+        Name::new("Pressure Plate"),
+    ));
+
+    commands.spawn((
+        TextBundle::from_section(
+            "Velocity: ",
+            TextStyle {
+                font_size: 16.0,
+                ..default()
+            },
+        )
+        .with_style(Style {
+            position_type: PositionType::Absolute,
+            bottom: Val::Px(5.0),
+            left: Val::Px(5.0),
+            ..default()
+        }),
+        CharacterVelocityText,
+        Name::new("Character Velocity Text"),
+    ));
+
+    commands.spawn(Camera2dBundle::default());
+}
+
+#[derive(Event, Debug, Reflect)]
+pub enum MovementAction {
+    Move(Vec2),
+    Stop,
+}
+
+fn keyboard_input(
+    mut movement_event_writer: EventWriter<MovementAction>,
+    keyboard_input: Res<Input<KeyCode>>,
+    time: Res<Time<Physics>>,
+) {
+    if time.is_paused() {
+        return;
+    }
+    let left = keyboard_input.any_pressed([KeyCode::A, KeyCode::Left]);
+    let right = keyboard_input.any_pressed([KeyCode::D, KeyCode::Right]);
+    let up = keyboard_input.any_pressed([KeyCode::W, KeyCode::Up]);
+    let down = keyboard_input.any_pressed([KeyCode::S, KeyCode::Down]);
+    let space = keyboard_input.pressed(KeyCode::Space);
+    if space {
+        movement_event_writer.send(MovementAction::Stop);
+        return;
+    }
+    let horizontal = right as i8 - left as i8;
+    let vertical = up as i8 - down as i8;
+    let direction = Vec2::new(horizontal as Scalar, vertical as Scalar);
+    if direction != Vec2::ZERO {
+        movement_event_writer.send(MovementAction::Move(direction));
+    }
+}
+
+fn has_movement(mut reader: EventReader<MovementAction>) -> bool {
+    !reader.read().next().is_none()
+}
+fn movement(
+    time: Res<Time>,
+    mut movement_event_reader: EventReader<MovementAction>,
+    mut controllers: Query<&mut LinearVelocity, With<Character>>,
+) {
+    let delta_time = time.delta_seconds_f64().adjust_precision();
+    let movement_acceleration = 2000.0;
+    for event in movement_event_reader.read() {
+        for mut linear_velocity in &mut controllers {
+            match event {
+                MovementAction::Stop => {
+                    linear_velocity.x = 0.0;
+                    linear_velocity.y = 0.0;
+                }
+                MovementAction::Move(direction) => {
+                    linear_velocity.x += direction.x * movement_acceleration * delta_time;
+                    linear_velocity.y += direction.y * movement_acceleration * delta_time;
+                }
+            }
+        }
+    }
+}
+
+fn apply_movement_damping(
+    mut query: Query<(&mut LinearVelocity, &mut AngularVelocity), (With<Character>, Without<Sleeping>)>,
+    time: Res<Time<Physics>>,
+) {
+    if time.is_paused() {
+        return;
+    }
+    let damping_factor = 0.95;
+    for (mut linear_velocity, mut angular_velocity) in &mut query {
+        linear_velocity.x *= damping_factor;
+        if linear_velocity.x.abs() < 0.001 {
+            linear_velocity.x = 0.0;
+        }
+        linear_velocity.y *= damping_factor;
+        if linear_velocity.y.abs() < 0.001 {
+            linear_velocity.y = 0.0;
+        }
+        angular_velocity.0 *= damping_factor;
+        if angular_velocity.0.abs() < 0.001 {
+            angular_velocity.0 = 0.0;
+        }
+    }
+}
+
+fn apply_pressure_plate_colour(
+    mut query: Query<(&mut Sprite, &CollidingEntities), With<PressurePlate>>,
+) {
+    for (mut sprite, colliding_entities) in &mut query {
+        if colliding_entities.0.is_empty() {
+            sprite.color = Color::rgb(0.2, 0.7, 0.9);
+        } else {
+            sprite.color = Color::rgb(0.9, 0.7, 0.2);
+        }
+    }
+}
+
+fn update_velocity_text(
+    character_query: Query<(&LinearVelocity, Has<Sleeping>), With<Character>>,
+    pressure_plate_query: Query<Has<Sleeping>, With<PressurePlate>>,
+    mut text_query: Query<&mut Text, With<CharacterVelocityText>>,
+) {
+    if let (Ok((velocity, character_sleeping)), Ok(pressure_plate_sleeping)) = (
+        character_query.get_single(),
+        pressure_plate_query.get_single(),
+    ) {
+        text_query.single_mut().sections[0].value = format!(
+            "Velocity: {}, {}\nCharacter sleeping:{}\nPressure plate sleeping: {}",
+            velocity.x, velocity.y, character_sleeping, pressure_plate_sleeping
+        );
+    }
+}
+
+fn log_events(mut started: EventReader<CollisionStarted>, mut ended: EventReader<CollisionEnded>) {
+    // print out the started and ended events
+    for event in started.read() {
+        println!("CollisionStarted: {:?}", event);
+    }
+    for event in ended.read() {
+        println!("CollisionEnded: {:?}", event);
+    }
+}

--- a/crates/bevy_xpbd_2d/examples/sensor.rs
+++ b/crates/bevy_xpbd_2d/examples/sensor.rs
@@ -185,10 +185,11 @@ fn movement(
     }
 }
 
+#[allow(clippy::type_complexity)]
 fn apply_movement_damping(
     mut query: Query<
         (&mut LinearVelocity, &mut AngularVelocity),
-        (With<Character>, Without<Sleeping>)
+        (With<Character>, Without<Sleeping>),
     >,
     time: Res<Time<Physics>>,
 ) {

--- a/crates/bevy_xpbd_2d/examples/sensor.rs
+++ b/crates/bevy_xpbd_2d/examples/sensor.rs
@@ -155,7 +155,7 @@ fn keyboard_input2(
 }
 
 fn has_movement(mut reader: EventReader<MovementAction>) -> bool {
-    !reader.read().next().is_none()
+    reader.read().next().is_some()
 }
 fn movement(
     time: Res<Time>,

--- a/crates/bevy_xpbd_2d/examples/sensor.rs
+++ b/crates/bevy_xpbd_2d/examples/sensor.rs
@@ -102,8 +102,8 @@ fn setup(
 
 #[derive(Event, Debug, Reflect)]
 pub enum MovementAction {
-    Velocity(Vec2),
-    Offset(Vec2),
+    Velocity(Vector),
+    Offset(Vector),
     Stop,
 }
 
@@ -128,8 +128,8 @@ fn keyboard_input1(
     let down = keyboard_input.any_pressed([KeyCode::S]);
     let horizontal = right as i8 - left as i8;
     let vertical = up as i8 - down as i8;
-    let direction = Vec2::new(horizontal as Scalar, vertical as Scalar);
-    if direction != Vec2::ZERO {
+    let direction = Vector::new(horizontal as Scalar, vertical as Scalar);
+    if direction != Vector::ZERO {
         movement_event_writer.send(MovementAction::Velocity(direction));
     }
 }
@@ -148,8 +148,8 @@ fn keyboard_input2(
     let down = keyboard_input.any_pressed([KeyCode::Down]);
     let horizontal = right as i8 - left as i8;
     let vertical = up as i8 - down as i8;
-    let direction = Vec2::new(horizontal as Scalar, vertical as Scalar);
-    if direction != Vec2::ZERO {
+    let direction = Vector::new(horizontal as Scalar, vertical as Scalar);
+    if direction != Vector::ZERO {
         movement_event_writer.send(MovementAction::Offset(direction));
     }
 }

--- a/crates/bevy_xpbd_2d/examples/sensor.rs
+++ b/crates/bevy_xpbd_2d/examples/sensor.rs
@@ -202,7 +202,7 @@ fn update_velocity_text(
         pressure_plate_query.get_single(),
     ) {
         text_query.single_mut().sections[0].value = format!(
-            "Velocity: {}, {}\nCharacter sleeping:{}\nPressure plate sleeping: {}",
+            "Velocity: {:.4}, {:.4}\nCharacter sleeping:{}\nPressure plate sleeping: {}",
             velocity.x, velocity.y, character_sleeping, pressure_plate_sleeping
         );
     }

--- a/crates/bevy_xpbd_2d/examples/sensor.rs
+++ b/crates/bevy_xpbd_2d/examples/sensor.rs
@@ -186,7 +186,10 @@ fn movement(
 }
 
 fn apply_movement_damping(
-    mut query: Query<(&mut LinearVelocity, &mut AngularVelocity), (With<Character>, Without<Sleeping>)>,
+    mut query: Query<
+        (&mut LinearVelocity, &mut AngularVelocity),
+        (With<Character>, Without<Sleeping>)
+    >,
     time: Res<Time<Physics>>,
 ) {
     if time.is_paused() {

--- a/src/plugins/collision/narrow_phase.rs
+++ b/src/plugins/collision/narrow_phase.rs
@@ -110,6 +110,7 @@ pub fn collect_collisions(
     #[cfg(feature = "parallel")]
     {
         let pool = ComputeTaskPool::get();
+        // TODO: Verify if `par_splat_map` is deterministic. If not, sort the collisions.
         let new_collisions1 = broad_collision_pairs
             .0
             .par_splat_map(pool, None, |chunks| {
@@ -238,7 +239,7 @@ pub fn reset_collision_states(
         {
             let active1 = !rb1.map_or(false, |rb| rb.is_static()) && !sleeping1;
             let active2 = !rb2.map_or(false, |rb| rb.is_static()) && !sleeping2;
-            
+
             // Reset collision states if either of the bodies is active (not static or sleeping)
             // Otherwise, the bodies are still in contact.
             if active1 || active2 {

--- a/src/plugins/collision/narrow_phase.rs
+++ b/src/plugins/collision/narrow_phase.rs
@@ -6,7 +6,6 @@ use crate::prelude::*;
 use bevy::ecs::query::Has;
 #[cfg(feature = "parallel")]
 use bevy::tasks::{ComputeTaskPool, ParallelSlice};
-use itertools::Itertools;
 
 /// Computes contacts between entities.
 ///

--- a/src/plugins/collision/narrow_phase.rs
+++ b/src/plugins/collision/narrow_phase.rs
@@ -134,7 +134,7 @@ pub fn collect_collisions(
 
         let new_collisions2 = existing_stationary_collisions
             .cloned()
-            .collect_vec()
+            .collect::<Vec<_>>()
             .par_splat_map(pool, None, |chunks| {
                 let mut new_collisions: Vec<Contacts> = vec![];
                 for &(entity1, entity2) in chunks {


### PR DESCRIPTION
# Objective

Fixes #264 


https://github.com/Jondolf/bevy_xpbd/assets/9356891/b77c9eba-aa21-474c-bec0-1cc3f5f24800



## Changelog

> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

- Added example
- Added collision preservation logic

## Other

5 tests are failing when I run them, but they fail without my changes so idk

<details><summary>Details</summary>

```
     Running unittests ../../src/lib.rs (target\debug\deps\bevy_xpbd_3d-f7a1d1ec81464a89.exe)

running 10 tests
test components::tests::coefficient_combine_works ... ok
test components::tests::restitution_clamping_works ... ok
test components::world_queries::tests::mass_properties_add_assign_works ... ok
test components::world_queries::tests::mass_properties_sub_assign_works ... ok
test components::world_queries::tests::mass_properties_add_sub_works ... ok
test tests::no_ambiguity_errors ... FAILED
test tests::body_with_velocity_moves ... FAILED
test tests::body_with_velocity_moves_on_first_frame ... FAILED
test tests::it_loads_plugin_without_errors ... FAILED
test tests::cubes_simulation_is_locally_deterministic ... FAILED

failures:

---- tests::no_ambiguity_errors stdout ----
thread 'tests::no_ambiguity_errors' panicked at C:\Users\TeamD\.cargo\registry\src\index.crates.io-6f17d22bba15001f\bevy_ecs-0.12.0\src\system\system_param.rs:451:17:
Resource requested by bevy_xpbd_3d::plugins::prepare::init_async_scene_colliders does not exist: bevy_asset::assets::Assets<bevy_render::mesh::mesh::Mesh>
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Encountered a panic in system `bevy_xpbd_3d::plugins::prepare::init_async_scene_colliders`!
Encountered a panic in system `bevy_app::main_schedule::Main::run_main`!

---- tests::body_with_velocity_moves stdout ----
thread 'tests::body_with_velocity_moves' panicked at C:\Users\TeamD\.cargo\registry\src\index.crates.io-6f17d22bba15001f\bevy_ecs-0.12.0\src\system\system_param.rs:451:17:
Resource requested by bevy_xpbd_3d::plugins::prepare::init_async_scene_colliders does not exist: bevy_asset::assets::Assets<bevy_render::mesh::mesh::Mesh>
Encountered a panic in system `bevy_xpbd_3d::plugins::prepare::init_async_scene_colliders`!
Encountered a panic in system `bevy_app::main_schedule::Main::run_main`!

---- tests::body_with_velocity_moves_on_first_frame stdout ----
thread 'tests::body_with_velocity_moves_on_first_frame' panicked at C:\Users\TeamD\.cargo\registry\src\index.crates.io-6f17d22bba15001f\bevy_ecs-0.12.0\src\system\system_param.rs:451:17:
Resource requested by bevy_xpbd_3d::plugins::prepare::init_async_scene_colliders does not exist: bevy_asset::assets::Assets<bevy_render::mesh::mesh::Mesh>
Encountered a panic in system `bevy_xpbd_3d::plugins::prepare::init_async_scene_colliders`!
Encountered a panic in system `bevy_app::main_schedule::Main::run_main`!

---- tests::it_loads_plugin_without_errors stdout ----
thread 'tests::it_loads_plugin_without_errors' panicked at C:\Users\TeamD\.cargo\registry\src\index.crates.io-6f17d22bba15001f\bevy_ecs-0.12.0\src\system\system_param.rs:451:17:
Resource requested by bevy_xpbd_3d::plugins::prepare::init_async_scene_colliders does not exist: bevy_asset::assets::Assets<bevy_render::mesh::mesh::Mesh>
Encountered a panic in system `bevy_xpbd_3d::plugins::prepare::init_async_scene_colliders`!
Encountered a panic in system `bevy_app::main_schedule::Main::run_main`!

---- tests::cubes_simulation_is_locally_deterministic stdout ----
thread 'tests::cubes_simulation_is_locally_deterministic' panicked at C:\Users\TeamD\.cargo\registry\src\index.crates.io-6f17d22bba15001f\bevy_ecs-0.12.0\src\system\system_param.rs:451:17:
Resource requested by bevy_xpbd_3d::plugins::prepare::init_async_scene_colliders does not exist: bevy_asset::assets::Assets<bevy_render::mesh::mesh::Mesh>
Encountered a panic in system `bevy_xpbd_3d::plugins::prepare::init_async_scene_colliders`!
Encountered a panic in system `bevy_app::main_schedule::Main::run_main`!


failures:
    tests::body_with_velocity_moves
    tests::body_with_velocity_moves_on_first_frame
    tests::cubes_simulation_is_locally_deterministic
    tests::it_loads_plugin_without_errors
    tests::no_ambiguity_errors

test result: FAILED. 5 passed; 5 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```

</details> 
