### PR TITLE
add `IgnoredCollisions` component

### DIFF
--- a/src/components/layers.rs
+++ b/src/components/layers.rs
@@ -237,6 +237,8 @@ impl Not for LayerMask {
 /// Colliders without this component can be considered as having all memberships and filters, and they can
 /// interact with everything that belongs on any layer.
 ///
+/// See also [`IgnoredCollisions`](crate::components::IgnoredCollisions).
+///
 /// ## Creation
 ///
 /// Collision layers store memberships and filters using [`LayerMask`]s. A [`LayerMask`] can be created using

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -15,7 +15,7 @@ pub use rotation::*;
 pub use world_queries::*;
 
 use crate::prelude::*;
-use bevy::prelude::*;
+use bevy::{prelude::*, utils::HashSet};
 use derive_more::From;
 
 /// A non-deformable body used for the simulation of most physics objects.
@@ -899,6 +899,63 @@ pub struct AngularDamping(pub Scalar);
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[reflect(Component)]
 pub struct Dominance(pub i8);
+
+/// A component containing a set of entities for which any collisions with the
+/// owning entity will be ignored.
+///
+/// ## Example
+///
+/// ```
+/// use bevy::prelude::*;
+/// # #[cfg(feature = "2d")]
+/// # use bevy_xpbd_2d::prelude::*;
+/// # #[cfg(feature = "3d")]
+/// use bevy_xpbd_3d::prelude::*;
+///
+/// fn setup(mut commands: Commands) {
+///     // Spawn an entity with a collider
+#[cfg_attr(
+    feature = "2d",
+    doc = "    let ent1 = commands",
+    doc = "        .spawn((RigidBody::Dynamic, Collider::circle(0.5)))",
+    doc = "        .id();"
+)]
+#[cfg_attr(
+    feature = "3d",
+    doc = "    let ent1 = commands",
+    doc = "       .spawn((RigidBody::Dynamic, Collider::sphere(0.5)))",
+    doc = "       .id();"
+)]
+///
+///     // Spawn another entity with a collider and configure it to avoid collisions with the first entity.
+#[cfg_attr(
+    feature = "2d",
+    doc = "    let ent1 = commands.spawn((",
+    doc = "        RigidBody::Dynamic,",
+    doc = "        Collider::circle(0.5),",
+    doc = "        IgnoredCollisions::from_iter([ent1]),",
+    doc = "));"
+)]
+#[cfg_attr(
+    feature = "3d",
+    doc = "    let ent1 = commands.spawn((",
+    doc = "        RigidBody::Dynamic,",
+    doc = "        Collider::sphere(0.5),",
+    doc = "        IgnoredCollisions::from_iter([ent1]),",
+    doc = "    ));"
+)]
+/// }
+/// ```
+///
+/// See also [`CollisionLayers`].
+#[derive(Component, Clone, Debug, Default, Deref, DerefMut)]
+pub struct IgnoredCollisions(pub HashSet<Entity>);
+
+impl FromIterator<Entity> for IgnoredCollisions {
+    fn from_iter<T: IntoIterator<Item = Entity>>(iter: T) -> Self {
+        Self(HashSet::from_iter(iter))
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,7 @@
 //!     - [Creation](Collider#creation)
 //!     - [Density](ColliderDensity)
 //!     - [Friction] and [restitution](Restitution) (bounciness)
+//!     - [Ignoring collisions](IgnoredCollisions)
 //!     - [Collision layers](CollisionLayers)
 //!     - [Sensors](Sensor)
 #![cfg_attr(

--- a/src/plugins/collision/collider/parry/mod.rs
+++ b/src/plugins/collision/collider/parry/mod.rs
@@ -80,7 +80,7 @@ pub type TriMeshFlags = parry::shape::TriMeshFlags;
 /// ```
 ///
 /// Colliders can be further configured using various components like [`Friction`], [`Restitution`],
-/// [`Sensor`], and [`CollisionLayers`].
+/// [`Sensor`], [`IgnoredCollisions`], and [`CollisionLayers`].
 ///
 /// In addition, Bevy XPBD automatically adds some other components for colliders, like the following:
 ///
@@ -158,6 +158,7 @@ pub type TriMeshFlags = parry::shape::TriMeshFlags;
 /// - [Rigid bodies](RigidBody)
 /// - [Density](ColliderDensity)
 /// - [Friction] and [restitution](Restitution) (bounciness)
+/// - [Ignoring collisions](IgnoredCollisions)
 /// - [Collision layers](CollisionLayers)
 /// - [Sensors](Sensor)
 #[cfg_attr(

--- a/src/plugins/collision/mod.rs
+++ b/src/plugins/collision/mod.rs
@@ -57,6 +57,12 @@ use indexmap::IndexMap;
 /// The collisions can be accessed at any time, but modifications to contacts should be performed
 /// in the [`PostProcessCollisions`] schedule. Otherwise, the physics solver will use the old contact data.
 ///
+/// ### Ignoring collisions
+///
+/// You can attach an [`IgnoredCollisions`] component to an entity with a
+/// [`Collider`] to completely avoid collision detection between the entity and
+/// the entities contained within the [`IgnoredCollisions`] component.
+///
 /// ### Filtering and removing collisions
 ///
 /// The following methods can be used for filtering or removing existing collisions:


### PR DESCRIPTION
# Objective

Allow to set ignored collisions per entity.

## Solution

Added an `IgnoredCollisions` component which is checked in the broad phase to filter out ignored collisions before any detection checks.

---

## Changelog

### Added

Added an `IgnoredCollisions` component which can be added to entities with a `Collider` to configure a set of entities with which there will be no collision detection with the owning entity.