### PR TITLE
Update bevy-0.14 branch to crates.io release of nalgebra 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,3 @@ resolver = "2"
 
 [profile.dev]
 opt-level = 1 # Use slightly better optimization, so examples work
-
-[patch.crates-io]
-nalgebra = { path = "../nalgebra", optional = true }

--- a/crates/bevy_xpbd_2d/Cargo.toml
+++ b/crates/bevy_xpbd_2d/Cargo.toml
@@ -50,7 +50,7 @@ bevy = { version = "0.14.0-rc" }
 bevy_math = { version = "0.14.0-rc" }
 parry2d = { version = "0.15", optional = true }
 parry2d-f64 = { version = "0.15", optional = true }
-nalgebra = { version = "0.32", features = ["convert-glam027"], optional = true }
+nalgebra = { version = "0.32.6", features = ["convert-glam027"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 derive_more = "0.99"
 indexmap = "2.0.0"

--- a/crates/bevy_xpbd_3d/Cargo.toml
+++ b/crates/bevy_xpbd_3d/Cargo.toml
@@ -59,7 +59,7 @@ bevy = { version = "0.14.0-rc" }
 bevy_math = { version = "0.14.0-rc" }
 parry3d = { version = "0.15", optional = true }
 parry3d-f64 = { version = "0.15", optional = true }
-nalgebra = { version = "0.32", features = ["convert-glam027"], optional = true }
+nalgebra = { version = "0.32.6", features = ["convert-glam027"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 derive_more = "0.99"
 indexmap = "2.0.0"


### PR DESCRIPTION
Glam 0.27 support was [merged and released in 0.3.26](https://github.com/dimforge/nalgebra/pull/1390) so I think this should work with the crates.io version now. 

The tests don't all pass, but that doesn't look like it's related to nalgebra, just the bevy update.