### PR TITLE
Adding Collider::round_cuboid

### DIFF
--- a/src/components/collider.rs
+++ b/src/components/collider.rs
@@ -337,6 +337,29 @@ impl Collider {
         SharedShape::cuboid(x_length * 0.5, y_length * 0.5, z_length * 0.5).into()
     }
 
+    /// Creates a collider with a cuboid shape defined by its extents and rounded corners.
+    #[cfg(feature = "2d")]
+    pub fn round_cuboid(x_length: Scalar, y_length: Scalar, border_radius: Scalar) -> Self {
+        SharedShape::round_cuboid(x_length * 0.5, y_length * 0.5, border_radius).into()
+    }
+
+    /// Creates a collider with a cuboid shape defined by its extents and rounded corners.
+    #[cfg(feature = "3d")]
+    pub fn round_cuboid(
+        x_length: Scalar,
+        y_length: Scalar,
+        z_length: Scalar,
+        border_radius: Scalar,
+    ) -> Self {
+        SharedShape::round_cuboid(
+            x_length * 0.5,
+            y_length * 0.5,
+            z_length * 0.5,
+            border_radius,
+        )
+        .into()
+    }
+
     /// Creates a collider with a cylinder shape defined by its height along the `Y` axis and its radius on the `XZ` plane.
     #[cfg(feature = "3d")]
     pub fn cylinder(height: Scalar, radius: Scalar) -> Self {


### PR DESCRIPTION
# Objective
Looking through the code it appears we have a round cuboid available from Parry but are missing the function to create it. Rounded cuboids are handy for several things though in my case it's providing a smooth tunnel edge for couched players entering tunnels and also offering slight "just missed it" jump handling.

## Solution

I reviewed the cubiod functions and SharedShapes to determine the round_cubiod pattern. Not sure if I've missed some things and happy to accept any changes or add tests and docs as needed.

## Changelog
Added
2d: `Collider::round_cuboid(x_length: Scalar, y_length: Scalar, border_radius: Scalar)`
3d: `Collider::round_cuboid(x_length: Scalar, y_length: Scalar, z_length: Scalar, border_radius: Scalar)`
