### PR TITLE
Store impulses in contacts and refactor contact data

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -693,6 +693,8 @@ pub enum PhysicsStepSet {
 /// 4. Solve positional and angular constraints
 /// 5. Update velocities
 /// 6. Solve velocity constraints (dynamic friction and restitution)
+/// 7. Store contact impulses in [`Collisions`].
+/// 8. Apply [`AccumulatedTranslation`] to positions.
 #[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum SubstepSet {
     /// Responsible for integrating Newton's 2nd law of motion,
@@ -736,6 +738,10 @@ pub enum SubstepSet {
     ///
     /// See [`SolverPlugin`].
     SolveVelocities,
+    /// Contact impulses computed by the solver are stored in contacts in [`Collisions`].
+    ///
+    /// See [`SolverPlugin`].
+    StoreImpulses,
     /// Responsible for applying translation accumulated during the substep.
     ///
     /// See [`SolverPlugin`].

--- a/src/plugins/collision/mod.rs
+++ b/src/plugins/collision/mod.rs
@@ -268,11 +268,11 @@ pub struct Contacts {
     pub during_previous_frame: bool,
     /// The total normal impulse applied to the first body in a collision.
     ///
-    /// To get the corresponding force, multiply the impulse by `Time<Substeps>`.
+    /// To get the corresponding force, divide the impulse by `Time<Substeps>`.
     pub total_normal_impulse: Scalar,
     /// The total tangent impulse applied to the first body in a collision.
     ///
-    /// To get the corresponding force, multiply the impulse by `Time<Substeps>`.
+    /// To get the corresponding force, divide the impulse by `Time<Substeps>`.
     #[doc(alias = "total_friction_impulse")]
     pub total_tangent_impulse: Scalar,
 }
@@ -290,6 +290,7 @@ impl Contacts {
     ///
     /// Because contacts are solved over several substeps, `delta_time` should
     /// typically use `Time<Substeps>`.
+    #[doc(alias = "total_friction_force")]
     pub fn total_tangent_force(&self, delta_time: Scalar) -> Scalar {
         self.total_tangent_impulse / delta_time
     }
@@ -400,7 +401,7 @@ pub struct ContactData {
     pub penetration: Scalar,
     /// The impulse applied to the first body along the normal.
     ///
-    /// To get the corresponding force, multiply the impulse by `Time<Substeps>`.
+    /// To get the corresponding force, divide the impulse by `Time<Substeps>`.
     ///
     /// ## Caveats
     ///
@@ -414,7 +415,7 @@ pub struct ContactData {
     pub normal_impulse: Scalar,
     /// The impulse applied to the first body along the tangent. This corresponds to the impulse caused by friction.
     ///
-    /// To get the corresponding force, multiply the impulse by `Time<Substeps>`.
+    /// To get the corresponding force, divide the impulse by `Time<Substeps>`.
     ///
     /// ## Caveats
     ///
@@ -467,6 +468,7 @@ impl ContactData {
     ///
     /// Because contacts are solved over several substeps, `delta_time` should
     /// typically use `Time<Substeps>`.
+    #[doc(alias = "friction_force")]
     pub fn tangent_force(&self, delta_time: Scalar) -> Scalar {
         self.tangent_impulse / delta_time
     }

--- a/src/plugins/collision/mod.rs
+++ b/src/plugins/collision/mod.rs
@@ -266,6 +266,33 @@ pub struct Contacts {
     pub during_current_substep: bool,
     /// True if the bodies were in contact during the previous frame.
     pub during_previous_frame: bool,
+    /// The total normal impulse applied to the first body in a collision.
+    ///
+    /// To get the corresponding force, multiply the impulse by `Time<Substeps>`.
+    pub total_normal_impulse: Scalar,
+    /// The total tangent impulse applied to the first body in a collision.
+    ///
+    /// To get the corresponding force, multiply the impulse by `Time<Substeps>`.
+    #[doc(alias = "total_friction_impulse")]
+    pub total_tangent_impulse: Scalar,
+}
+
+impl Contacts {
+    /// The force corresponding to the total normal impulse applied over `delta_time`.
+    ///
+    /// Because contacts are solved over several substeps, `delta_time` should
+    /// typically use `Time<Substeps>`.
+    pub fn total_normal_force(&self, delta_time: Scalar) -> Scalar {
+        self.total_normal_impulse / delta_time
+    }
+
+    /// The force corresponding to the total tangent impulse applied over `delta_time`.
+    ///
+    /// Because contacts are solved over several substeps, `delta_time` should
+    /// typically use `Time<Substeps>`.
+    pub fn total_tangent_force(&self, delta_time: Scalar) -> Scalar {
+        self.total_tangent_impulse / delta_time
+    }
 }
 
 /// A contact manifold between two colliders, containing a set of contact points.
@@ -281,9 +308,71 @@ pub struct ContactManifold {
     /// A contact normal shared by all contacts in this manifold,
     /// expressed in the local space of the second entity.
     pub normal2: Vector,
+    /// The index of the manifold in the collision.
+    pub index: usize,
 }
 
 impl ContactManifold {
+    /// Returns the world-space contact normal pointing towards the exterior of the first entity.
+    pub fn global_normal1(&self, rotation: &Rotation) -> Vector {
+        rotation.rotate(self.normal1)
+    }
+
+    /// Returns the world-space contact normal pointing towards the exterior of the second entity.
+    pub fn global_normal2(&self, rotation: &Rotation) -> Vector {
+        rotation.rotate(self.normal2)
+    }
+}
+
+/// Data related to a single contact between two bodies.
+///
+/// If you want a contact that belongs to a [contact manifold](ContactManifold) and has more data,
+/// see [`ContactData`].
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct SingleContact {
+    /// Contact point on the first entity in local coordinates.
+    pub point1: Vector,
+    /// Contact point on the second entity in local coordinates.
+    pub point2: Vector,
+    /// A contact normal expressed in the local space of the first entity.
+    pub normal1: Vector,
+    /// A contact normal expressed in the local space of the second entity.
+    pub normal2: Vector,
+    /// Penetration depth.
+    pub penetration: Scalar,
+}
+
+impl SingleContact {
+    /// Creates a new [`SingleContact`]. The contact points and normals should be given in local space.
+    pub fn new(
+        point1: Vector,
+        point2: Vector,
+        normal1: Vector,
+        normal2: Vector,
+        penetration: Scalar,
+    ) -> Self {
+        Self {
+            point1,
+            point2,
+            normal1,
+            normal2,
+            penetration,
+        }
+    }
+
+    /// Returns the global contact point on the first entity,
+    /// transforming the local point by the given entity position and rotation.
+    pub fn global_point1(&self, position: &Position, rotation: &Rotation) -> Vector {
+        position.0 + rotation.rotate(self.point1)
+    }
+
+    /// Returns the global contact point on the second entity,
+    /// transforming the local point by the given entity position and rotation.
+    pub fn global_point2(&self, position: &Position, rotation: &Rotation) -> Vector {
+        position.0 + rotation.rotate(self.point2)
+    }
+
     /// Returns the world-space contact normal pointing towards the exterior of the first entity.
     pub fn global_normal1(&self, rotation: &Rotation) -> Vector {
         rotation.rotate(self.normal1)
@@ -309,9 +398,79 @@ pub struct ContactData {
     pub normal2: Vector,
     /// Penetration depth.
     pub penetration: Scalar,
+    /// The impulse applied to the first body along the normal.
+    ///
+    /// To get the corresponding force, multiply the impulse by `Time<Substeps>`.
+    ///
+    /// ## Caveats
+    ///
+    /// * This will initially be zero after collision detection and will only be computed after constraint solving.
+    /// It is recommended to access this before or after physics.
+    /// * The impulse is from a single *substep*. Each physics frame has [`SubstepCount`] substeps.
+    /// * Impulses in contact events like [`Collision`] currently use the impulse from the *last* substep.
+    ///
+    /// The total impulse for a collision including all contacts can be accessed in [`Contacts`] returned by
+    /// the [`Collision`] event or the [`Collisions`] rsource.
+    pub normal_impulse: Scalar,
+    /// The impulse applied to the first body along the tangent. This corresponds to the impulse caused by friction.
+    ///
+    /// To get the corresponding force, multiply the impulse by `Time<Substeps>`.
+    ///
+    /// ## Caveats
+    ///
+    /// * This will initially be zero after collision detection and will only be computed after constraint solving.
+    /// It is recommended to access this before or after physics.
+    /// * The impulse is from a single *substep*. Each physics frame has [`SubstepCount`] substeps.
+    /// * Impulses in contact events like [`Collision`] currently use the impulse from the *last* substep.
+    ///
+    /// The total impulse for a collision including all contacts can be accessed in [`Contacts`] returned by
+    /// the [`Collision`] event or the [`Collisions`] rsource.
+    #[doc(alias = "friction_impulse")]
+    pub tangent_impulse: Scalar,
+    /// The index of the contact in a contact manifold if it is in one.
+    pub index: usize,
 }
 
 impl ContactData {
+    /// Creates a new [`ContactData`]. The contact points and normals should be given in local space.
+    ///
+    /// The given `index` is the index of the contact in a contact manifold, if it is in one.
+    pub fn new(
+        point1: Vector,
+        point2: Vector,
+        normal1: Vector,
+        normal2: Vector,
+        penetration: Scalar,
+        index: usize,
+    ) -> Self {
+        Self {
+            point1,
+            point2,
+            normal1,
+            normal2,
+            penetration,
+            normal_impulse: 0.0,
+            tangent_impulse: 0.0,
+            index,
+        }
+    }
+
+    /// The force corresponding to the normal impulse applied over `delta_time`.
+    ///
+    /// Because contacts are solved over several substeps, `delta_time` should
+    /// typically use `Time<Substeps>`.
+    pub fn normal_force(&self, delta_time: Scalar) -> Scalar {
+        self.normal_impulse / delta_time
+    }
+
+    /// The force corresponding to the tangent impulse applied over `delta_time`.
+    ///
+    /// Because contacts are solved over several substeps, `delta_time` should
+    /// typically use `Time<Substeps>`.
+    pub fn tangent_force(&self, delta_time: Scalar) -> Scalar {
+        self.tangent_impulse / delta_time
+    }
+
     /// Returns the global contact point on the first entity,
     /// transforming the local point by the given entity position and rotation.
     pub fn global_point1(&self, position: &Position, rotation: &Rotation) -> Vector {

--- a/src/plugins/collision/narrow_phase.rs
+++ b/src/plugins/collision/narrow_phase.rs
@@ -197,6 +197,8 @@ fn process_collision_pair<F>(
                 *rotation2,
                 narrow_phase_config.prediction_distance,
             ),
+            total_normal_impulse: 0.0,
+            total_tangent_impulse: 0.0,
         };
 
         if !contacts.manifolds.is_empty() {
@@ -213,6 +215,9 @@ pub fn reset_collision_states(
     query: Query<(Option<&RigidBody>, Has<Sleeping>)>,
 ) {
     for contacts in collisions.get_internal_mut().values_mut() {
+        contacts.total_normal_impulse = 0.0;
+        contacts.total_tangent_impulse = 0.0;
+
         if let Ok([(rb1, sleeping1), (rb2, sleeping2)]) =
             query.get_many([contacts.entity1, contacts.entity2])
         {

--- a/src/plugins/debug/configuration.rs
+++ b/src/plugins/debug/configuration.rs
@@ -52,6 +52,8 @@ pub struct PhysicsDebugConfig {
     pub contact_point_color: Option<Color>,
     /// The color of the contact normals. If `None`, the contact normals will not be rendered.
     pub contact_normal_color: Option<Color>,
+    /// The scale used for contact normals.
+    pub contact_normal_scale: ContactGizmoScale,
     /// The color of the lines drawn from the centers of bodies to their joint anchors.
     pub joint_anchor_color: Option<Color>,
     /// The color of the lines drawn between joint anchors, indicating the separation.
@@ -88,6 +90,7 @@ impl Default for PhysicsDebugConfig {
             sleeping_color_multiplier: Some([1.0, 1.0, 0.4, 1.0]),
             contact_point_color: None,
             contact_normal_color: None,
+            contact_normal_scale: ContactGizmoScale::default(),
             joint_anchor_color: Some(Color::PINK),
             joint_separation_color: Some(Color::RED),
             raycast_color: Some(Color::RED),
@@ -98,6 +101,28 @@ impl Default for PhysicsDebugConfig {
             shapecast_point_color: Some(Color::YELLOW),
             shapecast_normal_color: Some(Color::PINK),
             hide_meshes: false,
+        }
+    }
+}
+
+/// The scale used for contact normals rendered using gizmos.
+#[derive(Reflect)]
+pub enum ContactGizmoScale {
+    /// The length of the rendered contact normal is constant.
+    Constant(Scalar),
+    /// The length of the rendered contact normal is scaled by the contact force and the given scaling factor.
+    Scaled(Scalar),
+}
+
+impl Default for ContactGizmoScale {
+    fn default() -> Self {
+        #[cfg(feature = "2d")]
+        {
+            Self::Scaled(0.025)
+        }
+        #[cfg(feature = "3d")]
+        {
+            Self::Scaled(0.25)
         }
     }
 }
@@ -116,6 +141,7 @@ impl PhysicsDebugConfig {
             sleeping_color_multiplier: Some([1.0, 1.0, 0.4, 1.0]),
             contact_point_color: Some(Color::CYAN),
             contact_normal_color: Some(Color::RED),
+            contact_normal_scale: ContactGizmoScale::default(),
             joint_anchor_color: Some(Color::PINK),
             joint_separation_color: Some(Color::RED),
             raycast_color: Some(Color::RED),
@@ -141,6 +167,7 @@ impl PhysicsDebugConfig {
             sleeping_color_multiplier: None,
             contact_point_color: None,
             contact_normal_color: None,
+            contact_normal_scale: ContactGizmoScale::default(),
             joint_anchor_color: None,
             joint_separation_color: None,
             raycast_color: None,
@@ -233,9 +260,21 @@ impl PhysicsDebugConfig {
         self
     }
 
-    /// Sets the contact color.
+    /// Sets the contact point color.
     pub fn with_contact_point_color(mut self, color: Color) -> Self {
         self.contact_point_color = Some(color);
+        self
+    }
+
+    /// Sets the contact normal color.
+    pub fn with_contact_normal_color(mut self, color: Color) -> Self {
+        self.contact_normal_color = Some(color);
+        self
+    }
+
+    /// Sets the contact normal scale.
+    pub fn with_contact_normal_scale(mut self, scale: ContactGizmoScale) -> Self {
+        self.contact_normal_scale = scale;
         self
     }
 

--- a/src/plugins/debug/configuration.rs
+++ b/src/plugins/debug/configuration.rs
@@ -116,14 +116,7 @@ pub enum ContactGizmoScale {
 
 impl Default for ContactGizmoScale {
     fn default() -> Self {
-        #[cfg(feature = "2d")]
-        {
-            Self::Scaled(0.025)
-        }
-        #[cfg(feature = "3d")]
-        {
-            Self::Scaled(0.25)
-        }
+        Self::Scaled(0.025)
     }
 }
 

--- a/src/plugins/setup/mod.rs
+++ b/src/plugins/setup/mod.rs
@@ -173,6 +173,7 @@ impl Plugin for PhysicsSetupPlugin {
                     SubstepSet::SolveUserConstraints,
                     SubstepSet::UpdateVelocities,
                     SubstepSet::SolveVelocities,
+                    SubstepSet::StoreImpulses,
                     SubstepSet::ApplyTranslation,
                 )
                     .chain(),


### PR DESCRIPTION
# Objective

Having access to contact impulses can be very useful for several tasks, like implementing destructable objects or determining how much damage a hit should deal. Currently, however, this is not really possible.

There should be a way to access contact impulses.

## Solution

Add properties for normal and tangent (i.e. friction) impulses to `ContactData`. These are computed for `PenetrationConstraint`s in the constraint solver and stored in `Collisions` in the new `SubstepSet::StoreImpulses` system set.

The impulses can be accessed in `Collision` events or using the `Collisions` resource. Note that the impulses in `Colision` events are currently *only from the last substep*.

Impulses are stored instead of forces for a few reasons:

- It's more efficient internally, as it skips some operations
- Impulses might make more sense for impacts
- It's what e.g. Box2D and Unity use

Computing the corresponding force is simple however, as you just need to divide by the (substep) delta time. For this, the contact types also have helpers like `normal_force` and `tangent_force`.

---

## Changelog

- Added `SubstepSet::StoreImpulses` with a `store_contact_impulses` system
- Added normal and tangent impulses and contact index to `ContactData`
- Added total normal and tangent impulses to `Contacts`
- Added manifold index to `ContactManifold`
- Added collider entities and the contact manifold index to `PenetrationConstraint`
- Added `SingleContact` struct, which is used by the `contact` query
- Removed force properties from `PenetrationConstraint` in favor of impulses
- Changed contact normal debug rendering to scale based on the impulse by default
  - Added `ContactGizmoScale` enum for configuring the scaling