### PR TITLE
Fix 3D ShapeCaster global_rotation

### DIFF
--- a/src/plugins/spatial_query/mod.rs
+++ b/src/plugins/spatial_query/mod.rs
@@ -401,7 +401,7 @@ fn update_shape_caster_positions(
             }
             #[cfg(feature = "3d")]
             {
-                shape_caster.set_global_shape_rotation(shape_rotation + global_rotation.0);
+                shape_caster.set_global_shape_rotation(shape_rotation * global_rotation.0);
             }
         } else if parent.is_none() {
             shape_caster.set_global_direction(direction);
@@ -443,7 +443,7 @@ fn update_shape_caster_positions(
                     }
                     #[cfg(feature = "3d")]
                     {
-                        shape_caster.set_global_shape_rotation(shape_rotation + rotation.0);
+                        shape_caster.set_global_shape_rotation(shape_rotation * rotation.0);
                     }
                 }
             }


### PR DESCRIPTION
# Objective

Fix 3D `ShapeCaster` global rotation. Currently, shape and parent rotation are adding its `Quat` instead of multiplying.

## Solution

Multiply the rotations instead of adding.


-----

## Before and After

https://github.com/Jondolf/bevy_xpbd/assets/4665205/7aa92bec-fa62-4810-b518-945fd9896859