### PR TITLE
Fix doc examples

### DIFF
--- a/src/plugins/collision/collider/parry.rs
+++ b/src/plugins/collision/collider/parry.rs
@@ -48,7 +48,7 @@ pub type TriMeshFlags = parry::shape::TriMeshFlags;
 ///     commands.spawn((
 ///         RigidBody::Dynamic,
 ///         Collider::ball(0.5),
-///         Transform::from_xyz(0.0, 2.0, 0.0),
+///         TransformBundle::from_transform(Transform::from_xyz(0.0, 2.0, 0.0)),
 ///     ));
 #[cfg_attr(
     feature = "2d",
@@ -95,8 +95,14 @@ pub type TriMeshFlags = parry::shape::TriMeshFlags;
 ///         .spawn((RigidBody::Dynamic, Collider::ball(0.5)))
 ///         .with_children(|children| {
 ///             // Spawn the child colliders positioned relative to the rigid body
-///             children.spawn((Collider::ball(0.5), Transform::from_xyz(2.0, 0.0, 0.0)));
-///             children.spawn((Collider::ball(0.5), Transform::from_xyz(-2.0, 0.0, 0.0)));
+///             children.spawn((
+///                 Collider::ball(0.5),
+///                 TransformBundle::from_transform(Transform::from_xyz(2.0, 0.0, 0.0)),
+///             ));
+///             children.spawn((
+///                 Collider::ball(0.5),
+///                 TransformBundle::from_transform(Transform::from_xyz(-2.0, 0.0, 0.0)),
+///             ));
 ///         });
 /// }
 /// ```

--- a/src/plugins/spatial_query/system_param.rs
+++ b/src/plugins/spatial_query/system_param.rs
@@ -156,20 +156,21 @@ impl<'w, 's> SpatialQuery<'w, 's> {
     /// # #[cfg(feature = "3d")]
     /// use bevy_xpbd_3d::prelude::*;
     ///
+    /// #[derive(Component)]
+    /// struct Invisible;
+    ///
     /// # #[cfg(all(feature = "3d", feature = "f32"))]
-    /// fn print_hits(spatial_query: SpatialQuery) {
+    /// fn print_hits(spatial_query: SpatialQuery, query: Query<&Invisible>) {
     ///     // Cast ray and print first hit
-    ///     if let Some(first_hit) = spatial_query.cast_ray(
+    ///     if let Some(first_hit) = spatial_query.cast_ray_predicate(
     ///         Vec3::ZERO,                    // Origin
     ///         Vec3::X,                       // Direction
     ///         100.0,                         // Maximum time of impact (travel distance)
     ///         true,                          // Does the ray treat colliders as "solid"
     ///         SpatialQueryFilter::default(), // Query filter
     ///         &|entity| {                    // Predicate
-    ///             if let Some(value) = query.get(entity) {
-    ///                 return value == x;     // ignore if value from query is x
-    ///             }
-    ///             true                       // else check for collision
+    ///             // Skip entities with the `Invisible` component.
+    ///             !query.contains(entity)
     ///         }
     ///     ) {
     ///         println!("First hit: {:?}", first_hit);
@@ -668,7 +669,7 @@ impl<'w, 's> SpatialQuery<'w, 's> {
     ///
     /// # #[cfg(all(feature = "3d", feature = "f32"))]
     /// fn print_aabb_intersections(spatial_query: SpatialQuery) {
-    ///     let aabb = Collider::ball(0.5).compute_aabb(Vec3::ZERO, Quat::default());
+    ///     let aabb = Collider::ball(0.5).aabb(Vec3::ZERO, Quat::default());
     ///     let intersections = spatial_query.aabb_intersections_with_aabb(aabb);
     ///
     ///     for entity in intersections.iter() {
@@ -698,7 +699,7 @@ impl<'w, 's> SpatialQuery<'w, 's> {
     ///     let mut intersections = vec![];
     ///
     ///     spatial_query.aabb_intersections_with_aabb_callback(
-    ///         Collider::ball(0.5).compute_aabb(Vec3::ZERO, Quat::default()),
+    ///         Collider::ball(0.5).aabb(Vec3::ZERO, Quat::default()),
     ///         |entity| {
     ///             intersections.push(entity);
     ///             true


### PR DESCRIPTION
# Objective

Fixes #245.

The docs have a few errors and outdated method names.

## Solution

- Use `TransformBundle` instead of `Transform` in `Collider` docs to make positioning actually work
- Fix `cast_ray_predicate` docs calling the wrong method and using non-existent variables
- Fix `compute_aabb` -> `aabb`