### PR TITLE
Rework layers

### DIFF
--- a/crates/bevy_xpbd_3d/examples/cast_ray_predicate.rs
+++ b/crates/bevy_xpbd_3d/examples/cast_ray_predicate.rs
@@ -175,7 +175,7 @@ fn raycast(
         direction,
         Scalar::MAX,
         true,
-        SpatialQueryFilter::new(),
+        SpatialQueryFilter::default(),
         &|entity| {
             if let Ok((_, out_of_glass)) = cubes.get(entity) {
                 return !out_of_glass.0; // only look at cubes not out of glass

--- a/src/components/layers.rs
+++ b/src/components/layers.rs
@@ -62,7 +62,7 @@ impl<L: PhysicsLayer> PhysicsLayer for &L {
 /// pub const FIRST_LAYER: LayerMask = LayerMask(1 << 0);
 /// pub const LAST_LAYER: LayerMask = LayerMask(1 << 31);
 ///
-/// // Bitwise operations unfortunately can't be const, so we need to access the `u32` values.
+/// // Bitwise operations for `LayerMask` unfortunately can't be const, so we need to access the `u32` values.
 /// pub const COMBINED: LayerMask = LayerMask(FIRST_LAYER.0 | LAST_LAYER.0);
 /// ```
 #[derive(Reflect, Clone, Copy, Debug, Deref, DerefMut, Eq, PartialOrd, Ord)]

--- a/src/components/layers.rs
+++ b/src/components/layers.rs
@@ -28,7 +28,6 @@ impl<L: PhysicsLayer> PhysicsLayer for &L {
 /// A [`LayerMask`] can be constructed from bits directly, or from types implementing [`PhysicsLayer`].
 ///
 /// ```
-/// # use bevy::prelude::*;
 #[cfg_attr(feature = "2d", doc = "# use bevy_xpbd_2d::prelude::*;")]
 #[cfg_attr(feature = "3d", doc = "# use bevy_xpbd_3d::prelude::*;")]
 /// #
@@ -46,6 +45,8 @@ impl<L: PhysicsLayer> PhysicsLayer for &L {
 /// Bitwise operations can be used to modify and combine masks:
 ///
 /// ```
+#[cfg_attr(feature = "2d", doc = "# use bevy_xpbd_2d::prelude::*;")]
+#[cfg_attr(feature = "3d", doc = "# use bevy_xpbd_3d::prelude::*;")]
 /// let mask1 = LayerMask(0b0001);
 /// let mask2 = LayerMask(0b0010);
 /// assert_eq!(mask1 | mask2, LayerMask(0b0011));
@@ -106,6 +107,8 @@ impl LayerMask {
     /// # Example
     ///
     /// ```
+    #[cfg_attr(feature = "2d", doc = "# use bevy_xpbd_2d::prelude::*;")]
+    #[cfg_attr(feature = "3d", doc = "# use bevy_xpbd_3d::prelude::*;")]
     /// let mut layers = LayerMask(0b1010);
     ///
     /// // These are equivalent
@@ -124,6 +127,8 @@ impl LayerMask {
     /// # Example
     ///
     /// ```
+    #[cfg_attr(feature = "2d", doc = "# use bevy_xpbd_2d::prelude::*;")]
+    #[cfg_attr(feature = "3d", doc = "# use bevy_xpbd_3d::prelude::*;")]
     /// let mut layers = LayerMask(0b1010);
     ///
     /// // These are equivalent
@@ -142,6 +147,8 @@ impl LayerMask {
     /// # Example
     ///
     /// ```
+    #[cfg_attr(feature = "2d", doc = "# use bevy_xpbd_2d::prelude::*;")]
+    #[cfg_attr(feature = "3d", doc = "# use bevy_xpbd_3d::prelude::*;")]
     /// let mut layers = LayerMask(0b1010);
     ///
     /// // These are equivalent
@@ -248,7 +255,6 @@ impl Not for LayerMask {
 /// You can also use an enum that implements [`PhysicsLayer`]:
 ///
 /// ```
-/// # use bevy::prelude::*;
 #[cfg_attr(feature = "2d", doc = "# use bevy_xpbd_2d::prelude::*;")]
 #[cfg_attr(feature = "3d", doc = "# use bevy_xpbd_3d::prelude::*;")]
 /// #
@@ -276,6 +282,9 @@ impl Not for LayerMask {
 /// Layers can also be defined using constants and bitwise operations:
 ///
 /// ```
+/// # use bevy::prelude::Commands;
+#[cfg_attr(feature = "2d", doc = "# use bevy_xpbd_2d::prelude::*;")]
+#[cfg_attr(feature = "3d", doc = "# use bevy_xpbd_3d::prelude::*;")]
 /// // `1 << n` is bitshifting: the first layer shifted by `n` layers.
 /// pub const FIRST_LAYER: u32 = 1 << 0;
 /// pub const SECOND_LAYER: u32 = 1 << 1;
@@ -297,6 +306,8 @@ impl Not for LayerMask {
 /// and changing their [`LayerMask`]s.
 ///
 /// ```
+#[cfg_attr(feature = "2d", doc = "# use bevy_xpbd_2d::prelude::*;")]
+#[cfg_attr(feature = "3d", doc = "# use bevy_xpbd_3d::prelude::*;")]
 /// let layers = CollisionLayers::new(0b0010, 0b1011);
 ///
 /// // Add memberships (these are equivalent)

--- a/src/components/layers.rs
+++ b/src/components/layers.rs
@@ -24,6 +24,46 @@ impl<L: PhysicsLayer> PhysicsLayer for &L {
 }
 
 /// A bitmask for layers.
+///
+/// A [`LayerMask`] can be constructed from bits directly, or from types implementing [`PhysicsLayer`].
+///
+/// ```
+/// # use bevy::prelude::*;
+#[cfg_attr(feature = "2d", doc = "# use bevy_xpbd_2d::prelude::*;")]
+#[cfg_attr(feature = "3d", doc = "# use bevy_xpbd_3d::prelude::*;")]
+/// #
+/// #[derive(PhysicsLayer)]
+/// enum GameLayer {
+///     Player, // Layer 0
+///     Enemy,  // Layer 1
+///     Ground, // Layer 2
+/// }
+///
+/// // Here, `GameLayer::Enemy` is automatically converted to a `LayerMask` for the comparison.
+/// assert_eq!(LayerMask(0b0010), GameLayer::Enemy);
+/// ```
+///
+/// Bitwise operations can be used to modify and combine masks:
+///
+/// ```
+/// let mask1 = LayerMask(0b0001);
+/// let mask2 = LayerMask(0b0010);
+/// assert_eq!(mask1 | mask2, LayerMask(0b0011));
+///
+/// // You can also add layers from `u32` bitmasks and compare against them directly.
+/// assert_eq!(mask1 | 0b0010, 0b0011);
+/// ```
+///
+/// Another way to use [`LayerMask`] is to define layers as constants:
+///
+/// ```
+/// // `1 << n` is bitshifting: the first layer shifted by `n` layers.
+/// pub const FIRST_LAYER: LayerMask = LayerMask(1 << 0);
+/// pub const LAST_LAYER: LayerMask = LayerMask(1 << 31);
+///
+/// // Bitwise operations unfortunately can't be const, so we need to access the `u32` values.
+/// pub const COMBINED: LayerMask = LayerMask(FIRST_LAYER.0 | LAST_LAYER.0);
+/// ```
 #[derive(Reflect, Clone, Copy, Debug, Deref, DerefMut, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct LayerMask(pub u32);
@@ -214,9 +254,9 @@ impl Not for LayerMask {
 /// #
 /// #[derive(PhysicsLayer)]
 /// enum GameLayer {
-///     Player,
-///     Enemy,
-///     Ground,
+///     Player, // Layer 0
+///     Enemy,  // Layer 1
+///     Ground, // Layer 2
 /// }
 ///
 /// // Player collides with enemies and the ground, but not with other players
@@ -236,8 +276,7 @@ impl Not for LayerMask {
 /// Layers can also be defined using constants and bitwise operations:
 ///
 /// ```
-/// // Define layers using constants
-/// // (names chosen for demonstration purposes, use more fitting names in your own application)
+/// // `1 << n` is bitshifting: the first layer shifted by `n` layers.
 /// pub const FIRST_LAYER: u32 = 1 << 0;
 /// pub const SECOND_LAYER: u32 = 1 << 1;
 /// pub const LAST_LAYER: u32 = 1 << 31;

--- a/src/components/layers.rs
+++ b/src/components/layers.rs
@@ -91,7 +91,8 @@ pub struct CollisionLayers {
 }
 
 /// A bitmask for layers.
-#[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Reflect, Clone, Copy, Debug, Deref, DerefMut, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Layers(pub u32);
 
 impl From<u32> for Layers {

--- a/src/components/layers.rs
+++ b/src/components/layers.rs
@@ -305,6 +305,8 @@ mod tests {
 
         assert!(with_bitmask.contains_groups(GameLayer::Enemy));
         assert!(!with_bitmask.contains_groups(GameLayer::Player));
-        assert!(!with_bitmask.contains_masks(GameLayer::Player));
+
+        assert!(with_bitmask.contains_masks(GameLayer::Ground));
+        assert!(!with_bitmask.contains_masks(GameLayer::Enemy));
     }
 }

--- a/src/components/layers.rs
+++ b/src/components/layers.rs
@@ -31,7 +31,7 @@ impl<L: PhysicsLayer> PhysicsLayer for &L {
 #[cfg_attr(feature = "2d", doc = "# use bevy_xpbd_2d::prelude::*;")]
 #[cfg_attr(feature = "3d", doc = "# use bevy_xpbd_3d::prelude::*;")]
 /// #
-/// #[derive(PhysicsLayer)]
+/// #[derive(PhysicsLayer, Clone, Copy, Debug)]
 /// enum GameLayer {
 ///     Player, // Layer 0
 ///     Enemy,  // Layer 1
@@ -58,6 +58,8 @@ impl<L: PhysicsLayer> PhysicsLayer for &L {
 /// Another way to use [`LayerMask`] is to define layers as constants:
 ///
 /// ```
+#[cfg_attr(feature = "2d", doc = "# use bevy_xpbd_2d::prelude::*;")]
+#[cfg_attr(feature = "3d", doc = "# use bevy_xpbd_3d::prelude::*;")]
 /// // `1 << n` is bitshifting: the first layer shifted by `n` layers.
 /// pub const FIRST_LAYER: LayerMask = LayerMask(1 << 0);
 /// pub const LAST_LAYER: LayerMask = LayerMask(1 << 31);
@@ -115,7 +117,7 @@ impl LayerMask {
     /// layers.add(0b0001);
     /// layers |= 0b0001;
     ///
-    /// assert_eq!(layers, 0b0001);
+    /// assert_eq!(layers, 0b1011);
     /// ```
     pub fn add(&mut self, layers: impl Into<Self>) {
         let layers: LayerMask = layers.into();
@@ -308,7 +310,7 @@ impl Not for LayerMask {
 /// ```
 #[cfg_attr(feature = "2d", doc = "# use bevy_xpbd_2d::prelude::*;")]
 #[cfg_attr(feature = "3d", doc = "# use bevy_xpbd_3d::prelude::*;")]
-/// let layers = CollisionLayers::new(0b0010, 0b1011);
+/// let mut layers = CollisionLayers::new(0b0010, 0b1011);
 ///
 /// // Add memberships (these are equivalent)
 /// layers.memberships.add(0b0001);

--- a/src/plugins/spatial_query/query_filter.rs
+++ b/src/plugins/spatial_query/query_filter.rs
@@ -15,9 +15,7 @@ use crate::prelude::*;
 ///     let object = commands.spawn(Collider::ball(0.5)).id();
 ///
 ///     // A query filter that has three collision masks and excludes the `object` entity
-///     let query_filter = SpatialQueryFilter::new()
-///         .with_masks_from_bits(0b1011)
-///         .without_entities([object]);
+///     let query_filter = SpatialQueryFilter::from_masks(0b1011).with_excluded_entities([object]);
 ///
 ///     // Spawn a ray caster with the query filter
 ///     commands.spawn(RayCaster::default().with_query_filter(query_filter));
@@ -26,8 +24,8 @@ use crate::prelude::*;
 #[derive(Clone)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct SpatialQueryFilter {
-    /// Specifies which [collision groups](CollisionLayers) will be included in a [spatial query](crate::spatial_query).
-    pub masks: u32,
+    /// Specifies which [collision groups](CollisionLayers) will be included in the [spatial query](crate::spatial_query).
+    pub masks: Layers,
     /// Entities that will not be included in [spatial queries](crate::spatial_query).
     pub excluded_entities: HashSet<Entity>,
 }
@@ -35,39 +33,39 @@ pub struct SpatialQueryFilter {
 impl Default for SpatialQueryFilter {
     fn default() -> Self {
         Self {
-            masks: 0xffff_ffff,
+            masks: Layers::ALL,
             excluded_entities: default(),
         }
     }
 }
 
 impl SpatialQueryFilter {
-    /// Creates a new [`SpatialQueryFilter`] that doesn't exclude any colliders.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Sets the masks of the filter configuration using a bitmask. Colliders with the corresponding
-    /// [collision group](CollisionLayers) will be included in the [spatial query](crate::spatial_query).
-    pub fn with_masks_from_bits(mut self, masks: u32) -> Self {
-        self.masks = masks;
-        self
-    }
-
-    /// Sets the masks of the filter configuration using a list of [layers](PhysicsLayer).
-    /// Colliders with the corresponding [collision groups](CollisionLayers) will be included
-    /// in the [spatial query](crate::spatial_query).
-    pub fn with_masks(mut self, masks: impl IntoIterator<Item = impl PhysicsLayer>) -> Self {
-        self.masks = 0;
-        for mask in masks.into_iter().map(|l| l.to_bits()) {
-            self.masks |= mask;
+    /// Creates a new [`SpatialQueryFilter`] with the given masks determining
+    /// which [collision groups](CollisionLayers) will be included in the [spatial query](crate::spatial_query).
+    pub fn from_masks(masks: impl Into<Layers>) -> Self {
+        Self {
+            masks: masks.into(),
+            ..default()
         }
+    }
+
+    /// Creates a new [`SpatialQueryFilter`] with the given entities excluded from the [spatial query](crate::spatial_query).
+    pub fn from_excluded_entities(entities: impl IntoIterator<Item = Entity>) -> Self {
+        Self {
+            excluded_entities: HashSet::from_iter(entities),
+            ..default()
+        }
+    }
+
+    /// Sets the masks of the filter configuration to the given layers. Only colliders with the corresponding
+    /// [collision groups](CollisionLayers) will be included in the [spatial query](crate::spatial_query).
+    pub fn with_masks(mut self, masks: impl Into<Layers>) -> Self {
+        self.masks = masks.into();
         self
     }
 
-    /// Excludes the given entities from [spatial queries](crate::spatial_query).
-    #[doc(alias = "exclude_entities")]
-    pub fn without_entities(mut self, entities: impl IntoIterator<Item = Entity>) -> Self {
+    /// Excludes the given entities from the [spatial query](crate::spatial_query).
+    pub fn with_excluded_entities(mut self, entities: impl IntoIterator<Item = Entity>) -> Self {
         self.excluded_entities = HashSet::from_iter(entities);
         self
     }
@@ -76,8 +74,7 @@ impl SpatialQueryFilter {
     /// filter configuration.
     pub fn test(&self, entity: Entity, layers: CollisionLayers) -> bool {
         !self.excluded_entities.contains(&entity)
-            && CollisionLayers::from_bits(0xffff_ffff, self.masks).interacts_with(
-                CollisionLayers::from_bits(layers.groups_bits(), 0xffff_ffff),
-            )
+            && CollisionLayers::new(Layers::ALL, self.masks)
+                .interacts_with(CollisionLayers::new(layers.groups, Layers::ALL))
     }
 }

--- a/src/plugins/spatial_query/query_filter.rs
+++ b/src/plugins/spatial_query/query_filter.rs
@@ -25,7 +25,7 @@ use crate::prelude::*;
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct SpatialQueryFilter {
     /// Specifies which [collision groups](CollisionLayers) will be included in the [spatial query](crate::spatial_query).
-    pub masks: Layers,
+    pub masks: LayerMask,
     /// Entities that will not be included in [spatial queries](crate::spatial_query).
     pub excluded_entities: HashSet<Entity>,
 }
@@ -33,7 +33,7 @@ pub struct SpatialQueryFilter {
 impl Default for SpatialQueryFilter {
     fn default() -> Self {
         Self {
-            masks: Layers::ALL,
+            masks: LayerMask::ALL,
             excluded_entities: default(),
         }
     }
@@ -42,7 +42,7 @@ impl Default for SpatialQueryFilter {
 impl SpatialQueryFilter {
     /// Creates a new [`SpatialQueryFilter`] with the given masks determining
     /// which [collision groups](CollisionLayers) will be included in the [spatial query](crate::spatial_query).
-    pub fn from_masks(masks: impl Into<Layers>) -> Self {
+    pub fn from_masks(masks: impl Into<LayerMask>) -> Self {
         Self {
             masks: masks.into(),
             ..default()
@@ -59,7 +59,7 @@ impl SpatialQueryFilter {
 
     /// Sets the masks of the filter configuration to the given layers. Only colliders with the corresponding
     /// [collision groups](CollisionLayers) will be included in the [spatial query](crate::spatial_query).
-    pub fn with_masks(mut self, masks: impl Into<Layers>) -> Self {
+    pub fn with_masks(mut self, masks: impl Into<LayerMask>) -> Self {
         self.masks = masks.into();
         self
     }
@@ -74,7 +74,7 @@ impl SpatialQueryFilter {
     /// filter configuration.
     pub fn test(&self, entity: Entity, layers: CollisionLayers) -> bool {
         !self.excluded_entities.contains(&entity)
-            && CollisionLayers::new(Layers::ALL, self.masks)
-                .interacts_with(CollisionLayers::new(layers.groups, Layers::ALL))
+            && CollisionLayers::new(LayerMask::ALL, self.masks)
+                .interacts_with(CollisionLayers::new(layers.groups, LayerMask::ALL))
     }
 }

--- a/src/plugins/spatial_query/query_filter.rs
+++ b/src/plugins/spatial_query/query_filter.rs
@@ -14,8 +14,8 @@ use crate::prelude::*;
 /// fn setup(mut commands: Commands) {
 ///     let object = commands.spawn(Collider::ball(0.5)).id();
 ///
-///     // A query filter that has three collision masks and excludes the `object` entity
-///     let query_filter = SpatialQueryFilter::from_masks(0b1011).with_excluded_entities([object]);
+///     // A query filter that has three collision layers and excludes the `object` entity
+///     let query_filter = SpatialQueryFilter::from_mask(0b1011).with_excluded_entities([object]);
 ///
 ///     // Spawn a ray caster with the query filter
 ///     commands.spawn(RayCaster::default().with_query_filter(query_filter));
@@ -24,8 +24,8 @@ use crate::prelude::*;
 #[derive(Clone)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct SpatialQueryFilter {
-    /// Specifies which [collision groups](CollisionLayers) will be included in the [spatial query](crate::spatial_query).
-    pub masks: LayerMask,
+    /// Specifies which [collision layers](CollisionLayers) will be included in the [spatial query](crate::spatial_query).
+    pub mask: LayerMask,
     /// Entities that will not be included in [spatial queries](crate::spatial_query).
     pub excluded_entities: HashSet<Entity>,
 }
@@ -33,18 +33,18 @@ pub struct SpatialQueryFilter {
 impl Default for SpatialQueryFilter {
     fn default() -> Self {
         Self {
-            masks: LayerMask::ALL,
+            mask: LayerMask::ALL,
             excluded_entities: default(),
         }
     }
 }
 
 impl SpatialQueryFilter {
-    /// Creates a new [`SpatialQueryFilter`] with the given masks determining
-    /// which [collision groups](CollisionLayers) will be included in the [spatial query](crate::spatial_query).
-    pub fn from_masks(masks: impl Into<LayerMask>) -> Self {
+    /// Creates a new [`SpatialQueryFilter`] with the given [`LayerMask`] determining
+    /// which [collision layers](CollisionLayers) will be included in the [spatial query](crate::spatial_query).
+    pub fn from_mask(mask: impl Into<LayerMask>) -> Self {
         Self {
-            masks: masks.into(),
+            mask: mask.into(),
             ..default()
         }
     }
@@ -57,10 +57,10 @@ impl SpatialQueryFilter {
         }
     }
 
-    /// Sets the masks of the filter configuration to the given layers. Only colliders with the corresponding
-    /// [collision groups](CollisionLayers) will be included in the [spatial query](crate::spatial_query).
-    pub fn with_masks(mut self, masks: impl Into<LayerMask>) -> Self {
-        self.masks = masks.into();
+    /// Sets the [`LayerMask`] of the filter configuration. Only colliders with the corresponding
+    /// [collision layer memberships](CollisionLayers) will be included in the [spatial query](crate::spatial_query).
+    pub fn with_mask(mut self, masks: impl Into<LayerMask>) -> Self {
+        self.mask = masks.into();
         self
     }
 
@@ -74,7 +74,7 @@ impl SpatialQueryFilter {
     /// filter configuration.
     pub fn test(&self, entity: Entity, layers: CollisionLayers) -> bool {
         !self.excluded_entities.contains(&entity)
-            && CollisionLayers::new(LayerMask::ALL, self.masks)
-                .interacts_with(CollisionLayers::new(layers.groups, LayerMask::ALL))
+            && CollisionLayers::new(LayerMask::ALL, self.mask)
+                .interacts_with(CollisionLayers::new(layers.memberships, LayerMask::ALL))
     }
 }


### PR DESCRIPTION
# Objective

Fixes #322 (among other things).

Improve and simplify the API used for `CollisionLayers` and `SpatialQueryFilter`.

## Solution

Add a `LayerMask` struct that stores a bitmask used for collision layers. The `groups` and `masks` properties have also been renamed to `memberships` and `filters`, because "groups" and "layers" sound like the same thing, and "masks" might be confusing since it's a single bitmask (just like groups/memberships). The new naming is also what Rapier uses.

A `LayerMask` can be created from a `u32`, a type implementing `PhysicsLayer`, or an array of layers. `CollisionLayers::new` now takes `impl Into<LayerMask>`. All of the following work:

```rust
let layers = CollisionLayers::new(0b00010, 0b0111);
let layers = CollisionLayers::new(GameLayer::Player, [GameLayer::Enemy, GameLayer::Ground]);
let layers = CollisionLayers::new(LayerMask(0b0001), LayerMask::ALL);
```

`LayerMask` also allows us to reduce the number of `CollisionLayers` methods. `contains_group`/`contains_mask`, `add_group`/`add_mask` and so on have been removed in favor of simply calling methods like `add` or `remove` on the actual properties.

```rust
layers.memberships.remove(GameLayer::Environment);
layers.filters.add([GameLayer::Environment, GameLayer::Tree]);

// Bitwise ops also work since we're accessing the bitmasks/layermasks directly
layers.memberships |= GameLayer::Player; // or bitmask directly, e.g. 0b0010
```

The methods mutate in place instead of returning a copy, which fixes #322.

`SpatialQueryFilter` also now uses `LayerMask` for its masks, and its constructors have been improved. `new` has been removed for redundancy, `with_mask_from_bits` has been removed, and instead it has the methods `from_mask`, `from_excluded_entities`, `with_mask`, and `with_excluded_entities`.

---

## Changelog

### Added

- `LayerMask` struct
- `SpatialQueryFilter::from_mask`
- `SpatialQueryFilter::from_excluded_entities`

### Changed

#### `CollisionLayers`

- `groups` and `masks` of `CollisionLayers` are now called `memberships` and `filters`
- `CollisionLayers` stores `LayerMask`s for memberships and filters
- Methods that took `impl IntoIterator<Item = impl PhysicsLayer>` now take `impl Into<LayerMask>`
- Change `CollisionLayers::all()` to constant `CollisionLayers::ALL`
- Change `CollisionLayers::none()` to constant `CollisionLayers::NONE`
- Change `CollisionLayers::all_groups()` to constant `CollisionLayers::ALL_MEMBERSHIPS`
- Change `CollisionLayers::all_masks()` to constant `CollisionLayers::ALL_FILTERS`

#### `SpatialQueryFilter`

- `SpatialQueryFilter` stores a `LayerMask` for collision masks
- `SpatialQueryFilter::with_mask` now takes `impl Into<LayerMask>`
- Rename `SpatialQueryFilter::without_entities` to `with_excluded_entities` for consistency

### Removed

- `CollisionLayers::add_group` and `CollisionLayers::add_mask`
- `CollisionLayers::remove_group` and `CollisionLayers::remove_mask`
- `CollisionLayers::contains_group` and `CollisionLayers::contains_mask`
- `CollisionLayers::groups_bits` and `CollisionLayers::masks_bits` (you could get e.g. `layers.groups.0` instead)
- `SpatialQueryFilter::new`
- `SpatialQueryFilter::with_masks_from_bits`

## Migration Guide

- Replace e.g. every `layers.add_group(...)` with `layers.memberships.add(...)` and so on, and similarly for masks/filters
- Change `CollisionLayers::all()` to `CollisionLayers::ALL`
- Change `CollisionLayers::none()` to `CollisionLayers::NONE`
- Change `CollisionLayers::all_groups()` to `CollisionLayers::ALL_MEMBERSHIPS`
- Change `CollisionLayers::all_masks()` to `CollisionLayers::ALL_FILTERS`
- Change `SpatialQueryFilter::new()` to `SpatialQueryFilter::default()` or use the `SpatialQueryFilter::from_mask` or `SpatialQueryFilter::from_excluded_entities` constructors
- Change `SpatialQueryFilter::without_entities` to `with_excluded_entities`
- Change `CollisionLayers::groups_bits()` and `CollisionLayers::masks_bits()` to `layers.memberships.0` and `layers.filters.0`