### PR TITLE
Fix dead custom constraints link in docs

### DIFF
--- a/src/constraints/mod.rs
+++ b/src/constraints/mod.rs
@@ -23,7 +23,7 @@
 //!     - [`PrismaticJoint`]
 //!
 //! More constraint types will be added in future releases. If you need more constraints now, consider
-//! [creating your own constraints](custom-constraints).
+//! [creating your own constraints](#custom-constraints).
 //!
 //! ## Custom constraints
 //!


### PR DESCRIPTION
# Objective

The "creating your own constraints" link in the [constraints module's docs](https://docs.rs/bevy_xpbd_3d/0.3.2/bevy_xpbd_3d/constraints/index.html) currently links to [constraints/custom-constraints](https://docs.rs/bevy_xpbd_3d/0.3.2/bevy_xpbd_3d/constraints/custom-constraints) instead of [constraints#custom-constraints](https://docs.rs/bevy_xpbd_3d/0.3.2/bevy_xpbd_3d/constraints/index.html#custom-constraints).

## Solution

Add a # to the link to make it link to the right page and section of the doc.