### PR TITLE
Don't overwrite `Time<Physics>` when `PhysicsPlugins` are added

### DIFF
--- a/src/plugins/setup/mod.rs
+++ b/src/plugins/setup/mod.rs
@@ -62,7 +62,7 @@ impl Default for PhysicsSetupPlugin {
 impl Plugin for PhysicsSetupPlugin {
     fn build(&self, app: &mut App) {
         // Init resources and register component types
-        app.insert_resource(Time::new_with(Physics::default()))
+        app.init_resource::<Time<Physics>>()
             .insert_resource(Time::new_with(Substeps))
             .init_resource::<SubstepCount>()
             .init_resource::<BroadCollisionPairs>()


### PR DESCRIPTION
# Objective

insert_resource always overwrites the existing resource, so if you insert your own physics time. e.g. for fixed timestep before adding PhysicsPlugins, you would still get non-fixed time.

## Solution

init_resource only adds the resource if it isn't already added, using the default constructor, which should otherwise have the same behavior as before.

