### PR TITLE
Debug render contact normals

### DIFF
--- a/src/plugins/debug/configuration.rs
+++ b/src/plugins/debug/configuration.rs
@@ -49,7 +49,9 @@ pub struct PhysicsDebugConfig {
     /// If `None`, sleeping will have no effect on the colors.
     pub sleeping_color_multiplier: Option<[f32; 4]>,
     /// The color of the contact points. If `None`, the contact points will not be rendered.
-    pub contact_color: Option<Color>,
+    pub contact_point_color: Option<Color>,
+    /// The color of the contact normals. If `None`, the contact normals will not be rendered.
+    pub contact_normal_color: Option<Color>,
     /// The color of the lines drawn from the centers of bodies to their joint anchors.
     pub joint_anchor_color: Option<Color>,
     /// The color of the lines drawn between joint anchors, indicating the separation.
@@ -84,7 +86,8 @@ impl Default for PhysicsDebugConfig {
             aabb_color: None,
             collider_color: Some(Color::ORANGE),
             sleeping_color_multiplier: Some([1.0, 1.0, 0.4, 1.0]),
-            contact_color: None,
+            contact_point_color: None,
+            contact_normal_color: None,
             joint_anchor_color: Some(Color::PINK),
             joint_separation_color: Some(Color::RED),
             raycast_color: Some(Color::RED),
@@ -111,7 +114,8 @@ impl PhysicsDebugConfig {
             aabb_color: Some(Color::rgb(0.8, 0.8, 0.8)),
             collider_color: Some(Color::ORANGE),
             sleeping_color_multiplier: Some([1.0, 1.0, 0.4, 1.0]),
-            contact_color: Some(Color::CYAN),
+            contact_point_color: Some(Color::CYAN),
+            contact_normal_color: Some(Color::RED),
             joint_anchor_color: Some(Color::PINK),
             joint_separation_color: Some(Color::RED),
             raycast_color: Some(Color::RED),
@@ -135,7 +139,8 @@ impl PhysicsDebugConfig {
             aabb_color: None,
             collider_color: None,
             sleeping_color_multiplier: None,
-            contact_color: None,
+            contact_point_color: None,
+            contact_normal_color: None,
             joint_anchor_color: None,
             joint_separation_color: None,
             raycast_color: None,
@@ -176,11 +181,20 @@ impl PhysicsDebugConfig {
         }
     }
 
-    /// Creates a [`PhysicsDebugConfig`] configuration with a given contact color.
+    /// Creates a [`PhysicsDebugConfig`] configuration with a given contact point color.
     /// Other debug rendering options will be disabled.
-    pub fn contacts(color: Color) -> Self {
+    pub fn contact_points(color: Color) -> Self {
         Self {
-            contact_color: Some(color),
+            contact_point_color: Some(color),
+            ..Self::none()
+        }
+    }
+
+    /// Creates a [`PhysicsDebugConfig`] configuration with a given contact normal color.
+    /// Other debug rendering options will be disabled.
+    pub fn contact_normals(color: Color) -> Self {
+        Self {
+            contact_normal_color: Some(color),
             ..Self::none()
         }
     }
@@ -220,8 +234,8 @@ impl PhysicsDebugConfig {
     }
 
     /// Sets the contact color.
-    pub fn with_contact_color(mut self, color: Color) -> Self {
-        self.contact_color = Some(color);
+    pub fn with_contact_point_color(mut self, color: Color) -> Self {
+        self.contact_point_color = Some(color);
         self
     }
 
@@ -286,9 +300,15 @@ impl PhysicsDebugConfig {
         self
     }
 
-    /// Disables contact debug rendering.
-    pub fn without_contacts(mut self) -> Self {
-        self.contact_color = None;
+    /// Disables contact point debug rendering.
+    pub fn without_contact_points(mut self) -> Self {
+        self.contact_point_color = None;
+        self
+    }
+
+    /// Disables contact normal debug rendering.
+    pub fn without_contact_normals(mut self) -> Self {
+        self.contact_normal_color = None;
         self
     }
 

--- a/src/plugins/debug/mod.rs
+++ b/src/plugins/debug/mod.rs
@@ -277,14 +277,15 @@ fn debug_render_colliders(
 }
 
 fn debug_render_contacts(
-    colliders: Query<(&Position, &Rotation), With<Collider>>,
+    colliders: Query<(&Position, &Rotation)>,
     mut collisions: EventReader<Collision>,
     mut debug_renderer: PhysicsDebugRenderer,
     config: Res<PhysicsDebugConfig>,
 ) {
-    let Some(color) = config.contact_color else {
+    if config.contact_point_color.is_none() && config.contact_normal_color.is_none() {
         return;
-    };
+    }
+
     for Collision(contacts) in collisions.read() {
         let Ok((position1, rotation1)) = colliders.get(contacts.entity1) else {
             continue;
@@ -295,22 +296,43 @@ fn debug_render_contacts(
 
         for manifold in contacts.manifolds.iter() {
             for contact in manifold.contacts.iter() {
-                let p1 = contact.global_point1(position1, rotation1);
-                let p2 = contact.global_point2(position2, rotation2);
-                #[cfg(feature = "2d")]
-                let len = 5.0;
-                #[cfg(feature = "3d")]
-                let len = 0.3;
+                let p1 = contact.global_point1(position1, rotation1).as_f32();
+                let p2 = contact.global_point2(position2, rotation2).as_f32();
+                let normal1 = contact.global_normal1(rotation1).as_f32();
+                let normal2 = contact.global_normal2(rotation2).as_f32();
 
-                debug_renderer.draw_line(p1 - Vector::X * len, p1 + Vector::X * len, color);
-                debug_renderer.draw_line(p1 - Vector::Y * len, p1 + Vector::Y * len, color);
-                #[cfg(feature = "3d")]
-                debug_renderer.draw_line(p1 - Vector::Z * len, p1 + Vector::Z * len, color);
+                // Don't render contacts that aren't penetrating
+                if contact.penetration <= Scalar::EPSILON {
+                    continue;
+                }
 
-                debug_renderer.draw_line(p2 - Vector::X * len, p2 + Vector::X * len, color);
-                debug_renderer.draw_line(p2 - Vector::Y * len, p2 + Vector::Y * len, color);
-                #[cfg(feature = "3d")]
-                debug_renderer.draw_line(p2 - Vector::Z * len, p2 + Vector::Z * len, color);
+                // Draw contact points
+                if let Some(color) = config.contact_point_color {
+                    #[cfg(feature = "2d")]
+                    {
+                        debug_renderer.gizmos.circle_2d(p1, 3.0, color);
+                        debug_renderer.gizmos.circle_2d(p2, 3.0, color);
+                    }
+                    #[cfg(feature = "3d")]
+                    {
+                        debug_renderer.gizmos.sphere(p1, default(), 0.025, color);
+                        debug_renderer.gizmos.sphere(p2, default(), 0.025, color);
+                    }
+                }
+
+                // Draw contact normals
+                if let Some(color) = config.contact_normal_color {
+                    #[cfg(feature = "2d")]
+                    {
+                        debug_renderer.draw_arrow(p1, p1 + normal1 * 30.0, 8.0, 8.0, color);
+                        debug_renderer.draw_arrow(p2, p2 + normal2 * 30.0, 8.0, 8.0, color);
+                    }
+                    #[cfg(feature = "3d")]
+                    {
+                        debug_renderer.draw_arrow(p1, p1 + normal1 * 0.5, 0.1, 0.1, color);
+                        debug_renderer.draw_arrow(p2, p2 + normal2 * 0.5, 0.1, 0.1, color);
+                    }
+                }
             }
         }
     }

--- a/src/plugins/debug/renderer.rs
+++ b/src/plugins/debug/renderer.rs
@@ -78,32 +78,39 @@ impl<'w, 's> PhysicsDebugRenderer<'w, 's> {
     ) {
         self.draw_line(a, b, color);
 
-        let dir = (b - a).normalize_or_zero();
+        let pointing = (b - a).normalize();
 
         #[cfg(feature = "2d")]
         {
-            let v = head_width * 0.5 * Vector::new(-dir.y, dir.x);
-            self.draw_line(b, b - head_length * dir + v, color);
-            self.draw_line(b, b - head_length * dir - v, color);
+            let v = head_width * 0.5 * Vector::new(-pointing.y, pointing.x);
+            self.draw_line(b, b - head_length * pointing + v, color);
+            self.draw_line(b, b - head_length * pointing - v, color);
         }
 
         #[cfg(feature = "3d")]
         {
-            let back = Vector::NEG_Z;
-            let up = dir.try_normalize().unwrap_or(Vector::Y);
-            let right = up
-                .cross(back)
-                .try_normalize()
-                .unwrap_or_else(|| up.any_orthonormal_vector());
-            let up = back.cross(right);
-            let q = Quaternion::from_mat3(&Matrix3::from_cols(right, up, back));
+            // first, draw the body of the arrow
+            self.gizmos.line(a, b, color);
 
-            self.draw_collider(
-                &Collider::cone(head_length, head_width * 0.5),
-                &Position(b - dir * head_length * 0.5),
-                &Rotation(q),
-                color,
-            );
+            // Now the hard part is to draw the head in a sensible way.
+            // Put us in a coordinate system where the arrow is pointing towards +x and ends at the origin.
+            let rotation = Quat::from_rotation_arc(Vec3::X, pointing);
+            let tips = [
+                Vec3::new(-head_width, head_width, 0.0),
+                Vec3::new(-head_width, 0.0, head_width),
+                Vec3::new(-head_width, -head_width, 0.0),
+                Vec3::new(-head_width, 0.0, -head_width),
+            ];
+
+            // - Extend the vectors so their length is `tip_length`
+            // - Rotate the world so +x is facing in the same direction as the arrow
+            // - Translate over to the tip of the arrow
+            let tips = tips.map(|v| rotation * (v.normalize() * head_length) + b);
+
+            // Draw the tips
+            for v in tips {
+                self.gizmos.line(b, v, color);
+            }
         }
     }
 


### PR DESCRIPTION
# Objective

Currently, only contact points can be debug rendered. It'd be useful to support rendering contact normals.

## Solution

Add contact normal debug rendering. The old `contact_color` and similar configuration options have been renamed like `contact_point_color`.

I also fixed the arrow gizmo that previously sometimes rendered the tip with an incorrect orientation. When Bevy 0.13 is released, it can be replaced with the built-in arrow gizmo.

---

## Changelog

- Renamed `PhysicsDebugConfig` properties and methods like `contact_foo` to `contact_point_foo`
- Added corresponding `contact_normal_foo` properties and methods
- Removed `With<Collider>` filter from `debug_render_contacts`
- Fixed arrow gizmo

## Migration Guide

- Change `PhysicsDebugConfig` properties and methods like `contact_foo` to `contact_point_foo`