### PR TITLE
Fix time of impact description in `ShapeHits`

### DIFF
--- a/src/plugins/spatial_query/shape_caster.rs
+++ b/src/plugins/spatial_query/shape_caster.rs
@@ -412,8 +412,7 @@ impl MapEntities for ShapeHits {
 pub struct ShapeHitData {
     /// The entity of the collider that was hit by the shape.
     pub entity: Entity,
-    /// How long the shape travelled before the initial hit,
-    /// i.e. the distance between the origin and the point of intersection.
+    /// The time of impact (TOI), or how long the shape travelled before the initial hit.
     pub time_of_impact: Scalar,
     /// The closest point on the collider that was hit by the shapecast, at the time of impact,
     /// expressed in the local space of the collider shape.


### PR DESCRIPTION
# Objective

As reported by `@nezuo` on the Bevy Discord, the documentation for the `time_of_impact` in `ShapeHits` is inaccurate and contradictory.

> How long the shape travelled before the initial hit, i.e. the distance between the origin and the point of intersection.

These are two separate things: "the distance between the origin and the point of intersection" implies that it corresponds to the blue line, but in reality it is the orange line.

![TOI visualized](https://github.com/Jondolf/bevy_xpbd/assets/57632562/80210b86-3439-48e0-94db-0f15f2dde0f0)

## Solution

Clarify the doc comment and remove the incorrect part:

> The time of impact (TOI), or how long the shape travelled before the initial hit.