### PR TITLE
docs: corrects other outdated calls to .iter

### DIFF
--- a/src/plugins/collision/contact_reporting.rs
+++ b/src/plugins/collision/contact_reporting.rs
@@ -73,7 +73,7 @@ impl Plugin for ContactReportingPlugin {
 /// }
 ///
 /// fn print_collisions(mut collision_event_reader: EventReader<Collision>) {
-///     for Collision(contacts) in collision_event_reader.iter() {
+///     for Collision(contacts) in collision_event_reader.read() {
 ///         println!(
 ///             "Entities {:?} and {:?} are colliding",
 ///             contacts.entity1,
@@ -104,7 +104,7 @@ pub struct Collision(pub Contacts);
 /// }
 ///
 /// fn print_started_collisions(mut collision_event_reader: EventReader<CollisionStarted>) {
-///     for CollisionStarted(entity1, entity2) in collision_event_reader.iter() {
+///     for CollisionStarted(entity1, entity2) in collision_event_reader.read() {
 ///         println!(
 ///             "Entities {:?} and {:?} started colliding",
 ///             entity1,
@@ -135,7 +135,7 @@ pub struct CollisionStarted(pub Entity, pub Entity);
 /// }
 ///
 /// fn print_ended_collisions(mut collision_event_reader: EventReader<CollisionEnded>) {
-///     for CollisionEnded(entity1, entity2) in collision_event_reader.iter() {
+///     for CollisionEnded(entity1, entity2) in collision_event_reader.read() {
 ///         println!(
 ///             "Entities {:?} and {:?} stopped colliding",
 ///             entity1,


### PR DESCRIPTION
# Objective

- Describe the objective or issue this PR addresses.
- If you're fixing a specific issue, say "Fixes #X".

There are a few more examples in the documentation that I missed with my last PR of using the deprecated `.iter` function of `EventReader`.

## Solution

- Describe the solution used to achieve the objective above.

I've changed the sample to use `.read` instead.
