### PR TITLE
Scale debug rendering of center of mass dot by axis lengths

### DIFF
--- a/src/plugins/debug/mod.rs
+++ b/src/plugins/debug/mod.rs
@@ -168,13 +168,20 @@ fn debug_render_axes(
 
             // Draw dot at the center of mass
             #[cfg(feature = "2d")]
-            debug_renderer
-                .gizmos
-                .circle_2d(global_com.as_f32(), 0.5, center_color);
+            debug_renderer.gizmos.circle_2d(
+                global_com.as_f32(),
+                // Scale dot size based on axis lengths
+                (lengths.x + lengths.y) / 30.0,
+                center_color,
+            );
             #[cfg(feature = "3d")]
-            debug_renderer
-                .gizmos
-                .sphere(global_com.as_f32(), rot.as_f32(), 0.025, center_color);
+            debug_renderer.gizmos.sphere(
+                global_com.as_f32(),
+                rot.as_f32(),
+                // Scale dot size based on axis lengths
+                (lengths.x + lengths.y + lengths.z) / 30.0,
+                center_color,
+            );
         }
     }
 }

--- a/src/plugins/debug/mod.rs
+++ b/src/plugins/debug/mod.rs
@@ -171,7 +171,7 @@ fn debug_render_axes(
             debug_renderer.gizmos.circle_2d(
                 global_com.as_f32(),
                 // Scale dot size based on axis lengths
-                (lengths.x + lengths.y) / 30.0,
+                (lengths.x + lengths.y) / 20.0,
                 center_color,
             );
             #[cfg(feature = "3d")]


### PR DESCRIPTION
# Objective

Fixes #260.

Currently, the size of the debug-rendered yellow dot visualizing the center of mass in the middle of a body's axes is hard-coded. This is annoying and confusing when working at different scales than the assumed default scale.

## Solution

Derive the radius of the dot based on the average of the debug rendered rigid body axis lengths.