### PR TITLE
Add feature to examples_common to enable PhysicsDebugPlugin

### DIFF
--- a/crates/examples_common_2d/Cargo.toml
+++ b/crates/examples_common_2d/Cargo.toml
@@ -3,6 +3,9 @@ name = "examples_common_2d"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+use-debug-plugin = []
+
 [dependencies]
 bevy = { version = "0.13", default-features = false, features = [
     "bevy_core_pipeline",

--- a/crates/examples_common_2d/src/lib.rs
+++ b/crates/examples_common_2d/src/lib.rs
@@ -11,20 +11,25 @@ pub struct XpbdExamplePlugin;
 
 impl Plugin for XpbdExamplePlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins((PhysicsPlugins::default(), FrameTimeDiagnosticsPlugin))
-            .init_state::<AppState>()
-            .add_systems(Startup, setup)
-            .add_systems(
-                OnEnter(AppState::Paused),
-                |mut time: ResMut<Time<Physics>>| time.pause(),
-            )
-            .add_systems(
-                OnExit(AppState::Paused),
-                |mut time: ResMut<Time<Physics>>| time.unpause(),
-            )
-            .add_systems(Update, update_fps_text)
-            .add_systems(Update, pause_button)
-            .add_systems(Update, step_button.run_if(in_state(AppState::Paused)));
+        app.add_plugins((
+            PhysicsPlugins::default(),
+            FrameTimeDiagnosticsPlugin,
+            #[cfg(feature = "use-debug-plugin")]
+            PhysicsDebugPlugin::default(),
+        ))
+        .init_state::<AppState>()
+        .add_systems(Startup, setup)
+        .add_systems(
+            OnEnter(AppState::Paused),
+            |mut time: ResMut<Time<Physics>>| time.pause(),
+        )
+        .add_systems(
+            OnExit(AppState::Paused),
+            |mut time: ResMut<Time<Physics>>| time.unpause(),
+        )
+        .add_systems(Update, update_fps_text)
+        .add_systems(Update, pause_button)
+        .add_systems(Update, step_button.run_if(in_state(AppState::Paused)));
     }
 }
 

--- a/crates/examples_common_3d/Cargo.toml
+++ b/crates/examples_common_3d/Cargo.toml
@@ -3,6 +3,9 @@ name = "examples_common_3d"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+use-debug-plugin = []
+
 [dependencies]
 bevy = { version = "0.13", default-features = false, features = [
     "bevy_core_pipeline",

--- a/crates/examples_common_3d/src/lib.rs
+++ b/crates/examples_common_3d/src/lib.rs
@@ -11,20 +11,25 @@ pub struct XpbdExamplePlugin;
 
 impl Plugin for XpbdExamplePlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins((PhysicsPlugins::default(), FrameTimeDiagnosticsPlugin))
-            .init_state::<AppState>()
-            .add_systems(Startup, setup)
-            .add_systems(
-                OnEnter(AppState::Paused),
-                |mut time: ResMut<Time<Physics>>| time.pause(),
-            )
-            .add_systems(
-                OnExit(AppState::Paused),
-                |mut time: ResMut<Time<Physics>>| time.unpause(),
-            )
-            .add_systems(Update, update_fps_text)
-            .add_systems(Update, pause_button)
-            .add_systems(Update, step_button.run_if(in_state(AppState::Paused)));
+        app.add_plugins((
+            PhysicsPlugins::default(),
+            FrameTimeDiagnosticsPlugin,
+            #[cfg(feature = "use-debug-plugin")]
+            PhysicsDebugPlugin::default(),
+        ))
+        .init_state::<AppState>()
+        .add_systems(Startup, setup)
+        .add_systems(
+            OnEnter(AppState::Paused),
+            |mut time: ResMut<Time<Physics>>| time.pause(),
+        )
+        .add_systems(
+            OnExit(AppState::Paused),
+            |mut time: ResMut<Time<Physics>>| time.unpause(),
+        )
+        .add_systems(Update, update_fps_text)
+        .add_systems(Update, pause_button)
+        .add_systems(Update, step_button.run_if(in_state(AppState::Paused)));
     }
 }
 


### PR DESCRIPTION
# Objective

- Enable using the PhysicsDebugPlugin in examples with `cargo run --example cubes --release --features examples_common_3d/use-debug-plugin`


## Solution

- I added a feature to examples_common_[2d,3d] that adds the physics debug plugin
