### PR TITLE
Make sensors not contribute to mass properties

### DIFF
--- a/src/components/mass_properties.rs
+++ b/src/components/mass_properties.rs
@@ -356,6 +356,13 @@ impl ColliderMassProperties {
     pub fn new<C: AnyCollider>(collider: &C, density: Scalar) -> Self {
         collider.mass_properties(density)
     }
+
+    /// Transforms the center of mass by the given [`ColliderTransform`].
+    #[inline]
+    pub fn transformed_by(mut self, transform: &ColliderTransform) -> Self {
+        self.center_of_mass.0 = transform.transform_point(self.center_of_mass.0);
+        self
+    }
 }
 
 impl Default for ColliderMassProperties {

--- a/src/plugins/collision/collider/backend.rs
+++ b/src/plugins/collision/collider/backend.rs
@@ -181,15 +181,15 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
                     collider_transform,
                 )) = collider_query.get_mut(trigger.entity())
                 {
-                    // If the collider mass properties are zero, there is nothing to add.
-                    if *collider_mass_properties == ColliderMassProperties::ZERO {
-                        return;
-                    }
-
                     if let Ok(mut mass_properties) = body_query.get_mut(collider_parent.0) {
                         // Update collider mass props.
                         *collider_mass_properties =
                             collider.mass_properties(density.max(Scalar::EPSILON));
+
+                        // If the collider mass properties are zero, there is nothing to add.
+                        if *collider_mass_properties == ColliderMassProperties::ZERO {
+                            return;
+                        }
 
                         // Add new collider mass props to the body's mass props.
                         mass_properties +=

--- a/src/plugins/collision/collider/backend.rs
+++ b/src/plugins/collision/collider/backend.rs
@@ -131,7 +131,7 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
                 );
             });
 
-        // When the `Sensor` component is removed from a collider,
+        // When the `Sensor` component is added to a collider,
         // remove the collider's contribution on the rigid body's mass properties.
         app.observe(
             |trigger: Trigger<OnAdd, Sensor>,
@@ -161,7 +161,7 @@ impl<C: ScalableCollider> Plugin for ColliderBackendPlugin<C> {
             },
         );
 
-        // When the `Sensor` component is added to a collider,
+        // When the `Sensor` component is removed from a collider,
         // add the collider's mass properties to the rigid body's mass properties.
         app.observe(
             |trigger: Trigger<OnRemove, Sensor>,

--- a/src/plugins/collision/collider/mod.rs
+++ b/src/plugins/collision/collider/mod.rs
@@ -410,6 +410,8 @@ impl From<Transform> for ColliderTransform {
 /// but allow other bodies to pass through them. This is often used to detect when something enters
 /// or leaves an area or is intersecting some shape.
 ///
+/// Sensor colliders do *not* contribute to the mass properties of rigid bodies.
+///
 /// ## Example
 ///
 /// ```
@@ -420,7 +422,13 @@ impl From<Transform> for ColliderTransform {
 /// fn setup(mut commands: Commands) {
 ///     // Spawn a static body with a sensor collider.
 ///     // Other bodies will pass through, but it will still send collision events.
-///     commands.spawn((RigidBody::Static, Collider::ball(0.5), Sensor));
+///     let collider = Collider::ball(0.5);
+///     commands.spawn((
+///         RigidBody::Static,
+///         MassPropertiesBundle::new_computed(&collider, 1.0),
+///         collider,
+///         Sensor,
+///     ));
 /// }
 /// ```
 #[doc(alias = "Trigger")]

--- a/src/plugins/collision/collider/mod.rs
+++ b/src/plugins/collision/collider/mod.rs
@@ -422,13 +422,7 @@ impl From<Transform> for ColliderTransform {
 /// fn setup(mut commands: Commands) {
 ///     // Spawn a static body with a sensor collider.
 ///     // Other bodies will pass through, but it will still send collision events.
-///     let collider = Collider::ball(0.5);
-///     commands.spawn((
-///         RigidBody::Static,
-///         MassPropertiesBundle::new_computed(&collider, 1.0),
-///         collider,
-///         Sensor,
-///     ));
+///     commands.spawn((RigidBody::Static, Collider::ball(0.5), Sensor));
 /// }
 /// ```
 #[doc(alias = "Trigger")]


### PR DESCRIPTION
# Objective

Similar to #355 by @yrns, but without special casing `ColliderDensity` defaults, and implemented with observers.

Sensor colliders currently contribute to the mass properties of rigid bodies. This differs from most peoples' expectations, and is also different from many existing engines such as Godot and Unity. Sensor colliders should have no impact on the physics simulation.

## Solution

- When the `Sensor` component is added to an entity, remove the collider's contribution on the rigid body's mass properties.
- When the `Sensor` component is removed from an entity, add the collider's mass properties to the rigid body's mass properties.

## Testing

There is a test to make sure that the mass properties of a rigid body are updated accordingly when the `Sensor` component is first added and then removed from a collider.

---

## Migration Guide

Colliders with the `Sensor` component no longer contribute to the mass properties of rigid bodies. You can add mass for them by adding another collider that is *not* a sensor, or by manually adding mass properties with the `MassPropertiesBundle` or its components.

Additionally, the mass properties of `Sensor` colliders are no longer updated automatically, unless the `Sensor` component is removed.