### PR TITLE
Clean up and refactor joint logic

### DIFF
--- a/crates/avian3d/examples/custom_constraint.rs
+++ b/crates/avian3d/examples/custom_constraint.rs
@@ -79,19 +79,14 @@ impl XpbdConstraint<2> for CustomDistanceConstraint {
         // Compute generalized inverse masses (method from PositionConstraint)
         let w1 = self.compute_generalized_inverse_mass(body1, r1, n);
         let w2 = self.compute_generalized_inverse_mass(body2, r2, n);
-        let w = [w1, w2];
-
-        // Constraint gradients, i.e. how the bodies should be moved
-        // relative to each other in order to satisfy the constraint
-        let gradients = [n, -n];
 
         // Compute Lagrange multiplier update, essentially the signed magnitude of the correction
         let delta_lagrange =
-            self.compute_lagrange_update(self.lagrange, c, &gradients, &w, self.compliance, dt);
+            self.compute_lagrange_update(self.lagrange, c, &[w1, w2], self.compliance, dt);
         self.lagrange += delta_lagrange;
 
         // Apply positional correction (method from PositionConstraint)
-        self.apply_positional_correction(body1, body2, delta_lagrange, n, r1, r2);
+        self.apply_positional_lagrange_update(body1, body2, delta_lagrange, n, r1, r2);
     }
 }
 

--- a/src/collision/collider/backend.rs
+++ b/src/collision/collider/backend.rs
@@ -14,7 +14,7 @@ use bevy::{
 
 /// A plugin for handling generic collider backend logic.
 ///
-/// - Initializes colliders, including [`AsyncCollider`] and [`AsyncSceneCollider`].
+/// - Initializes colliders, handles [`ColliderConstructor`] and [`ColliderConstructorHierarchy`].
 /// - Updates [`ColliderAabb`]s.
 /// - Updates collider scale based on `Transform` scale.
 /// - Updates collider mass properties, also updating rigid bodies accordingly.

--- a/src/debug_render/mod.rs
+++ b/src/debug_render/mod.rs
@@ -126,6 +126,7 @@ impl Plugin for PhysicsDebugPlugin {
                     debug_render_joints::<PrismaticJoint>,
                     debug_render_joints::<DistanceJoint>,
                     debug_render_joints::<RevoluteJoint>,
+                    #[cfg(feature = "3d")]
                     debug_render_joints::<SphericalJoint>,
                     debug_render_raycasts,
                     #[cfg(all(

--- a/src/dynamics/solver/joints/distance.rs
+++ b/src/dynamics/solver/joints/distance.rs
@@ -152,23 +152,20 @@ impl DistanceJoint {
         let w2 = PositionConstraint::compute_generalized_inverse_mass(self, body2, world_r2, dir);
         let w = [w1, w2];
 
-        // Constraint gradients, i.e. how the bodies should be moved
-        // relative to each other in order to satisfy the constraint
-        let gradients = [dir, -dir];
-
         // Compute Lagrange multiplier update, essentially the signed magnitude of the correction
-        let delta_lagrange = self.compute_lagrange_update(
-            self.lagrange,
-            distance,
-            &gradients,
-            &w,
-            self.compliance,
-            dt,
-        );
+        let delta_lagrange =
+            self.compute_lagrange_update(self.lagrange, distance, &w, self.compliance, dt);
         self.lagrange += delta_lagrange;
 
         // Apply positional correction (method from PositionConstraint)
-        self.apply_positional_correction(body1, body2, delta_lagrange, dir, world_r1, world_r2);
+        self.apply_positional_lagrange_update(
+            body1,
+            body2,
+            delta_lagrange,
+            dir,
+            world_r1,
+            world_r2,
+        );
 
         // Return constraint force
         self.compute_force(self.lagrange, dir, dt)

--- a/src/dynamics/solver/joints/fixed.rs
+++ b/src/dynamics/solver/joints/fixed.rs
@@ -52,9 +52,10 @@ impl XpbdConstraint<2> for FixedJoint {
         let compliance = self.compliance;
 
         // Align orientation
-        let dq = self.get_delta_q(&body1.rotation, &body2.rotation);
+        let difference = self.get_rotation_difference(&body1.rotation, &body2.rotation);
         let mut lagrange = self.align_lagrange;
-        self.align_torque = self.align_orientation(body1, body2, dq, &mut lagrange, compliance, dt);
+        self.align_torque =
+            self.align_orientation(body1, body2, difference, &mut lagrange, compliance, dt);
         self.align_lagrange = lagrange;
 
         // Align position of local attachment points
@@ -143,12 +144,12 @@ impl Joint for FixedJoint {
 
 impl FixedJoint {
     #[cfg(feature = "2d")]
-    fn get_delta_q(&self, rot1: &Rotation, rot2: &Rotation) -> Vector3 {
-        rot1.angle_between(*rot2) * Vector3::Z
+    fn get_rotation_difference(&self, rot1: &Rotation, rot2: &Rotation) -> Scalar {
+        rot1.angle_between(*rot2)
     }
 
     #[cfg(feature = "3d")]
-    fn get_delta_q(&self, rot1: &Rotation, rot2: &Rotation) -> Vector {
+    fn get_rotation_difference(&self, rot1: &Rotation, rot2: &Rotation) -> Vector {
         // TODO: The XPBD paper doesn't have this minus sign, but it seems to be needed for stability.
         //       The angular correction code might have a wrong sign elsewhere.
         -2.0 * (rot1.0 * rot2.inverse().0).xyz()

--- a/src/dynamics/solver/joints/mod.rs
+++ b/src/dynamics/solver/joints/mod.rs
@@ -18,7 +18,10 @@
 //! | [`DistanceJoint`]  | 1 Translation, 1 Rotation | 2 Translations, 3 Rotations |
 //! | [`PrismaticJoint`] | 1 Translation             | 1 Translation               |
 //! | [`RevoluteJoint`]  | 1 Rotation                | 1 Rotation                  |
-//! | [`SphericalJoint`] | 1 Rotation                | 3 Rotations                 |
+#![cfg_attr(
+    feature = "3d",
+    doc = "| [`SphericalJoint`] | 1 Rotation                | 3 Rotations                 |"
+)]
 //!
 //! ## Using joints
 //!

--- a/src/dynamics/solver/joints/mod.rs
+++ b/src/dynamics/solver/joints/mod.rs
@@ -84,12 +84,14 @@ mod distance;
 mod fixed;
 mod prismatic;
 mod revolute;
+#[cfg(feature = "3d")]
 mod spherical;
 
 pub use distance::*;
 pub use fixed::*;
 pub use prismatic::*;
 pub use revolute::*;
+#[cfg(feature = "3d")]
 pub use spherical::*;
 
 use crate::{dynamics::solver::xpbd::*, prelude::*};
@@ -157,72 +159,23 @@ pub trait Joint: Component + PositionConstraint + AngularConstraint {
         let w1 = PositionConstraint::compute_generalized_inverse_mass(self, body1, world_r1, dir);
         let w2 = PositionConstraint::compute_generalized_inverse_mass(self, body2, world_r2, dir);
 
-        // Constraint gradients and inverse masses
-        let gradients = [dir, -dir];
-        let w = [w1, w2];
-
         // Compute Lagrange multiplier update
         let delta_lagrange =
-            self.compute_lagrange_update(*lagrange, magnitude, &gradients, &w, compliance, dt);
+            self.compute_lagrange_update(*lagrange, magnitude, &[w1, w2], compliance, dt);
         *lagrange += delta_lagrange;
 
         // Apply positional correction to align the positions of the bodies
-        self.apply_positional_correction(body1, body2, delta_lagrange, dir, world_r1, world_r2);
+        self.apply_positional_lagrange_update(
+            body1,
+            body2,
+            delta_lagrange,
+            dir,
+            world_r1,
+            world_r2,
+        );
 
         // Return constraint force
         self.compute_force(*lagrange, dir, dt)
-    }
-
-    /// Applies an angular correction that aligns the orientation of the bodies.
-    ///
-    /// Returns the torque exerted by the alignment.
-    fn align_orientation(
-        &self,
-        body1: &mut RigidBodyQueryItem,
-        body2: &mut RigidBodyQueryItem,
-        delta_q: Vector3,
-        lagrange: &mut Scalar,
-        compliance: Scalar,
-        dt: Scalar,
-    ) -> Torque {
-        let angle = delta_q.length();
-
-        if angle <= Scalar::EPSILON {
-            return Torque::ZERO;
-        }
-
-        let axis = delta_q / angle;
-
-        // Compute generalized inverse masses
-        let w1 = AngularConstraint::compute_generalized_inverse_mass(self, body1, axis);
-        let w2 = AngularConstraint::compute_generalized_inverse_mass(self, body2, axis);
-
-        // Constraint gradients and inverse masses
-        let gradients = {
-            #[cfg(feature = "2d")]
-            {
-                // `axis.z` controls if the body should rotate counterclockwise or clockwise.
-                // The gradient has to be a 2D vector, so we use the y axis instead.
-                // This should work similarly, as `axis.x` and `axis.y` are normally 0 in 2D.
-                [Vector::Y * axis.z, Vector::NEG_Y * axis.z]
-            }
-            #[cfg(feature = "3d")]
-            {
-                [axis, -axis]
-            }
-        };
-        let w = [w1, w2];
-
-        // Compute Lagrange multiplier update
-        let delta_lagrange =
-            self.compute_lagrange_update(*lagrange, angle, &gradients, &w, compliance, dt);
-        *lagrange += delta_lagrange;
-
-        // Apply angular correction to aling the bodies
-        self.apply_angular_correction(body1, body2, delta_lagrange, axis);
-
-        // Return constraint torque
-        self.compute_torque(*lagrange, axis, dt)
     }
 }
 
@@ -241,7 +194,7 @@ impl DistanceLimit {
     pub const ZERO: Self = Self { min: 0.0, max: 0.0 };
 
     /// Creates a new `DistanceLimit`.
-    pub fn new(min: Scalar, max: Scalar) -> Self {
+    pub const fn new(min: Scalar, max: Scalar) -> Self {
         Self { min, max }
     }
 
@@ -269,7 +222,7 @@ impl DistanceLimit {
 
     /// Returns the positional correction required to limit the distance between `p1` and `p2`
     /// to be within the distance limit along a given `axis`.
-    fn compute_correction_along_axis(&self, p1: Vector, p2: Vector, axis: Vector) -> Vector {
+    pub fn compute_correction_along_axis(&self, p1: Vector, p2: Vector, axis: Vector) -> Vector {
         let pos_offset = p2 - p1;
         let a = pos_offset.dot(axis);
 
@@ -291,59 +244,88 @@ impl DistanceLimit {
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct AngleLimit {
     /// The minimum angle.
-    pub alpha: Scalar,
+    pub min: Scalar,
     /// The maximum angle.
-    pub beta: Scalar,
+    pub max: Scalar,
 }
 
 impl AngleLimit {
     /// An `AngleLimit` with `alpha` and `beta` set to zero.
-    pub const ZERO: Self = Self {
-        alpha: 0.0,
-        beta: 0.0,
-    };
+    pub const ZERO: Self = Self { min: 0.0, max: 0.0 };
 
     /// Creates a new `AngleLimit`.
-    pub fn new(alpha: Scalar, beta: Scalar) -> Self {
-        Self { alpha, beta }
+    pub const fn new(min: Scalar, max: Scalar) -> Self {
+        Self { min, max }
     }
 
-    /// Returns the angular correction required to limit the angle between the axes `n1` and `n2`
+    /// Returns the angular correction required to limit the angle between two rotations
     /// to be within the angle limits.
-    fn compute_correction(
+    #[cfg(feature = "2d")]
+    pub fn compute_correction(
         &self,
-        n: Vector3,
-        n1: Vector3,
-        n2: Vector3,
+        rotation1: Rotation,
+        rotation2: Rotation,
         max_correction: Scalar,
-    ) -> Option<Vector3> {
-        let mut phi = n1.cross(n2).dot(n).asin();
+    ) -> Option<Scalar> {
+        let angle = rotation1.angle_between(rotation2);
 
-        if n1.dot(n2) < 0.0 {
+        let correction = if angle < self.min {
+            angle - self.min
+        } else if angle > self.max {
+            angle - self.max
+        } else {
+            return None;
+        };
+
+        Some(correction.min(max_correction))
+    }
+
+    /// Returns the angular correction required to limit the angle between `axis1` and `axis2`
+    /// to be within the angle limits with respect to the `limit_axis`.
+    #[cfg(feature = "3d")]
+    pub fn compute_correction(
+        &self,
+        limit_axis: Vector,
+        axis1: Vector,
+        axis2: Vector,
+        max_correction: Scalar,
+    ) -> Option<Vector> {
+        // [limit_axis, axis1, axis2] = [n, n1, n2] in XPBD rigid body paper.
+
+        // Angle between axis1 and axis2 with respect to limit_axis.
+        let mut phi = axis1.cross(axis2).dot(limit_axis).asin();
+
+        // `asin` returns the angle in the [-pi/2, pi/2] range.
+        // This is correct if the angle between n1 and n2 is acute,
+        // but obtuse angles must be accounted for.
+        if axis1.dot(axis2) < 0.0 {
             phi = PI - phi;
         }
 
+        // Map the angle to the [-pi, pi] range.
         if phi > PI {
-            phi -= 2.0 * PI;
+            phi -= TAU;
         }
 
-        if phi < -PI {
-            phi += 2.0 * PI;
-        }
+        // The XPBD rigid body paper has this, but the angle
+        // should already be in the correct range.
+        //
+        // if phi < -PI {
+        //     phi += TAU;
+        // }
 
-        if phi < self.alpha || phi > self.beta {
-            phi = phi.clamp(self.alpha, self.beta);
+        // Only apply a correction if the limit is violated.
+        if phi < self.min || phi > self.max {
+            // phi now represents the angle between axis1 and axis2.
 
-            let rot = Quaternion::from_axis_angle(n, phi);
-            let mut omega = rot.mul_vec3(n1).cross(n2);
+            // Clamp phi to get the target angle.
+            phi = phi.clamp(self.min, self.max);
 
-            phi = omega.length();
+            // Create a quaternion that represents the rotation.
+            let rot = Quaternion::from_axis_angle(limit_axis, phi);
 
-            if phi > max_correction {
-                omega *= max_correction / phi;
-            }
-
-            return Some(omega);
+            // Rotate axis1 by the target angle and compute the correction.
+            return Some((rot * axis1).cross(axis2).clamp_length_max(max_correction));
         }
 
         None

--- a/src/dynamics/solver/joints/prismatic.rs
+++ b/src/dynamics/solver/joints/prismatic.rs
@@ -55,9 +55,10 @@ impl XpbdConstraint<2> for PrismaticJoint {
         let compliance = self.compliance;
 
         // Align orientations
-        let dq = self.get_delta_q(&body1.rotation, &body2.rotation);
+        let difference = self.get_rotation_difference(&body1.rotation, &body2.rotation);
         let mut lagrange = self.align_lagrange;
-        self.align_torque = self.align_orientation(body1, body2, dq, &mut lagrange, compliance, dt);
+        self.align_torque =
+            self.align_orientation(body1, body2, difference, &mut lagrange, compliance, dt);
         self.align_lagrange = lagrange;
 
         // Constrain the relative positions of the bodies, only allowing translation along one free axis
@@ -200,23 +201,25 @@ impl PrismaticJoint {
         let w1 = PositionConstraint::compute_generalized_inverse_mass(self, body1, world_r1, dir);
         let w2 = PositionConstraint::compute_generalized_inverse_mass(self, body2, world_r2, dir);
 
-        // Constraint gradients and inverse masses
-        let gradients = [dir, -dir];
-        let w = [w1, w2];
-
         // Compute Lagrange multiplier update
         let delta_lagrange = self.compute_lagrange_update(
             self.position_lagrange,
             magnitude,
-            &gradients,
-            &w,
+            &[w1, w2],
             self.compliance,
             dt,
         );
         self.position_lagrange += delta_lagrange;
 
         // Apply positional correction to align the positions of the bodies
-        self.apply_positional_correction(body1, body2, delta_lagrange, dir, world_r1, world_r2);
+        self.apply_positional_lagrange_update(
+            body1,
+            body2,
+            delta_lagrange,
+            dir,
+            world_r1,
+            world_r2,
+        );
 
         // Return constraint force
         self.compute_force(self.position_lagrange, dir, dt)
@@ -239,12 +242,12 @@ impl PrismaticJoint {
     }
 
     #[cfg(feature = "2d")]
-    fn get_delta_q(&self, rot1: &Rotation, rot2: &Rotation) -> Vector3 {
-        rot1.angle_between(*rot2) * Vector3::Z
+    fn get_rotation_difference(&self, rot1: &Rotation, rot2: &Rotation) -> Scalar {
+        rot1.angle_between(*rot2)
     }
 
     #[cfg(feature = "3d")]
-    fn get_delta_q(&self, rot1: &Rotation, rot2: &Rotation) -> Vector {
+    fn get_rotation_difference(&self, rot1: &Rotation, rot2: &Rotation) -> Vector {
         // TODO: The XPBD paper doesn't have this minus sign, but it seems to be needed for stability.
         //       The angular correction code might have a wrong sign elsewhere.
         -2.0 * (rot1.0 * rot2.inverse().0).xyz()

--- a/src/dynamics/solver/joints/spherical.rs
+++ b/src/dynamics/solver/joints/spherical.rs
@@ -200,10 +200,16 @@ impl SphericalJoint {
 
             let n = n / n_magnitude;
 
-            if let Some(dq) = joint_limit.compute_correction(n, a1, a2, PI) {
+            if let Some(correction) = joint_limit.compute_correction(n, a1, a2, PI) {
                 let mut lagrange = self.swing_lagrange;
-                let torque =
-                    self.align_orientation(body1, body2, dq, &mut lagrange, self.compliance, dt);
+                let torque = self.align_orientation(
+                    body1,
+                    body2,
+                    correction,
+                    &mut lagrange,
+                    self.compliance,
+                    dt,
+                );
                 self.swing_lagrange = lagrange;
                 return torque;
             }
@@ -248,10 +254,16 @@ impl SphericalJoint {
 
             let max_correction = if a1.dot(a2) > -0.5 { 2.0 * PI } else { dt };
 
-            if let Some(dq) = joint_limit.compute_correction(n, n1, n2, max_correction) {
+            if let Some(correction) = joint_limit.compute_correction(n, n1, n2, max_correction) {
                 let mut lagrange = self.twist_lagrange;
-                let torque =
-                    self.align_orientation(body1, body2, dq, &mut lagrange, self.compliance, dt);
+                let torque = self.align_orientation(
+                    body1,
+                    body2,
+                    correction,
+                    &mut lagrange,
+                    self.compliance,
+                    dt,
+                );
                 self.twist_lagrange = lagrange;
                 return torque;
             }

--- a/src/dynamics/solver/xpbd/angular_constraint.rs
+++ b/src/dynamics/solver/xpbd/angular_constraint.rs
@@ -3,6 +3,173 @@ use crate::prelude::*;
 
 /// An angular constraint applies an angular correction around a given axis.
 pub trait AngularConstraint: XpbdConstraint<2> {
+    /// Applies an angular correction to two bodies.
+    ///
+    /// Returns the angular impulse that is applied proportional
+    /// to the inverse moments of inertia of the bodies.
+    #[cfg(feature = "2d")]
+    fn apply_angular_lagrange_update(
+        &self,
+        body1: &mut RigidBodyQueryItem,
+        body2: &mut RigidBodyQueryItem,
+        delta_lagrange: Scalar,
+    ) -> Scalar {
+        if delta_lagrange.abs() <= Scalar::EPSILON {
+            return 0.0;
+        }
+
+        self.apply_angular_impulse(body1, body2, -delta_lagrange)
+    }
+
+    /// Applies an angular impulse to two bodies.
+    ///
+    /// Returns the impulse that is applied proportional
+    /// to the inverse moments of inertia of the bodies.
+    #[cfg(feature = "2d")]
+    fn apply_angular_impulse(
+        &self,
+        body1: &mut RigidBodyQueryItem,
+        body2: &mut RigidBodyQueryItem,
+        impulse: Scalar,
+    ) -> Scalar {
+        let inv_inertia1 = body1.effective_world_inv_inertia();
+        let inv_inertia2 = body2.effective_world_inv_inertia();
+
+        // Apply rotational updates
+        if body1.rb.is_dynamic() && body1.dominance() <= body2.dominance() {
+            let delta_angle = Self::get_delta_rot(*body1.rotation, inv_inertia1, impulse);
+            *body1.rotation = body1.rotation.add_angle(delta_angle);
+        }
+        if body2.rb.is_dynamic() && body2.dominance() <= body1.dominance() {
+            let delta_angle = Self::get_delta_rot(*body2.rotation, inv_inertia2, -impulse);
+            *body2.rotation = body2.rotation.add_angle(delta_angle);
+        }
+
+        impulse
+    }
+
+    /// Applies an angular correction to two bodies.
+    ///
+    /// Returns the angular impulse that is applied proportional
+    /// to the inverse moments of inertia of the bodies.
+    #[cfg(feature = "3d")]
+    fn apply_angular_lagrange_update(
+        &self,
+        body1: &mut RigidBodyQueryItem,
+        body2: &mut RigidBodyQueryItem,
+        delta_lagrange: Scalar,
+        axis: Vector,
+    ) -> Vector {
+        if delta_lagrange.abs() <= Scalar::EPSILON {
+            return Vector::ZERO;
+        }
+
+        let impulse = -delta_lagrange * axis;
+
+        self.apply_angular_impulse(body1, body2, impulse)
+    }
+
+    /// Applies an angular impulse to two bodies.
+    ///
+    /// Returns the impulse that is applied proportional
+    /// to the inverse moments of inertia of the bodies.
+    #[cfg(feature = "3d")]
+    fn apply_angular_impulse(
+        &self,
+        body1: &mut RigidBodyQueryItem,
+        body2: &mut RigidBodyQueryItem,
+        impulse: Vector,
+    ) -> Vector {
+        let inv_inertia1 = body1.effective_world_inv_inertia();
+        let inv_inertia2 = body2.effective_world_inv_inertia();
+
+        // Apply rotational updates
+        if body1.rb.is_dynamic() {
+            // In 3D, adding quaternions can result in unnormalized rotations,
+            // which causes stability issues (see #235) and panics when trying to rotate unit vectors.
+            // TODO: It would be nice to avoid normalization if possible.
+            //       Maybe the math above can be done in a way that keeps rotations normalized?
+            let delta_quat = Self::get_delta_rot(*body1.rotation, inv_inertia1, impulse);
+            body1.rotation.0 = (body1.rotation.0 + delta_quat).normalize();
+        }
+        if body2.rb.is_dynamic() {
+            // See comments for `body1` above.
+            let delta_quat = Self::get_delta_rot(*body2.rotation, inv_inertia2, -impulse);
+            body2.rotation.0 = (body2.rotation.0 + delta_quat).normalize();
+        }
+
+        impulse
+    }
+
+    /// Applies an angular correction that aligns the orientation of the bodies.
+    ///
+    /// Returns the torque exerted by the alignment.
+    #[cfg(feature = "2d")]
+    fn align_orientation(
+        &self,
+        body1: &mut RigidBodyQueryItem,
+        body2: &mut RigidBodyQueryItem,
+        angle: Scalar,
+        lagrange: &mut Scalar,
+        compliance: Scalar,
+        dt: Scalar,
+    ) -> Torque {
+        if angle.abs() <= Scalar::EPSILON {
+            return Torque::ZERO;
+        }
+
+        let w1 = body1.effective_world_inv_inertia();
+        let w2 = body2.effective_world_inv_inertia();
+        let w = [w1, w2];
+
+        // Compute Lagrange multiplier update
+        let delta_lagrange = self.compute_lagrange_update(*lagrange, angle, &w, compliance, dt);
+        *lagrange += delta_lagrange;
+
+        // Apply angular correction to aling the bodies
+        self.apply_angular_lagrange_update(body1, body2, delta_lagrange);
+
+        // Return constraint torque
+        self.compute_torque(delta_lagrange, dt)
+    }
+
+    /// Applies an angular correction that aligns the orientation of the bodies.
+    ///
+    /// Returns the torque exerted by the alignment.
+    #[cfg(feature = "3d")]
+    fn align_orientation(
+        &self,
+        body1: &mut RigidBodyQueryItem,
+        body2: &mut RigidBodyQueryItem,
+        rotation_difference: Vector,
+        lagrange: &mut Scalar,
+        compliance: Scalar,
+        dt: Scalar,
+    ) -> Torque {
+        let angle = rotation_difference.length();
+
+        if angle <= Scalar::EPSILON {
+            return Torque::ZERO;
+        }
+
+        let axis = rotation_difference / angle;
+
+        // Compute generalized inverse masses
+        let w1 = AngularConstraint::compute_generalized_inverse_mass(self, body1, axis);
+        let w2 = AngularConstraint::compute_generalized_inverse_mass(self, body2, axis);
+        let w = [w1, w2];
+
+        // Compute Lagrange multiplier update
+        let delta_lagrange = self.compute_lagrange_update(*lagrange, angle, &w, compliance, dt);
+        *lagrange += delta_lagrange;
+
+        // Apply angular correction to aling the bodies
+        self.apply_angular_lagrange_update(body1, body2, delta_lagrange, axis);
+
+        // Return constraint torque
+        self.compute_torque(delta_lagrange, axis, dt)
+    }
+
     /// Applies angular constraints for interactions between two bodies.
     ///
     /// Here in 2D, `axis` is a unit vector with the Z coordinate set to 1 or -1. It controls if the body should rotate counterclockwise or clockwise.
@@ -120,16 +287,18 @@ pub trait AngularConstraint: XpbdConstraint<2> {
         Quaternion::from_vec4(0.5 * (inverse_inertia * p).extend(0.0)) * rot.0
     }
 
-    /// Computes the torque acting along the constraint using the equation tau = lambda * n / h^2
-    fn compute_torque(&self, lagrange: Scalar, axis: Vector3, dt: Scalar) -> Torque {
+    /// Computes the torque acting along the constraint using the equation `tau = lambda * n / h^2`,
+    /// where `n` is the Z axis in 2D.
+    #[cfg(feature = "2d")]
+    fn compute_torque(&self, lagrange: Scalar, dt: Scalar) -> Torque {
         // Eq (17)
-        #[cfg(feature = "2d")]
-        {
-            lagrange * axis.z / dt.powi(2)
-        }
-        #[cfg(feature = "3d")]
-        {
-            lagrange * axis / dt.powi(2)
-        }
+        lagrange / dt.powi(2)
+    }
+
+    /// Computes the torque acting along the constraint using the equation `tau = lambda * n / h^2`
+    #[cfg(feature = "3d")]
+    fn compute_torque(&self, lagrange: Scalar, axis: Vector, dt: Scalar) -> Torque {
+        // Eq (17)
+        lagrange * axis / dt.powi(2)
     }
 }

--- a/src/dynamics/solver/xpbd/positional_constraint.rs
+++ b/src/dynamics/solver/xpbd/positional_constraint.rs
@@ -8,7 +8,7 @@ pub trait PositionConstraint: XpbdConstraint<2> {
     ///
     /// Returns the positional impulse that is applied proportional to the inverse masses of the bodies.
     #[allow(clippy::too_many_arguments)]
-    fn apply_positional_correction(
+    fn apply_positional_lagrange_update(
         &self,
         body1: &mut RigidBodyQueryItem,
         body2: &mut RigidBodyQueryItem,
@@ -21,9 +21,22 @@ pub trait PositionConstraint: XpbdConstraint<2> {
             return Vector::ZERO;
         }
 
-        // Compute positional impulse
-        let p = delta_lagrange * direction;
+        let impulse = delta_lagrange * direction;
 
+        self.apply_positional_impulse(body1, body2, impulse, r1, r2)
+    }
+
+    /// Applies a positional impulse to two bodies.
+    ///
+    /// Returns the impulse that is applied proportional to the inverse masses of the bodies.
+    fn apply_positional_impulse(
+        &self,
+        body1: &mut RigidBodyQueryItem,
+        body2: &mut RigidBodyQueryItem,
+        impulse: Vector,
+        r1: Vector,
+        r2: Vector,
+    ) -> Vector {
         let inv_mass1 = body1.effective_inv_mass();
         let inv_mass2 = body2.effective_inv_mass();
         let inv_inertia1 = body1.effective_world_inv_inertia();
@@ -31,11 +44,11 @@ pub trait PositionConstraint: XpbdConstraint<2> {
 
         // Apply positional and rotational updates
         if body1.rb.is_dynamic() && body1.dominance() <= body2.dominance() {
-            body1.accumulated_translation.0 += p * inv_mass1;
+            body1.accumulated_translation.0 += impulse * inv_mass1;
 
             #[cfg(feature = "2d")]
             {
-                let delta_angle = Self::get_delta_rot(*body1.rotation, inv_inertia1, r1, p);
+                let delta_angle = Self::get_delta_rot(*body1.rotation, inv_inertia1, r1, impulse);
                 *body1.rotation = body1.rotation.add_angle(delta_angle);
             }
             #[cfg(feature = "3d")]
@@ -44,27 +57,27 @@ pub trait PositionConstraint: XpbdConstraint<2> {
                 // which causes stability issues (see #235) and panics when trying to rotate unit vectors.
                 // TODO: It would be nice to avoid normalization if possible.
                 //       Maybe the math above can be done in a way that keeps rotations normalized?
-                let delta_quat = Self::get_delta_rot(*body1.rotation, inv_inertia1, r1, p);
+                let delta_quat = Self::get_delta_rot(*body1.rotation, inv_inertia1, r1, impulse);
                 body1.rotation.0 = (body1.rotation.0 + delta_quat).normalize();
             }
         }
         if body2.rb.is_dynamic() && body2.dominance() <= body1.dominance() {
-            body2.accumulated_translation.0 -= p * inv_mass2;
+            body2.accumulated_translation.0 -= impulse * inv_mass2;
 
             #[cfg(feature = "2d")]
             {
-                let delta_angle = Self::get_delta_rot(*body2.rotation, inv_inertia2, r2, -p);
+                let delta_angle = Self::get_delta_rot(*body2.rotation, inv_inertia2, r2, -impulse);
                 *body2.rotation = body2.rotation.add_angle(delta_angle);
             }
             #[cfg(feature = "3d")]
             {
                 // See comments for `body1` above.
-                let delta_quat = Self::get_delta_rot(*body2.rotation, inv_inertia2, r2, -p);
+                let delta_quat = Self::get_delta_rot(*body2.rotation, inv_inertia2, r2, -impulse);
                 body2.rotation.0 = (body2.rotation.0 + delta_quat).normalize();
             }
         }
 
-        p
+        impulse
     }
 
     /// Computes the generalized inverse mass of a body when applying a positional correction

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,7 @@
 //!     - [Distance joint](DistanceJoint)
 //!     - [Prismatic joint](PrismaticJoint)
 //!     - [Revolute joint](RevoluteJoint)
-//!     - [Spherical joint](SphericalJoint)
+#![cfg_attr(feature = "3d", doc = "    - [Spherical joint](SphericalJoint)")]
 //! - [Custom XPBD constraints](dynamics::solver::xpbd#constraints) (advanced)
 //!
 //! Joint motors and articulations are not supported yet, but they will be implemented in a future release.


### PR DESCRIPTION
# Objective

The joint code has a lot of ugly parts:

- 2D joints are implemented as just 3D joints with Z as the rotation axis instead of being "true" 2D.
- `SphericalJoint` exists in 2D even though it doesn't really work since it's a 3D joint.
- Lagrange update computation often unnecessarily takes unit gradients. The gradients aren't needed if they have unit length, and in our case they do.
- Some variable and method names are very vague, like `delta_q` or `p` instead of `rotation_difference` and `impulse`.
- The 3D `AngleLimit::compute_correction` method has no comments or explanations for the angle magic it does.

## Solution

Fix the issues :)

I also did some other small cleanup and fixed some intra-doc links.

---

## Migration Guide

- `SphericalJoint` no longer exists in 2D. Use `RevoluteJoint` instead.
- `AngleLimit` properties `alpha` and `beta` are now named `min` and `max`.
- `apply_positional_correction` has been renamed to `apply_positional_lagrange_update`. There is also an `apply_positional_impulse` method.
- `apply_angular_correction` has been renamed to `apply_angular_lagrange_update`. There is also an `apply_angular_impulse` method.
- `compute_lagrange_update` no longer takes a slice over gradients. For that, use `compute_lagrange_update_with_gradients`.
- `Joint::align_orientation` has been moved to `AngularConstraint`.