### PR TITLE
Fix rotation change detection in integrator

### DIFF
--- a/src/plugins/integrator.rs
+++ b/src/plugins/integrator.rs
@@ -228,7 +228,7 @@ fn integrate_rot(mut bodies: Query<RotIntegrationComponents, Without<Sleeping>>,
             .extend(delta_secs * 0.5 * q.w);
         // avoid triggering bevy's change detection unnecessarily
         let delta = Quaternion::from_vec4(effective_dq);
-        if delta.w != 0.0 {
+        if delta != Quaternion::from_xyzw(0.0, 0.0, 0.0, 0.0) {
             rot.0 = (rot.0 + delta).normalize();
         }
     }


### PR DESCRIPTION
# Objective

In #272, the integrator was changed to update rotation only if `delta.w != 0.0`. However, in some cases, x, y, or z can be non-zero even if w is zero, like with `AngularVelocity(Vec3::X)`, and in those cases the rotation would incorrectly be ignored.

## Solution

Make the condition stricter by also checking if x, y, and z are 0. Based on a quick test, this should also keep change detection working, which is what #272 was trying to address.