### PR TITLE
fix raycast does not follow entity transform without rigidbody

### DIFF
--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -331,6 +331,38 @@ impl Position {
     }
 }
 
+impl From<GlobalTransform> for Position {
+    #[cfg(feature = "2d")]
+    fn from(value: GlobalTransform) -> Self {
+        Self::from_xy(value.translation().x, value.translation().y)
+    }
+
+    #[cfg(feature = "3d")]
+    fn from(value: GlobalTransform) -> Self {
+        Self::from_xyz(
+            value.translation().x,
+            value.translation().y,
+            value.translation().z,
+        )
+    }
+}
+
+impl From<&GlobalTransform> for Position {
+    #[cfg(feature = "2d")]
+    fn from(value: &GlobalTransform) -> Self {
+        Self::from_xy(value.translation().x, value.translation().y)
+    }
+
+    #[cfg(feature = "3d")]
+    fn from(value: &GlobalTransform) -> Self {
+        Self::from_xyz(
+            value.translation().x,
+            value.translation().y,
+            value.translation().z,
+        )
+    }
+}
+
 /// The position of a [rigid body](RigidBody) at the start of a substep.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -334,15 +334,18 @@ impl Position {
 impl From<GlobalTransform> for Position {
     #[cfg(feature = "2d")]
     fn from(value: GlobalTransform) -> Self {
-        Self::from_xy(value.translation().x, value.translation().y)
+        Self::from_xy(
+            value.translation().adjust_precision().x,
+            value.translation().adjust_precision().y,
+        )
     }
 
     #[cfg(feature = "3d")]
     fn from(value: GlobalTransform) -> Self {
         Self::from_xyz(
-            value.translation().x,
-            value.translation().y,
-            value.translation().z,
+            value.translation().adjust_precision().x,
+            value.translation().adjust_precision().y,
+            value.translation().adjust_precision().z,
         )
     }
 }
@@ -350,15 +353,18 @@ impl From<GlobalTransform> for Position {
 impl From<&GlobalTransform> for Position {
     #[cfg(feature = "2d")]
     fn from(value: &GlobalTransform) -> Self {
-        Self::from_xy(value.translation().x, value.translation().y)
+        Self::from_xy(
+            value.translation().adjust_precision().x,
+            value.translation().adjust_precision().y,
+        )
     }
 
     #[cfg(feature = "3d")]
     fn from(value: &GlobalTransform) -> Self {
         Self::from_xyz(
-            value.translation().x,
-            value.translation().y,
-            value.translation().z,
+            value.translation().adjust_precision().x,
+            value.translation().adjust_precision().y,
+            value.translation().adjust_precision().z,
         )
     }
 }

--- a/src/components/rotation.rs
+++ b/src/components/rotation.rs
@@ -277,6 +277,12 @@ impl From<GlobalTransform> for Rotation {
     }
 }
 
+impl From<&GlobalTransform> for Rotation {
+    fn from(value: &GlobalTransform) -> Self {
+        Self::from(value.compute_transform().rotation)
+    }
+}
+
 #[cfg(feature = "2d")]
 impl From<Quat> for Rotation {
     fn from(quat: Quat) -> Self {

--- a/src/plugins/spatial_query/mod.rs
+++ b/src/plugins/spatial_query/mod.rs
@@ -241,23 +241,47 @@ type RayCasterPositionQueryComponents = (
     Option<&'static Position>,
     Option<&'static Rotation>,
     Option<&'static Parent>,
+    Option<&'static GlobalTransform>,
 );
 
 fn update_ray_caster_positions(
     mut rays: Query<RayCasterPositionQueryComponents>,
-    parents: Query<(Option<&Position>, Option<&Rotation>), With<Children>>,
+    parents: Query<
+        (
+            Option<&Position>,
+            Option<&Rotation>,
+            Option<&GlobalTransform>,
+        ),
+        With<Children>,
+    >,
 ) {
-    for (mut ray, position, rotation, parent) in &mut rays {
+    for (mut ray, position, rotation, parent, transform) in &mut rays {
         let origin = ray.origin;
         let direction = ray.direction;
 
-        if let Some(position) = position {
+        let mut temp_position = None;
+        let mut temp_rotation = None;
+
+        if let Some(transform) = transform {
+            temp_position = Some(Position::from(transform));
+            temp_rotation = Some(Rotation::from(transform));
+        }
+
+        let (global_position, global_rotation) = match (position, rotation) {
+            (Some(pos), Some(rot)) => (Some(pos), Some(rot)),
+            _ if temp_position.is_some() && temp_rotation.is_some() => {
+                (temp_position.as_ref(), temp_rotation.as_ref())
+            }
+            _ => (None, None),
+        };
+
+        if let Some(position) = global_position {
             ray.set_global_origin(position.0 + rotation.map_or(origin, |rot| rot.rotate(origin)));
         } else if parent.is_none() {
             ray.set_global_origin(origin);
         }
 
-        if let Some(rotation) = rotation {
+        if let Some(rotation) = global_rotation {
             let global_direction = rotation.rotate(ray.direction);
             ray.set_global_direction(global_direction);
         } else if parent.is_none() {
@@ -265,18 +289,38 @@ fn update_ray_caster_positions(
         }
 
         if let Some(parent) = parent {
-            if let Ok((parent_position, parent_rotation)) = parents.get(parent.get()) {
-                if position.is_none() {
-                    if let Some(position) = parent_position {
-                        let rotation = rotation.map_or(
-                            parent_rotation.map_or(Rotation::default(), |rot| *rot),
+            if let Ok((parent_position, parent_rotation, parent_transform)) =
+                parents.get(parent.get())
+            {
+                // Temporary storage for parent transformations
+                let mut temp_parent_position = None;
+                let mut temp_parent_rotation = None;
+
+                if let Some(parent_transform) = parent_transform {
+                    temp_parent_position = Some(Position::from(parent_transform));
+                    temp_parent_rotation = Some(Rotation::from(parent_transform));
+                }
+
+                let (final_position, final_rotation) = match (parent_position, parent_rotation) {
+                    (Some(pos), Some(rot)) => (Some(pos), Some(rot)),
+                    _ if temp_parent_position.is_some() && temp_parent_rotation.is_some() => {
+                        (temp_parent_position.as_ref(), temp_parent_rotation.as_ref())
+                    }
+                    _ => (None, None),
+                };
+
+                // Apply parent transformations
+                if global_position.is_none() {
+                    if let Some(position) = final_position {
+                        let rotation = global_rotation.map_or(
+                            final_rotation.map_or(Rotation::default(), |rot| *rot),
                             |rot| *rot,
                         );
                         ray.set_global_origin(position.0 + rotation.rotate(origin));
                     }
                 }
-                if rotation.is_none() {
-                    if let Some(rotation) = parent_rotation {
+                if global_rotation.is_none() {
+                    if let Some(rotation) = final_rotation {
                         let global_direction = rotation.rotate(ray.direction);
                         ray.set_global_direction(global_direction);
                     }


### PR DESCRIPTION
# Objective

- Fixes #288 

## Solution

- If no Rotation and Position is available, fall back to GlobalTransform

## Changelog

- I've added a `From<GlobalTransform>` and `From<&GlobalTransform>` to `Position` as well as a `From<&GlobalTransform>` to `Rotation`. as a `From<GlobalTransform>` already existed.

I tested the updated `update_ray_caster_positions` system in my personal project, and it fixed the problem for me. I currently can't test the `update_shape_caster_positions` but as it is basically the same changes, i'd be surprised if it wouldn't work.

as this is my first time contributing to this crate, i'm not sure if the code is what is expected.