### PR TITLE
Fix angular corrections for some 3D joints

### DIFF
--- a/src/constraints/joints/fixed.rs
+++ b/src/constraints/joints/fixed.rs
@@ -149,7 +149,9 @@ impl FixedJoint {
 
     #[cfg(feature = "3d")]
     fn get_delta_q(&self, rot1: &Rotation, rot2: &Rotation) -> Vector {
-        2.0 * (rot1.0 * rot2.inverse().0).xyz()
+        // TODO: The XPBD paper doesn't have this minus sign, but it seems to be needed for stability.
+        //       The angular correction code might have a wrong sign elsewhere.
+        -2.0 * (rot1.0 * rot2.inverse().0).xyz()
     }
 }
 

--- a/src/constraints/joints/prismatic.rs
+++ b/src/constraints/joints/prismatic.rs
@@ -245,7 +245,9 @@ impl PrismaticJoint {
 
     #[cfg(feature = "3d")]
     fn get_delta_q(&self, rot1: &Rotation, rot2: &Rotation) -> Vector {
-        2.0 * (rot1.0 * rot2.inverse().0).xyz()
+        // TODO: The XPBD paper doesn't have this minus sign, but it seems to be needed for stability.
+        //       The angular correction code might have a wrong sign elsewhere.
+        -2.0 * (rot1.0 * rot2.inverse().0).xyz()
     }
 }
 


### PR DESCRIPTION
# Objective

Fixes #229.

Fixed joints and prismatic joints appear to have the wrong sign for the angular correction. This can cause bad instability issues, as seen in #229.

Additionally, the code for the revolute joint angle limit is very wrong and only works for specific limits and axes.

## Solution

- Negate the angular correction sign for the fixed joint and prismatic joint. The XPBD paper doesn't have this, so we might have a wrong sign elsewhere, but that can be investigated in a follow-up.
- Fix the revolute joint angle limit by computing the axes properly.

Before:

https://github.com/Jondolf/bevy_xpbd/assets/57632562/f4d5dc62-3b02-490d-b63d-e9355f21d0a4

After:

https://github.com/Jondolf/bevy_xpbd/assets/57632562/3469d880-ee03-466f-a2c5-11eff4f1c786

Before: (see how the limit gets stuck after a few rotations)

https://github.com/Jondolf/bevy_xpbd/assets/57632562/1400c9a3-ed72-428a-92bc-73a2fbc05cbc

After:

https://github.com/Jondolf/bevy_xpbd/assets/57632562/86013f9b-8154-41a3-966c-01c03f8a3dd9

## Future Work

- Figure out why the minus sign is needed and if there's a wrong sign elsewhere.
- Implement 2D angle corrections *actually* in 2D. I have code for this locally.