### PR TITLE
docs: use the read function for iterating over events

### DIFF
--- a/src/plugins/collision/contact_reporting.rs
+++ b/src/plugins/collision/contact_reporting.rs
@@ -30,7 +30,7 @@ use crate::prelude::*;
 /// }
 ///
 /// fn print_collisions(mut collision_event_reader: EventReader<Collision>) {
-///     for Collision(contacts) in collision_event_reader.iter() {
+///     for Collision(contacts) in collision_event_reader.read() {
 ///         println!(
 ///             "Entities {:?} and {:?} are colliding",
 ///             contacts.entity1,


### PR DESCRIPTION
# Objective

- Describe the objective or issue this PR addresses.
- If you're fixing a specific issue, say "Fixes #X".

Just a quick correction on the documentation for documentation on `ContactReportingPlugin`. The docs here use the deprecated `.iter()` function from `EventReader`. I searched the content of the repo and it looks like this is the only time the deprecated function is called.

## Solution

- Describe the solution used to achieve the objective above.

Change `.iter()` to `.read()`.
