### PR TITLE
Use `compile_error!` macro instead of panicking in `PhysicsLayer` derive macro

### DIFF
--- a/crates/bevy_xpbd_derive/Cargo.toml
+++ b/crates/bevy_xpbd_derive/Cargo.toml
@@ -12,5 +12,6 @@ readme = "README.md"
 proc-macro = true
 
 [dependencies]
+proc-macro2 = "1.0.78"
 quote = "1.0"
 syn = "2.0"


### PR DESCRIPTION
# Objective

Improve errors in the `PhysicsLayer` derive macro

## Solution

Instead of panicking, we can instead return a `compile_error!` macro. This removes the "proc-macro panicked" message and also allows us to specify a span (location in the code) for the error.

### Future solutions

I'm thinking of also adding a `nightly` feature which uses the unstable diagnostic API for even better errors.

---

## Changelog

- Improved errors in the `PhysicsLayer` derive macro
