### PR TITLE
Implement sweep-based CCD

### DIFF
--- a/crates/avian2d/Cargo.toml
+++ b/crates/avian2d/Cargo.toml
@@ -81,6 +81,10 @@ name = "kinematic_character_2d"
 required-features = ["2d", "default-collider"]
 
 [[example]]
+name = "ccd"
+required-features = ["2d", "default-collider"]
+
+[[example]]
 name = "chain_2d"
 required-features = ["2d", "default-collider"]
 

--- a/crates/avian2d/examples/ccd.rs
+++ b/crates/avian2d/examples/ccd.rs
@@ -54,15 +54,15 @@ fn setup(mut commands: Commands) {
         SpriteBundle {
             sprite: Sprite {
                 color: Color::srgb(0.7, 0.7, 0.8),
-                custom_size: Some(Vec2::new(2.5, 400.0)),
+                custom_size: Some(Vec2::new(1.0, 400.0)),
                 ..default()
             },
             transform: Transform::from_xyz(-200.0, -200.0, 0.0),
             ..default()
         },
         RigidBody::Kinematic,
-        AngularVelocity(20.0),
-        Collider::rectangle(2.5, 400.0),
+        AngularVelocity(25.0),
+        Collider::rectangle(1.0, 400.0),
         // Enable swept CCD for this body. Considers both translational and rotational motion by default.
         // This could also be on the ball projectiles.
         SweptCcd::default(),
@@ -71,15 +71,15 @@ fn setup(mut commands: Commands) {
         SpriteBundle {
             sprite: Sprite {
                 color: Color::srgb(0.7, 0.7, 0.8),
-                custom_size: Some(Vec2::new(2.5, 400.0)),
+                custom_size: Some(Vec2::new(1.0, 400.0)),
                 ..default()
             },
             transform: Transform::from_xyz(200.0, -200.0, 0.0),
             ..default()
         },
         RigidBody::Kinematic,
-        AngularVelocity(-20.0),
-        Collider::rectangle(2.5, 400.0),
+        AngularVelocity(-25.0),
+        Collider::rectangle(1.0, 400.0),
         // Enable swept CCD for this body. Considers both translational and rotational motion by default.
         // This could also be on the ball projectiles.
         SweptCcd::default(),
@@ -146,10 +146,6 @@ fn spawn_balls(
         LinearVelocity(2000.0 * direction),
         Friction::ZERO.with_combine_rule(CoefficientCombine::Min),
         Collider::from(circle),
-        // Specify an unbounded speculative margin used for speculative collision.
-        // The margin is already unbounded by default, but this component is added here
-        // to allow `update_config` to configure it.
-        SpeculativeMargin::MAX,
     ));
 }
 
@@ -164,6 +160,8 @@ fn update_config(
     mut ccd_bodies: Query<&mut SweptCcd>,
 ) {
     // Toggle speculative collision.
+    // Note: This sets the default speculative margin, but it can be overridden
+    //       for individual entities with the `SpeculativeMargin` component.
     if keys.just_pressed(KeyCode::Digit1) {
         let mut text = speculative_collision_text.single_mut();
         if narrow_phase_config.default_speculative_margin == Scalar::MAX {

--- a/crates/avian2d/examples/ccd.rs
+++ b/crates/avian2d/examples/ccd.rs
@@ -1,0 +1,201 @@
+//! Demonstrates Continuous Collision Detection (CCD) to prevent tunneling.
+//!
+//! Two forms of CCD are supported:
+//!
+//! 1. Speculative collision
+//!     - Predicts approximate contacts before they happen.
+//!     - Enabled by default for all rigid bodies.
+//!     - Very efficient and relatively reliable.
+//!     - Can sometimes cause ghost collisions.
+//!     - Can sometimes miss collisions against objects spinning at very high speeds.
+//!
+//! 2. Swept CCD
+//!     - Sweeps colliders from their previous positions to their current ones,
+//!       and if a hit is found, moves the bodies to the time of impact.
+//!     - Enabled for rigid bodies with the `SweptCcd` component.
+//!     - Can prevent tunneling completely. More reliable than speculative collision.
+//!     - More expensive than speculative collision.
+//!     - Can cause "time loss" where bodies appear to stop for a moment
+//!       because they are essentially brought back in time.
+//!     - Two modes:
+//!         1. Linear: Only considers translational motion.
+//!         2. Non-linear: Considers both translation and rotation. More expensive.
+
+use avian2d::{math::*, prelude::*};
+use bevy::{prelude::*, sprite::MaterialMesh2dBundle};
+use examples_common_2d::ExampleCommonPlugin;
+
+fn main() {
+    App::new()
+        .add_plugins((
+            DefaultPlugins,
+            ExampleCommonPlugin,
+            PhysicsPlugins::default(),
+        ))
+        .insert_resource(ClearColor(Color::srgb(0.05, 0.05, 0.1)))
+        .insert_resource(Gravity(Vector::NEG_Y * 9.81 * 100.0))
+        .add_systems(Startup, setup)
+        .add_systems(Update, update_config)
+        .add_systems(PhysicsSchedule, spawn_balls.in_set(PhysicsStepSet::First))
+        .run();
+}
+
+#[derive(Component)]
+struct SpeculativeCollisionText;
+
+#[derive(Component)]
+struct SweptCcdText;
+
+fn setup(mut commands: Commands) {
+    commands.spawn(Camera2dBundle::default());
+
+    // Add two kinematic bodies spinning at high speeds.
+    commands.spawn((
+        SpriteBundle {
+            sprite: Sprite {
+                color: Color::srgb(0.7, 0.7, 0.8),
+                custom_size: Some(Vec2::new(2.5, 400.0)),
+                ..default()
+            },
+            transform: Transform::from_xyz(-200.0, -200.0, 0.0),
+            ..default()
+        },
+        RigidBody::Kinematic,
+        AngularVelocity(20.0),
+        Collider::rectangle(2.5, 400.0),
+        // Enable swept CCD for this body. Considers both translational and rotational motion by default.
+        // This could also be on the ball projectiles.
+        SweptCcd::default(),
+    ));
+    commands.spawn((
+        SpriteBundle {
+            sprite: Sprite {
+                color: Color::srgb(0.7, 0.7, 0.8),
+                custom_size: Some(Vec2::new(2.5, 400.0)),
+                ..default()
+            },
+            transform: Transform::from_xyz(200.0, -200.0, 0.0),
+            ..default()
+        },
+        RigidBody::Kinematic,
+        AngularVelocity(-20.0),
+        Collider::rectangle(2.5, 400.0),
+        // Enable swept CCD for this body. Considers both translational and rotational motion by default.
+        // This could also be on the ball projectiles.
+        SweptCcd::default(),
+    ));
+
+    // Setup help text.
+    let text_style = TextStyle {
+        font_size: 20.0,
+        ..default()
+    };
+    commands.spawn((
+        SpeculativeCollisionText,
+        TextBundle::from_sections([
+            TextSection::new("(1) Speculative Collision: ", text_style.clone()),
+            TextSection::new("On", text_style.clone()),
+        ])
+        .with_style(Style {
+            position_type: PositionType::Absolute,
+            top: Val::Px(30.0),
+            left: Val::Px(10.0),
+            ..default()
+        }),
+    ));
+    commands.spawn((
+        SweptCcdText,
+        TextBundle::from_sections([
+            TextSection::new("(2) Swept CCD: ", text_style.clone()),
+            TextSection::new(
+                "Non-linear (considers both translation and rotation)",
+                text_style,
+            ),
+        ])
+        .with_style(Style {
+            position_type: PositionType::Absolute,
+            top: Val::Px(50.0),
+            left: Val::Px(10.0),
+            ..default()
+        }),
+    ));
+}
+
+/// Spawns balls moving at the spinning objects at high speeds.
+fn spawn_balls(
+    mut commands: Commands,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    time: Res<Time>,
+) {
+    let circle = Circle::new(2.0);
+
+    // Compute the shooting direction.
+    let (sin, cos) =
+        (0.5 * time.elapsed_seconds_f64().adjust_precision().sin() - PI / 2.0).sin_cos();
+    let direction = Vector::new(cos, sin).rotate(Vector::X);
+
+    commands.spawn((
+        MaterialMesh2dBundle {
+            mesh: meshes.add(circle).into(),
+            transform: Transform::from_xyz(0.0, 350.0, 0.0),
+            material: materials.add(Color::srgb(0.2, 0.7, 0.9)),
+            ..default()
+        },
+        RigidBody::Dynamic,
+        LinearVelocity(2000.0 * direction),
+        Friction::ZERO.with_combine_rule(CoefficientCombine::Min),
+        Collider::from(circle),
+        // Specify an unbounded speculative margin used for speculative collision.
+        // The margin is already unbounded by default, but this component is added here
+        // to allow `update_config` to configure it.
+        SpeculativeMargin::MAX,
+    ));
+}
+
+fn update_config(
+    mut speculative_collision_text: Query<
+        &mut Text,
+        (With<SpeculativeCollisionText>, Without<SweptCcdText>),
+    >,
+    mut swept_ccd_text: Query<&mut Text, (Without<SpeculativeCollisionText>, With<SweptCcdText>)>,
+    keys: Res<ButtonInput<KeyCode>>,
+    mut narrow_phase_config: ResMut<NarrowPhaseConfig>,
+    mut ccd_bodies: Query<&mut SweptCcd>,
+) {
+    // Toggle speculative collision.
+    if keys.just_pressed(KeyCode::Digit1) {
+        let mut text = speculative_collision_text.single_mut();
+        if narrow_phase_config.default_speculative_margin == Scalar::MAX {
+            narrow_phase_config.default_speculative_margin = 0.0;
+            text.sections[1].value = "Off".to_string();
+        } else {
+            narrow_phase_config.default_speculative_margin = Scalar::MAX;
+            text.sections[1].value = "On".to_string();
+        }
+    }
+
+    // Change the sweep mode and whether swept CCD is enabled.
+    if keys.just_pressed(KeyCode::Digit2) {
+        let mut text = swept_ccd_text.single_mut();
+        for mut swept_ccd in &mut ccd_bodies {
+            if swept_ccd.mode == SweepMode::NonLinear && swept_ccd.include_dynamic {
+                swept_ccd.mode = SweepMode::Linear;
+                text.sections[1].value = "Linear (considers only translation)".to_string();
+            } else if swept_ccd.mode == SweepMode::Linear {
+                // Disable swept CCD for collisions against dynamic bodies.
+                // To disable it completely, you should remove the component.
+                swept_ccd.include_dynamic = false;
+
+                swept_ccd.mode = SweepMode::NonLinear;
+                text.sections[1].value = "Off".to_string();
+            } else {
+                // Enable swept CCD again.
+                swept_ccd.include_dynamic = true;
+
+                text.sections[1].value =
+                    "Non-linear (considers both translation and rotation)".to_string();
+            }
+        }
+    }
+}

--- a/src/collision/broad_phase.rs
+++ b/src/collision/broad_phase.rs
@@ -72,7 +72,7 @@ pub struct BroadCollisionPairs(pub Vec<(Entity, Entity)>);
 /// Contains the entities whose AABBs intersect the AABB of this entity.
 /// Updated automatically during broad phase collision detection.
 ///
-/// Note that this component is only added to bodies with [`Ccd`] by default,
+/// Note that this component is only added to bodies with [`SweptCcd`] by default,
 /// but can be added to any entity.
 #[derive(Component, Clone, Debug, Default, Deref, DerefMut, Reflect)]
 #[reflect(Component)]

--- a/src/collision/collider/backend.rs
+++ b/src/collision/collider/backend.rs
@@ -452,6 +452,7 @@ fn update_aabb<C: AnyCollider>(
             &Rotation,
             Option<&ColliderParent>,
             Option<&SpeculativeMargin>,
+            Has<SweptCcd>,
             Option<&LinearVelocity>,
             Option<&AngularVelocity>,
         ),
@@ -475,11 +476,23 @@ fn update_aabb<C: AnyCollider>(
     let default_speculative_margin = length_unit.0 * narrow_phase_config.default_speculative_margin;
     let contact_tolerance = length_unit.0 * narrow_phase_config.contact_tolerance;
 
-    for (collider, mut aabb, pos, rot, collider_parent, speculative_margin, lin_vel, ang_vel) in
-        &mut colliders
+    for (
+        collider,
+        mut aabb,
+        pos,
+        rot,
+        collider_parent,
+        speculative_margin,
+        has_swept_ccd,
+        lin_vel,
+        ang_vel,
+    ) in &mut colliders
     {
-        let speculative_margin =
-            speculative_margin.map_or(default_speculative_margin, |margin| margin.0);
+        let speculative_margin = if has_swept_ccd {
+            Scalar::MAX
+        } else {
+            speculative_margin.map_or(default_speculative_margin, |margin| margin.0)
+        };
 
         if speculative_margin <= 0.0 {
             *aabb = collider

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -228,7 +228,7 @@ use parry::query::{
     cast_shapes, cast_shapes_nonlinear, NonlinearRigidMotion, ShapeCastHit, ShapeCastOptions,
 };
 
-/// A plugin for [Continuous Collision Detection](ccd).
+/// A plugin for [Continuous Collision Detection](self).
 pub struct CcdPlugin {
     schedule: Interned<dyn ScheduleLabel>,
 }
@@ -270,7 +270,7 @@ impl Plugin for CcdPlugin {
     }
 }
 
-/// A system set for [Continuous Collision Detection](ccd) systems.
+/// A system set for [Continuous Collision Detection](self) systems.
 #[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct SweptCcdSet;
 
@@ -316,7 +316,7 @@ impl SpeculativeMargin {
     pub const MAX: Self = Self(Scalar::MAX);
 }
 
-/// A component that enables sweep-based [Continuous Collision Detection](ccd) (CCD)
+/// A component that enables sweep-based [Continuous Collision Detection](self) (CCD)
 /// for a [`RigidBody`]. This helps prevent missed collisions for small and fast-moving objects.
 ///
 /// By default, swept CCD considers both translational and rotational motion, and is used
@@ -325,9 +325,9 @@ impl SpeculativeMargin {
 ///
 /// CCD is generally not useful for large or slow objects, as they are less likely
 /// to miss collisions. It is recommended to only use swept CCD when necessary,
-/// as it is more expensive than [speculative collision](ccd#speculative-collision) and discrete collision detection.
+/// as it is more expensive than [speculative collision](self#speculative-collision) and discrete collision detection.
 ///
-/// Read the [module-level documentation](ccd) for more information about what CCD is,
+/// Read the [module-level documentation](self) for more information about what CCD is,
 /// what it is used for, and what limitations and tradeoffs it can have.
 ///
 /// # Example
@@ -468,7 +468,7 @@ impl SweptCcd {
     }
 }
 
-/// The algorithm used for [Swept Continuous Collision Detection](ccd#swept-ccd).
+/// The algorithm used for [Swept Continuous Collision Detection](self#swept-ccd).
 ///
 /// If two entities with different sweep modes collide, [`SweepMode::NonLinear`]
 /// is preferred.
@@ -477,7 +477,7 @@ impl SweptCcd {
 /// and rotational motion.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Reflect)]
 pub enum SweepMode {
-    /// [Swept CCD](ccd#swept-ccd) is performed using linear time-of-impact queries
+    /// [Swept CCD](self#swept-ccd) is performed using linear time-of-impact queries
     /// from the previous positions of [`SweptCcd`] bodies to their current positions,
     /// stopping the bodies at the first time of impact.
     ///
@@ -486,7 +486,7 @@ pub enum SweepMode {
     /// that also considers rotational motion, consider using [`SweepMode::NonLinear`].
     Linear,
 
-    /// [Swept CCD](ccd#swept-ccd) is performed using non-linear time-of-impact queries
+    /// [Swept CCD](self#swept-ccd) is performed using non-linear time-of-impact queries
     /// from the previous positions of [`SweptCcd`] bodies to their current positions,
     /// stopping the bodies at the first time of impact.
     ///
@@ -519,7 +519,7 @@ struct SweptCcdBodyQuery {
     com: &'static CenterOfMass,
 }
 
-/// Performs [sweep-based mContinuous Collision Detection](ccd#swept-ccd)
+/// Performs [sweep-based mContinuous Collision Detection](self#swept-ccd)
 /// by performing time-of-impact queries from the previous positions of [`SweptCcd`] bodies
 /// to their current positions, stopping the bodies at the first time of impact.
 ///

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -266,7 +266,7 @@ impl Plugin for CcdPlugin {
 
         physics.configure_sets(SweptCcdSet.in_set(SolverSet::PostSubstep));
 
-        physics.add_systems((solve_swept_ccd,).chain().in_set(SweptCcdSet));
+        physics.add_systems(solve_swept_ccd.in_set(SweptCcdSet));
     }
 }
 

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -319,17 +319,13 @@ impl SpeculativeMargin {
 /// A component that enables sweep-based [Continuous Collision Detection](ccd) (CCD)
 /// for a [`RigidBody`]. This helps prevent missed collisions for small and fast-moving objects.
 ///
-/// By default, CCD considers both translational and rotational motion, and is used
+/// By default, swept CCD considers both translational and rotational motion, and is used
 /// against all types of rigid bodies and colliders. This behavior can be modified
 /// by changing [`SweptCcd::mode`] and other properties.
 ///
 /// CCD is generally not useful for large or slow objects, as they are less likely
-/// to miss collisions. It is recommended to only use CCD when necessary,
-/// as it is more expensive than normal discrete collision detection.
-///
-/// This component specifically enables [Swept CCD](ccd#swept-ccd).
-/// [Speculative Collision](ccd#speculative-collision) is enabled by default
-/// and configured separately.
+/// to miss collisions. It is recommended to only use swept CCD when necessary,
+/// as it is more expensive than [speculative collision](ccd#speculative-collision) and discrete collision detection.
 ///
 /// Read the [module-level documentation](ccd) for more information about what CCD is,
 /// what it is used for, and what limitations and tradeoffs it can have.
@@ -342,7 +338,7 @@ impl SpeculativeMargin {
 /// use bevy::prelude::*;
 ///
 /// fn setup(mut commands: Commands) {
-///     // Spawn a dynamic rigid body with CCD, travelling towards the right at a high speed.
+///     // Spawn a dynamic rigid body with swept CCD, travelling towards the right at a high speed.
 ///     // The default CCD configuration considers both translational and rotational motion.
 ///     commands.spawn((
 ///         RigidBody::Dynamic,
@@ -354,7 +350,7 @@ impl SpeculativeMargin {
 ///         TransformBundle::from_transform(Transform::from_xyz(-10.0, 3.0, 0.0)),
 ///     ));
 ///
-///     // Spawn another dynamic rigid body with CCD, but this time only considering
+///     // Spawn another dynamic rigid body with swept CCD, but this time only considering
 ///     // linear motion and not rotation.
 ///     commands.spawn((
 ///         RigidBody::Dynamic,
@@ -391,7 +387,7 @@ impl SpeculativeMargin {
 #[derive(Component, Clone, Copy, Debug, PartialEq, Reflect)]
 #[reflect(Component)]
 pub struct SweptCcd {
-    /// The type of sweep used for [sweep-based Continuous Collision Detection](ccd#swept-ccd).
+    /// The type of sweep used for swept CCD.
     ///
     /// If two entities with different sweep modes collide, [`SweepMode::NonLinear`]
     /// is preferred.
@@ -399,13 +395,13 @@ pub struct SweptCcd {
     /// The default is [`SweepMode::NonLinear`], which considers both translational
     /// and rotational motion.
     pub mode: SweepMode,
-    /// If `true`, [Continuous Collision Detection](ccd) is performed against dynamic rigid bodies.
+    /// If `true`, swept CCD is performed against dynamic rigid bodies.
     /// Otherwise, it is only performed against static geometry and kinematic bodies.
     ///
     /// The default is `true`.
     pub include_dynamic: bool,
     /// Determines how fast two bodies must be moving relative to each other
-    /// for [Continuous Collision Detection](ccd) to be activated for them.
+    /// for swept CCD to be activated for them.
     ///
     /// If the linear velocity is below this threshold, CCD is skipped,
     /// unless the angular velocity exceeds the `angular_threshold`.
@@ -413,7 +409,7 @@ pub struct SweptCcd {
     /// The default is `0.0`, meaning that CCD is performed regardless of the relative velocity.
     pub linear_threshold: Scalar,
     /// Determines how fast two bodies must be rotating relative to each other
-    /// for [Continuous Collision Detection](ccd) to be activated for them.
+    /// for swept CCD to be activated for them.
     ///
     /// If the angular velocity is below this threshold, CCD is skipped,
     /// unless the linear velocity exceeds the `linear_threshold`.
@@ -453,13 +449,21 @@ impl SweptCcd {
 
     /// Sets the linear and angular velocity thresholds in `self`,
     /// determining how fast two bodies must be moving relative to each other
-    /// for swept [Continuous Collision Detection](ccd) to be activated for them.
+    /// for swept CCD to be activated for them.
     ///
     /// CCD will be active if either of the two thresholds is exceeded.
     #[inline]
     pub const fn with_velocity_threshold(mut self, linear: Scalar, angular: Scalar) -> Self {
         self.linear_threshold = linear;
         self.angular_threshold = angular;
+        self
+    }
+
+    /// Sets whether swept CCD is performed against dynamic rigid bodies.
+    /// If `false`, it is only performed against static geometry and kinematic bodies.
+    #[inline]
+    pub const fn include_dynamic(mut self, should_include: bool) -> Self {
+        self.include_dynamic = should_include;
         self
     }
 }
@@ -473,7 +477,7 @@ impl SweptCcd {
 /// and rotational motion.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Reflect)]
 pub enum SweepMode {
-    /// [Continuous Collision Detection](ccd) is performed using linear time-of-impact queries
+    /// [Swept CCD](ccd#swept-ccd) is performed using linear time-of-impact queries
     /// from the previous positions of [`SweptCcd`] bodies to their current positions,
     /// stopping the bodies at the first time of impact.
     ///
@@ -482,7 +486,7 @@ pub enum SweepMode {
     /// that also considers rotational motion, consider using [`SweepMode::NonLinear`].
     Linear,
 
-    /// [Continuous Collision Detection](ccd) is performed using non-linear time-of-impact queries
+    /// [Swept CCD](ccd#swept-ccd) is performed using non-linear time-of-impact queries
     /// from the previous positions of [`SweptCcd`] bodies to their current positions,
     /// stopping the bodies at the first time of impact.
     ///

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -160,9 +160,9 @@
 //! in the [`PhysicsPlugins`] plugin group.
 //!
 //! ```
+#![cfg_attr(feature = "2d", doc = "use avian2d::prelude::*;")]
+#![cfg_attr(feature = "3d", doc = "use avian3d::prelude::*;")]
 //! use bevy::prelude::*;
-#![cfg_attr(feature = "2d", doc = "use bevy_newt_2d::prelude::*;")]
-#![cfg_attr(feature = "3d", doc = "use bevy_xpbd_3d::prelude::*;")]
 //!
 //! fn setup(mut commands: Commands) {
 //!     // Spawn a rigid body with swept CCD enabled.
@@ -337,6 +337,7 @@ impl SpeculativeMargin {
 #[cfg_attr(feature = "3d", doc = "use avian3d::prelude::*;")]
 /// use bevy::prelude::*;
 ///
+/// # #[cfg(feature = "f32")]
 /// fn setup(mut commands: Commands) {
 ///     // Spawn a dynamic rigid body with swept CCD, travelling towards the right at a high speed.
 ///     // The default CCD configuration considers both translational and rotational motion.
@@ -354,7 +355,7 @@ impl SpeculativeMargin {
 ///     // linear motion and not rotation.
 ///     commands.spawn((
 ///         RigidBody::Dynamic,
-///         SweptCcd::LINEAR_CAST, // or `SweptCcd::new_with_mode(SweepMode::Linear)`
+///         SweptCcd::LINEAR, // or `SweptCcd::new_with_mode(SweepMode::Linear)`
 #[cfg_attr(feature = "2d", doc = "        LinearVelocity(Vec2::X * 100.0),")]
 #[cfg_attr(feature = "3d", doc = "        LinearVelocity(Vec3::X * 100.0),")]
 #[cfg_attr(feature = "2d", doc = "        Collider::circle(0.1),")]

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -20,7 +20,9 @@
 //! </svg>
 //!
 //! **Continuous Collision Detection** (CCD) aims to prevent tunneling.
-//! Currently, only [Speculative Collision](#speculative-collision) is supported.
+//! Currently, two approaches are supported: [Speculative Collision](#speculative-collision) and [Swept CCD](#swept-ccd).
+//! Speculative collision is enabled by default, but swept CCD is opt-in with the [`SweptCcd`] component.
+//! The two approaches can also be used together.
 //!
 //! ## Speculative Collision
 //!
@@ -113,6 +115,92 @@
 //! especially for thin objects spinning at very high speeds. This is typically quite rare however,
 //! and speculative collision should work fine for the majority of cases.
 //!
+//! For an approach that is more expensive but doesn't suffer from ghost collisions
+//! or missed collisions, consider using swept CCD, which is described in the following section.
+//!
+//! ## Swept CCD
+//!
+//! **Swept CCD** is a form of Continuous Collision Detection that sweeps potentially colliding objects
+//! from their previous positions to their current positions, and if a collision is found, moves the bodies
+//! back to the time of impact. This way, the normal collision algorithms will be able to detect and handle
+//! the collision during the next frame.
+//!
+//! There are two variants of swept CCD: [`Linear`](SweepMode::Linear)
+//! and [`NonLinear`](SweepMode::Linear). The difference between the two
+//! is that [`Linear`](SweepMode::Linear) only considers translational motion,
+//! so bodies can still pass through objects that are spinning at high speeds,
+//! while [`NonLinear`](SweepMode::NonLinear) also considers rotational motion,
+//! but is more expensive.
+//!
+//! <svg width="300" height="350" viewBox="0 0 300 350" fill="none" xmlns="http://www.w3.org/2000/svg">
+//!     <rect x="141" y="1" width="18" height="298" fill="#64C850" stroke="black" stroke-width="2"/>
+//!     <circle cx="115" cy="150" r="24" stroke="#5064C8" stroke-width="2" stroke-dasharray="4 4"/>
+//!     <circle cx="25" cy="150" r="24" fill="#5064C8" stroke="black" stroke-width="2"/>
+//!     <path d="M115.707 150.707C116.098 150.317 116.098 149.683 115.707 149.293L109.343 142.929C108.953 142.538 108.319 142.538 107.929 142.929C107.538 143.319 107.538 143.953 107.929 144.343L113.586 150L107.929 155.657C107.538 156.047 107.538 156.681 107.929 157.071C108.319 157.462 108.953 157.462 109.343 157.071L115.707 150.707ZM25 151H115V149H25V151Z" fill="#E19664"/>
+//!     <text x="150" y="325" style="fill: #b4b4b4; font: 18px monospace; text-anchor: middle;">Linear / NonLinear</text>
+//! </svg>
+//!
+//! <svg width="600" height="350" viewBox="0 0 600 350" fill="none" xmlns="http://www.w3.org/2000/svg">
+//!     <rect x="438.95" y="25.3488" width="18" height="298" transform="rotate(27.5 438.95 25.3488)" stroke="#64C850" stroke-width="2" stroke-dasharray="4 4"/>
+//!     <rect x="301" y="1" width="18" height="298" fill="#64C850" stroke="black" stroke-width="2"/>
+//!     <circle cx="425" cy="150" r="24" fill="#5064C8" stroke="black" stroke-width="2"/>
+//!     <text x="150" y="325" style="fill: #b4b4b4; font: 18px monospace; text-anchor: middle;">Linear</text>
+//!     <circle cx="310" cy="290" r="5" fill="#D9D9D9" stroke="black" stroke-width="2"/>
+//!     <path d="M322.96 148.816L323.331 149.745L323.331 149.745L322.96 148.816ZM361.786 156.786L361.078 157.493L361.078 157.493L361.786 156.786ZM365 161C365.552 161 366 160.552 366 160L366 151C366 150.448 365.552 150 365 150C364.448 150 364 150.448 364 151L364 159L356 159C355.448 159 355 159.448 355 160C355 160.552 355.448 161 356 161L365 161ZM320.371 150.928L323.331 149.745L322.588 147.888L319.629 149.072L320.371 150.928ZM361.078 157.493L364.293 160.707L365.707 159.293L362.493 156.078L361.078 157.493ZM323.331 149.745C336.331 144.545 351.178 147.592 361.078 157.493L362.493 156.078C352.027 145.612 336.331 142.391 322.588 147.888L323.331 149.745Z" fill="#E19664"/>
+//!     <rect x="259.442" y="133.366" width="18" height="298" transform="rotate(60 259.442 133.366)" stroke="#64C850" stroke-width="2" stroke-dasharray="4 4"/>
+//!     <rect x="1" y="1" width="18" height="298" fill="#64C850" stroke="black" stroke-width="2"/>
+//!     <circle cx="125" cy="150" r="24" fill="#5064C8" stroke="black" stroke-width="2"/>
+//!     <text x="450" y="325" style="fill: #b4b4b4; font: 18px monospace; text-anchor: middle;">NonLinear</text>
+//!     <circle cx="10" cy="290" r="5" fill="#D9D9D9" stroke="black" stroke-width="2"/>
+//!     <path d="M54.0561 245.357L53.1144 245.694L53.1144 245.694L54.0561 245.357ZM54.5719 248.904C55.071 249.14 55.6673 248.927 55.9037 248.428L59.7565 240.294C59.9929 239.795 59.7799 239.199 59.2808 238.963C58.7817 238.726 58.1854 238.939 57.949 239.438L54.5243 246.668L47.2944 243.243C46.7953 243.007 46.199 243.22 45.9626 243.719C45.7261 244.218 45.9391 244.815 46.4382 245.051L54.5719 248.904ZM53.1144 245.694L54.0582 248.336L55.9417 247.664L54.9978 245.021L53.1144 245.694ZM20.3714 230.928C33.4979 225.678 48.3594 232.379 53.1144 245.694L54.9978 245.021C49.8615 230.639 33.808 223.4 19.6286 229.071L20.3714 230.928Z" fill="#E19664"/>
+//! </svg>
+//!
+//! To enable swept CCD for a rigid body, simply add the [`SweptCcd`] component
+//! and make sure that the [`CcdPlugin`] is enabled. The plugin is included
+//! in the [`PhysicsPlugins`] plugin group.
+//!
+//! ```
+//! use bevy::prelude::*;
+#![cfg_attr(feature = "2d", doc = "use bevy_newt_2d::prelude::*;")]
+#![cfg_attr(feature = "3d", doc = "use bevy_xpbd_3d::prelude::*;")]
+//!
+//! fn setup(mut commands: Commands) {
+//!     // Spawn a rigid body with swept CCD enabled.
+//!     // `SweepMode::NonLinear` is used by default.
+//!     commands.spawn((
+//!         RigidBody::Dynamic,
+//!         Collider::capsule(2.0, 0.5),
+//!         SweptCcd::default(),
+//!     ));
+//! }
+//! ```
+//!
+//! See the [documentation](SweptCcd) of the component for more details
+//! and configuration options.
+//!
+//! Swept CCD is more expensive than [Speculative Collision](#speculative-collision),
+//! but it doesn't have the same issues with ghost collisions or missed collisions.
+//! It is primarily intended as a safety net when it is crucial that a body never
+//! tunnels through geometry. Swept CCD should only be used when necessary,
+//! as it also has its own set of problems.
+//!
+//! ### Caveats of Swept CCD
+//!
+//! The [`Linear`](SweepMode::Linear) and [`NonLinear`](SweepMode::Linear)
+//! approaches can lead to *time loss* or *time stealing*, where bodies appear to momentarily
+//! move slower when Swept CCD is active. This happens because they are essentially moved
+//! backwards in time to avoid missing the collision.
+//!
+//! Swept CCD might also not account for chain reactions properly, so if a fast-moving body
+//! bumps into another body, making it a fast-moving body that potentially bumps into
+//! even more bodies, the collisions might not propagate accurately.
+//! However, speculative contacts do detect secondary collisions quite well,
+//! so using the two together can help mitigate the issue.
+//!
+//! Time loss and chain reactions could also be better accounted for with a substepped
+//! time-of-impact solver, but that would be much more expensive and complex,
+//! so it is not yet supported.
+//!
 //! ## Other Ways to Avoid Tunneling
 //!
 //! CCD is one way to prevent objects from tunneling through each other,
@@ -130,8 +218,61 @@
 //!
 //! Finally, making the [physics timestep](Physics) smaller can also help.
 //! However, this comes at the cost of worse performance for the entire simulation.
-use crate::prelude::*;
-use bevy::prelude::*;
+
+use crate::{collision::broad_phase::AabbIntersections, prelude::*, prepare::PrepareSet};
+use bevy::{
+    ecs::{intern::Interned, query::QueryData, schedule::ScheduleLabel},
+    prelude::*,
+};
+use parry::query::{
+    cast_shapes, cast_shapes_nonlinear, NonlinearRigidMotion, ShapeCastHit, ShapeCastOptions,
+};
+
+/// A plugin for [Continuous Collision Detection](ccd).
+pub struct CcdPlugin {
+    schedule: Interned<dyn ScheduleLabel>,
+}
+
+impl CcdPlugin {
+    /// Creates a [`CcdPlugin`] with the schedule that is used for running the [`PhysicsSchedule`].
+    ///
+    /// The default schedule is `PostUpdate`.
+    pub fn new(schedule: impl ScheduleLabel) -> Self {
+        Self {
+            schedule: schedule.intern(),
+        }
+    }
+}
+
+impl Default for CcdPlugin {
+    fn default() -> Self {
+        Self::new(PostUpdate)
+    }
+}
+
+impl Plugin for CcdPlugin {
+    fn build(&self, app: &mut App) {
+        app.register_type::<SweptCcd>().register_type::<SweepMode>();
+
+        app.add_systems(
+            self.schedule,
+            init_ccd_aabb_intersections.in_set(PrepareSet::InitColliders),
+        );
+
+        // Get the `PhysicsSchedule`, and panic if it doesn't exist.
+        let physics = app
+            .get_schedule_mut(PhysicsSchedule)
+            .expect("add PhysicsSchedule first");
+
+        physics.configure_sets(SweptCcdSet.in_set(SolverSet::PostSubstep));
+
+        physics.add_systems((solve_swept_ccd,).chain().in_set(SweptCcdSet));
+    }
+}
+
+/// A system set for [Continuous Collision Detection](ccd) systems.
+#[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct SweptCcdSet;
 
 /// The maximum distance at which [speculative contacts](self#speculative-collision)
 /// are generated for this entity. A value greater than zero helps prevent missing
@@ -164,10 +305,480 @@ use bevy::prelude::*;
 /// ```
 #[derive(Component, Clone, Copy, Debug, Deref, DerefMut, PartialEq, Reflect)]
 #[reflect(Component)]
-#[doc(alias = "CcdPredictionDistance")]
+#[doc(alias = "SweptCcdPredictionDistance")]
 pub struct SpeculativeMargin(pub Scalar);
 
 impl SpeculativeMargin {
+    /// A zero speculative margin. Disables speculative collision for this entity.
+    pub const ZERO: Self = Self(0.0);
+
     /// An unbounded speculative margin.
     pub const MAX: Self = Self(Scalar::MAX);
+}
+
+/// A component that enables sweep-based [Continuous Collision Detection](ccd) (CCD)
+/// for a [`RigidBody`]. This helps prevent missed collisions for small and fast-moving objects.
+///
+/// By default, CCD considers both translational and rotational motion, and is used
+/// against all types of rigid bodies and colliders. This behavior can be modified
+/// by changing [`SweptCcd::mode`] and other properties.
+///
+/// CCD is generally not useful for large or slow objects, as they are less likely
+/// to miss collisions. It is recommended to only use CCD when necessary,
+/// as it is more expensive than normal discrete collision detection.
+///
+/// This component specifically enables [Swept CCD](ccd#swept-ccd).
+/// [Speculative Collision](ccd#speculative-collision) is enabled by default
+/// and configured separately.
+///
+/// Read the [module-level documentation](ccd) for more information about what CCD is,
+/// what it is used for, and what limitations and tradeoffs it can have.
+///
+/// # Example
+///
+/// ```
+#[cfg_attr(feature = "2d", doc = "use avian2d::prelude::*;")]
+#[cfg_attr(feature = "3d", doc = "use avian3d::prelude::*;")]
+/// use bevy::prelude::*;
+///
+/// fn setup(mut commands: Commands) {
+///     // Spawn a dynamic rigid body with CCD, travelling towards the right at a high speed.
+///     // The default CCD configuration considers both translational and rotational motion.
+///     commands.spawn((
+///         RigidBody::Dynamic,
+///         SweptCcd::default(),
+#[cfg_attr(feature = "2d", doc = "        LinearVelocity(Vec2::X * 100.0),")]
+#[cfg_attr(feature = "3d", doc = "        LinearVelocity(Vec3::X * 100.0),")]
+#[cfg_attr(feature = "2d", doc = "        Collider::circle(0.1),")]
+#[cfg_attr(feature = "3d", doc = "        Collider::sphere(0.1),")]
+///         TransformBundle::from_transform(Transform::from_xyz(-10.0, 3.0, 0.0)),
+///     ));
+///
+///     // Spawn another dynamic rigid body with CCD, but this time only considering
+///     // linear motion and not rotation.
+///     commands.spawn((
+///         RigidBody::Dynamic,
+///         SweptCcd::LINEAR_CAST, // or `SweptCcd::new_with_mode(SweepMode::Linear)`
+#[cfg_attr(feature = "2d", doc = "        LinearVelocity(Vec2::X * 100.0),")]
+#[cfg_attr(feature = "3d", doc = "        LinearVelocity(Vec3::X * 100.0),")]
+#[cfg_attr(feature = "2d", doc = "        Collider::circle(0.1),")]
+#[cfg_attr(feature = "3d", doc = "        Collider::sphere(0.1),")]
+///         TransformBundle::from_transform(Transform::from_xyz(-10.0, -3.0, 0.0)),
+///     ));
+///
+///     // Spawn a thin, long object rotating at a high speed.
+///     // The first ball should hit it, but the second one does not consider
+///     // rotational motion, and most likely passes through.
+///     commands.spawn((
+///         RigidBody::Dynamic,
+///         LockedAxes::TRANSLATION_LOCKED,
+#[cfg_attr(feature = "2d", doc = "        AngularVelocity(100.0),")]
+#[cfg_attr(feature = "3d", doc = "        AngularVelocity(Vec3::Z * 100.0),")]
+#[cfg_attr(feature = "2d", doc = "        Collider::rectangle(0.2, 10.0),")]
+#[cfg_attr(feature = "3d", doc = "        Collider::cuboid(0.2, 10.0, 10.0),")]
+///     ));
+///
+///     // Spawn another thin, long object, this time not rotating.
+///     // The second ball should now hit this.
+///     commands.spawn((
+///         RigidBody::Static,
+#[cfg_attr(feature = "2d", doc = "        Collider::rectangle(0.2, 10.0),")]
+#[cfg_attr(feature = "3d", doc = "        Collider::cuboid(0.2, 10.0, 10.0),")]
+///         TransformBundle::from_transform(Transform::from_xyz(15.0, 0.0, 0.0)),
+///     ));
+/// }
+/// ```
+#[derive(Component, Clone, Copy, Debug, PartialEq, Reflect)]
+#[reflect(Component)]
+pub struct SweptCcd {
+    /// The type of sweep used for [sweep-based Continuous Collision Detection](ccd#swept-ccd).
+    ///
+    /// If two entities with different sweep modes collide, [`SweepMode::NonLinear`]
+    /// is preferred.
+    ///
+    /// The default is [`SweepMode::NonLinear`], which considers both translational
+    /// and rotational motion.
+    pub mode: SweepMode,
+    /// If `true`, [Continuous Collision Detection](ccd) is performed against dynamic rigid bodies.
+    /// Otherwise, it is only performed against static geometry and kinematic bodies.
+    ///
+    /// The default is `true`.
+    pub include_dynamic: bool,
+    /// Determines how fast two bodies must be moving relative to each other
+    /// for [Continuous Collision Detection](ccd) to be activated for them.
+    ///
+    /// If the linear velocity is below this threshold, CCD is skipped,
+    /// unless the angular velocity exceeds the `angular_threshold`.
+    ///
+    /// The default is `0.0`, meaning that CCD is performed regardless of the relative velocity.
+    pub linear_threshold: Scalar,
+    /// Determines how fast two bodies must be rotating relative to each other
+    /// for [Continuous Collision Detection](ccd) to be activated for them.
+    ///
+    /// If the angular velocity is below this threshold, CCD is skipped,
+    /// unless the linear velocity exceeds the `linear_threshold`.
+    ///
+    /// The default is `0.0`, meaning that CCD is performed regardless of the relative velocity.
+    pub angular_threshold: Scalar,
+}
+
+impl Default for SweptCcd {
+    fn default() -> Self {
+        Self::NON_LINEAR
+    }
+}
+
+impl SweptCcd {
+    /// Continuous Collision Detection with [`SweepMode::Linear`].
+    ///
+    /// This only takes into account translational motion, and can lead to tunneling
+    /// against thin, fast-spinning objects.
+    pub const LINEAR: Self = Self::new_with_mode(SweepMode::Linear);
+
+    /// Continuous Collision Detection with [`SweepMode::NonLinear`].
+    ///
+    /// This takes into account both translational and rotational motion.
+    pub const NON_LINEAR: Self = Self::new_with_mode(SweepMode::NonLinear);
+
+    /// Creates a new [`SweptCcd`] configuration with the given [`SweepMode`].
+    #[inline]
+    pub const fn new_with_mode(mode: SweepMode) -> Self {
+        Self {
+            mode,
+            include_dynamic: true,
+            linear_threshold: 0.0,
+            angular_threshold: 0.0,
+        }
+    }
+
+    /// Sets the linear and angular velocity thresholds in `self`,
+    /// determining how fast two bodies must be moving relative to each other
+    /// for swept [Continuous Collision Detection](ccd) to be activated for them.
+    ///
+    /// CCD will be active if either of the two thresholds is exceeded.
+    #[inline]
+    pub const fn with_velocity_threshold(mut self, linear: Scalar, angular: Scalar) -> Self {
+        self.linear_threshold = linear;
+        self.angular_threshold = angular;
+        self
+    }
+}
+
+/// The algorithm used for [Swept Continuous Collision Detection](ccd#swept-ccd).
+///
+/// If two entities with different sweep modes collide, [`SweepMode::NonLinear`]
+/// is preferred.
+///
+/// The default is [`SweepMode::NonLinear`], which considers both translational
+/// and rotational motion.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Reflect)]
+pub enum SweepMode {
+    /// [Continuous Collision Detection](ccd) is performed using linear time-of-impact queries
+    /// from the previous positions of [`SweptCcd`] bodies to their current positions,
+    /// stopping the bodies at the first time of impact.
+    ///
+    /// This mode only considers translational motion, and can lead to tunneling
+    /// against thin, fast-spinning objects. For the more expensive version
+    /// that also considers rotational motion, consider using [`SweepMode::NonLinear`].
+    Linear,
+
+    /// [Continuous Collision Detection](ccd) is performed using non-linear time-of-impact queries
+    /// from the previous positions of [`SweptCcd`] bodies to their current positions,
+    /// stopping the bodies at the first time of impact.
+    ///
+    /// This mode considers both translational and rotational motion.
+    /// For the cheaper version that only considers translational motion,
+    /// consider using [`SweepMode::Linear`].
+    #[default]
+    NonLinear,
+}
+
+fn init_ccd_aabb_intersections(mut commands: Commands, query: Query<Entity, Added<SweptCcd>>) {
+    for entity in &query {
+        commands.entity(entity).insert(AabbIntersections::default());
+    }
+}
+
+#[derive(QueryData)]
+#[query_data(mutable)]
+struct SweptCcdBodyQuery {
+    entity: Entity,
+    rb: &'static RigidBody,
+    pos: &'static Position,
+    translation: Option<&'static mut AccumulatedTranslation>,
+    rot: &'static mut Rotation,
+    prev_rot: Option<&'static mut PreviousRotation>,
+    lin_vel: Option<&'static LinearVelocity>,
+    ang_vel: Option<&'static AngularVelocity>,
+    ccd: Option<&'static SweptCcd>,
+    collider: &'static Collider,
+    com: &'static CenterOfMass,
+}
+
+/// Performs [sweep-based mContinuous Collision Detection](ccd#swept-ccd)
+/// by performing time-of-impact queries from the previous positions of [`SweptCcd`] bodies
+/// to their current positions, stopping the bodies at the first time of impact.
+///
+/// This approach can lead to "time loss" or "time stealing", because the bodies
+/// are essentially moved back in time, making them appear to momentarily move slower.
+/// Secondary contacts are also not accounted for.
+#[allow(clippy::useless_conversion)]
+fn solve_swept_ccd(
+    ccd_query: Query<(Entity, &AabbIntersections), With<SweptCcd>>,
+    bodies: Query<SweptCcdBodyQuery>,
+    colliders: Query<(&Collider, &ColliderParent)>,
+    time: Res<Time>,
+    narrow_phase_config: Res<NarrowPhaseConfig>,
+) {
+    let delta_secs = time.delta_seconds_adjusted();
+
+    // TODO: Parallelize.
+    for (entity, intersections) in &ccd_query {
+        // Get the CCD body.
+        let Ok(SweptCcdBodyQueryItem {
+            pos: pos1,
+            translation: Some(mut translation1),
+            rot: mut rot1,
+            prev_rot: Some(prev_rot),
+            lin_vel: Some(lin_vel1),
+            ang_vel: Some(ang_vel1),
+            ccd: Some(ccd1),
+            collider: collider1,
+            com: com1,
+            ..
+        }) = (
+            // Safety: `get_unchecked` is only unsafe if there are multiple mutable references
+            //         to the same component, and this is ensured not to happen when iterating
+            //         over the AABB intersections below.
+            unsafe { bodies.get_unchecked(entity) }
+        )
+        else {
+            continue;
+        };
+
+        // The smallest time of impact found. Starts at the largest value,
+        // how long a body moves during a single frame due to position integration.
+        let (mut min_toi, mut min_toi_entity) = (delta_secs, None);
+
+        // Iterate through colliders intersecting the AABB of the CCD body.
+        for (collider2, collider_parent) in colliders.iter_many(intersections.iter()) {
+            debug_assert_ne!(
+                entity,
+                collider_parent.get(),
+                "collider AABB cannot intersect itself"
+            );
+
+            // Get the body associated with the collider.
+            // Safety: `AabbIntersections` should never contain the entity of a collider
+            //         with the same parent as the first body, and the entities
+            //         are also ensured to be different above.
+            if let Ok(body2) = unsafe { bodies.get_unchecked(collider_parent.get()) } {
+                if !ccd1.include_dynamic && body2.rb.is_dynamic() {
+                    continue;
+                }
+
+                let lin_vel2 = body2.lin_vel.copied().unwrap_or_default().0;
+                let ang_vel2 = body2.ang_vel.copied().unwrap_or_default().0;
+
+                #[cfg(feature = "2d")]
+                let ang_vel_below_threshold =
+                    (ang_vel1.0 - ang_vel2).abs() < ccd1.angular_threshold;
+                #[cfg(feature = "3d")]
+                let ang_vel_below_threshold =
+                    (ang_vel1.0 - ang_vel2).length_squared() < ccd1.angular_threshold.powi(2);
+
+                // If both the relative linear and relative angular velocity
+                // are below the defined thresholds, skip this body.
+                if ang_vel_below_threshold
+                    && (lin_vel1.0 - lin_vel2).length_squared() < ccd1.linear_threshold.powi(2)
+                {
+                    continue;
+                }
+
+                let iso1 = make_isometry(pos1.0, prev_rot.0);
+                let iso2 = make_isometry(
+                    body2.pos.0,
+                    body2.prev_rot.as_ref().map_or(*body2.rot, |rot| rot.0),
+                );
+
+                // TODO: Support child colliders
+                let motion1 = NonlinearRigidMotion::new(
+                    iso1,
+                    com1.0.into(),
+                    lin_vel1.0.into(),
+                    ang_vel1.0.into(),
+                );
+                let motion2 = NonlinearRigidMotion::new(
+                    iso2,
+                    body2.com.0.into(),
+                    lin_vel2.into(),
+                    ang_vel2.into(),
+                );
+
+                let sweep_mode = if ccd1.mode == SweepMode::Linear
+                    && body2.ccd.map_or(true, |ccd| ccd.mode == SweepMode::Linear)
+                {
+                    SweepMode::Linear
+                } else {
+                    SweepMode::NonLinear
+                };
+
+                if let Some(toi) = compute_ccd_toi(
+                    sweep_mode,
+                    &motion1,
+                    collider1,
+                    &motion2,
+                    collider2,
+                    min_toi,
+                    narrow_phase_config.default_speculative_margin,
+                ) {
+                    min_toi = toi;
+                    min_toi_entity = Some(collider_parent.get());
+                }
+            }
+        }
+
+        // Advance the bodies from the previous poses to the first time of impact.
+        if let Some(Ok(mut body2)) =
+            min_toi_entity.map(|entity| unsafe { bodies.get_unchecked(entity) })
+        {
+            let collider_lin_vel = body2.lin_vel.copied().unwrap_or_default().0;
+            let collider_ang_vel = body2.ang_vel.copied().unwrap_or_default().0;
+
+            // Overshoot slightly to make sure the bodies advance and don't get stuck.
+            let min_toi = min_toi * 1.0001;
+
+            translation1.0 = min_toi * lin_vel1.0;
+
+            // TODO: Abstract the integration logic to reuse it here
+            #[cfg(feature = "2d")]
+            {
+                *rot1 = prev_rot.0 * Rotation::radians(ang_vel1.0 * min_toi);
+            }
+            #[cfg(feature = "3d")]
+            {
+                let delta_rot = Quaternion::from_vec4(
+                    (ang_vel1.0 * min_toi / 2.0).extend(prev_rot.w * min_toi / 2.0),
+                ) * prev_rot.0 .0;
+                rot1.0 = (prev_rot.0 .0 + delta_rot).normalize();
+            }
+
+            if let Some(mut collider_translation) = body2.translation {
+                collider_translation.0 = min_toi * collider_lin_vel;
+            }
+            if let Some(ref collider_prev_rot) = body2.prev_rot {
+                #[cfg(feature = "2d")]
+                {
+                    *body2.rot =
+                        collider_prev_rot.0 * Rotation::radians(collider_ang_vel * min_toi);
+                }
+                #[cfg(feature = "3d")]
+                {
+                    let delta_rot = Quaternion::from_vec4(
+                        (collider_ang_vel * min_toi / 2.0)
+                            .extend(collider_prev_rot.w * min_toi / 2.0),
+                    ) * collider_prev_rot.0 .0;
+                    body2.rot.0 = (collider_prev_rot.0 .0 + delta_rot).normalize();
+                }
+            }
+        }
+    }
+}
+
+/// Computes the time of impact for the motion of two objects for Continuous Collision Detection.
+/// If the TOI is larger than `min_toi` or the shapes never touch, `None` is returned.
+fn compute_ccd_toi(
+    mode: SweepMode,
+    motion1: &NonlinearRigidMotion,
+    collider1: &Collider,
+    motion2: &NonlinearRigidMotion,
+    collider2: &Collider,
+    min_toi: Scalar,
+    prediction_distance: Scalar,
+) -> Option<Scalar> {
+    if mode == SweepMode::Linear {
+        if let Ok(Some(ShapeCastHit {
+            time_of_impact: toi,
+            ..
+        })) = cast_shapes(
+            &motion1.start,
+            &motion1.linvel,
+            collider1.shape_scaled().as_ref(),
+            &motion2.start,
+            &motion2.linvel,
+            collider2.shape_scaled().as_ref(),
+            ShapeCastOptions {
+                max_time_of_impact: min_toi,
+                stop_at_penetration: false,
+                ..default()
+            },
+        ) {
+            if toi > 0.0 && toi < min_toi {
+                // New smaller time of impact found
+                return Some(toi);
+            } else if toi == 0.0 {
+                // If the time of impact is zero, fall back to computing the TOI of a small circle
+                // around the centroid of the first body.
+                if let Ok(Some(ShapeCastHit {
+                    time_of_impact: toi,
+                    ..
+                })) = cast_shapes(
+                    &motion1.start,
+                    &motion1.linvel,
+                    collider1.shape_scaled().as_ref(),
+                    &motion2.start,
+                    &motion2.linvel,
+                    &parry::shape::Ball::new(prediction_distance),
+                    ShapeCastOptions {
+                        max_time_of_impact: min_toi,
+                        stop_at_penetration: false,
+                        ..default()
+                    },
+                ) {
+                    if toi > 0.0 && toi < min_toi {
+                        // New smaller time of impact found
+                        return Some(toi);
+                    }
+                }
+            }
+        }
+    } else if let Ok(Some(ShapeCastHit {
+        time_of_impact: toi,
+        ..
+    })) = cast_shapes_nonlinear(
+        motion1,
+        collider1.shape_scaled().as_ref(),
+        motion2,
+        collider2.shape_scaled().as_ref(),
+        0.0,
+        min_toi,
+        false,
+    ) {
+        if toi > 0.0 && toi < min_toi {
+            // New smaller time of impact found
+            return Some(toi);
+        } else if toi == 0.0 {
+            // If the time of impact is zero, fall back to computing the TOI of a small circle
+            // around the centroid of the first body.
+            if let Ok(Some(ShapeCastHit {
+                time_of_impact: toi,
+                ..
+            })) = cast_shapes_nonlinear(
+                motion1,
+                collider1.shape_scaled().as_ref(),
+                motion2,
+                &parry::shape::Ball::new(prediction_distance),
+                0.0,
+                min_toi,
+                false,
+            ) {
+                if toi > 0.0 && toi < min_toi {
+                    // New smaller time of impact found
+                    return Some(toi);
+                }
+            }
+        }
+    }
+
+    None
 }

--- a/src/dynamics/mod.rs
+++ b/src/dynamics/mod.rs
@@ -70,7 +70,7 @@ pub mod solver;
 /// Re-exports common types related to the rigid body dynamics functionality.
 pub mod prelude {
     pub use super::{
-        ccd::SpeculativeMargin,
+        ccd::{CcdPlugin, SpeculativeMargin, SweepMode, SweptCcd},
         integrator::{Gravity, IntegratorPlugin},
         rigid_body::*,
         sleeping::{DeactivationTime, SleepingPlugin, SleepingThreshold},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -533,6 +533,7 @@ use prelude::*;
 /// - [`IntegratorPlugin`]: Handles motion caused by velocity, and applies external forces and gravity.
 /// - [`SolverPlugin`]: Solves [constraints](dynamics::solver::xpbd#constraints) (contacts and joints).
 /// (dynamic [friction](Friction) and [restitution](Restitution)).
+/// - [`CcdPlugin`]: Performs sweep-based [Continuous Collision Detection](ccd) for bodies with the [`SweptCcd`] component.
 /// - [`SleepingPlugin`]: Manages sleeping and waking for bodies, automatically deactivating them to save computational resources.
 /// - [`SpatialQueryPlugin`]: Handles spatial queries like [raycasting](spatial_query#raycasting) and [shapecasting](spatial_query#shapecasting).
 /// - [`SyncPlugin`]: Keeps [`Position`] and [`Rotation`] in sync with `Transform`.
@@ -737,9 +738,10 @@ impl PluginGroup for PhysicsPlugins {
 
         builder
             .add(BroadPhasePlugin)
-            .add(IntegratorPlugin::default())
             .add(ContactReportingPlugin)
+            .add(IntegratorPlugin::default())
             .add(SolverPlugin::new_with_length_unit(self.length_unit))
+            .add(CcdPlugin::new(self.schedule))
             .add(SleepingPlugin)
             .add(SpatialQueryPlugin::new(self.schedule))
             .add(SyncPlugin::new(self.schedule))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -533,7 +533,7 @@ use prelude::*;
 /// - [`IntegratorPlugin`]: Handles motion caused by velocity, and applies external forces and gravity.
 /// - [`SolverPlugin`]: Solves [constraints](dynamics::solver::xpbd#constraints) (contacts and joints).
 /// (dynamic [friction](Friction) and [restitution](Restitution)).
-/// - [`CcdPlugin`]: Performs sweep-based [Continuous Collision Detection](ccd) for bodies with the [`SweptCcd`] component.
+/// - [`CcdPlugin`]: Performs sweep-based [Continuous Collision Detection](dynamics::ccd) for bodies with the [`SweptCcd`] component.
 /// - [`SleepingPlugin`]: Manages sleeping and waking for bodies, automatically deactivating them to save computational resources.
 /// - [`SpatialQueryPlugin`]: Handles spatial queries like [raycasting](spatial_query#raycasting) and [shapecasting](spatial_query#shapecasting).
 /// - [`SyncPlugin`]: Keeps [`Position`] and [`Rotation`] in sync with `Transform`.


### PR DESCRIPTION
# Objective

#385 added speculative collision, a form of Continuous Collision Detection (CCD) with the goal of preventing tunneling. However, it isn't perfect; speculative collision can sometimes cause ghost collisions, and it can miss collisions against objects spinning at very high speeds.

Another form of CCD is swept CCD, which sweeps colliders from their previous positions to the current ones, and moves the bodies to the time of impact if a hit was found. This can be more reliable than speculative collision, and can act as a sort of safety net when you want to ensure that an object has no tunneling, at the cost of being more expensive and causing "time loss" where bodies appear to stop momentarily as they are brought back in time.

Both forms of CCD are valuable and should exist. They can also be used together to complement each other!

## Solution

Add a `CcdPlugin` that performs sweep-based CCD for rigid bodies that have the `SweptCcd` component.

```rust
commands.spawn((
    RigidBody::Dynamic,
    Collider::circle(0.5),
    // Enable swept CCD for this rigid body.
    SweptCcd::default(),
));
```

Two sweep modes are supported:

- If `SweptCcd::mode` is `SweepMode::Linear`, only translational motion is considered.
- If `SweptCcd::mode` is `SweepMode::NonLinear`, both translational and rotational motion are considered. This is more expensive.

By default, the mode is `SweepMode::NonLinear`, but it can be specified using associated constants `SweptCcd::Linear` or `SweptCcd::NonLinear`, or by using the `SweptCcd::new_with_mode` constructor.

It may not be desirable to have CCD enabled for all collisions. To enable it based on the relative velocities of the bodies involved, velocity thresholds can be set:

```rust
SweptCcd::NonLinear.with_velocity_threshold(linear, angular)
```

Additionally, swept CCD can be disabled for collisions against dynamic bodies:

```rust
SweptCcd::NonLinear.include_dynamic(false)
```

Below you can see the new `ccd` example and the different forms of CCD in action!


https://github.com/Jondolf/bevy_xpbd/assets/57632562/2a27d92b-85aa-404e-b258-dcf4f914b12e

As you can see, all the different modes and combinations behave differently, and have their own unique characteristics and trade-offs. In this spinning example, sweep-based CCD clearly has time loss, especially with speculative collision disabled. Non-linear swept CCD is also the most reliable however, as it doesn't let any of the projectiles tunnel through. Linear swept CCD on the other hand struggles a lot in this case since it doesn't take rotational motion into account.

Of course, this is a very extreme and relatively niche example. For most objects in most games, speculative collision should be enough, and swept CCD can be used as a safety net when it isn't.

### Implementation

The implementation works as follows:

- Store broad phase intersections for entities with `SweptCcd` in an `AabbIntersections` component.
- In `solve_swept_ccd`, iterate through the AABB intersections for each entity with `SweptCcd`, and perform shape casts to find the minimum time of impact.
  - If `SweptCcd::mode` is `SweepMode::Linear`, only translational motion is considered.
  - If `SweptCcd::mode` is `SweepMode::NonLinear`, both translational and rotational motion are considered. This is more expensive.
- Integrate the positions of the bodies for the duration of the minimum time of impact to move them into a touching state.
- Normal collision detection and collision response will handle the collision during the next frame.

A number of physics engines were used as inspiration for the implementation and terminology, primarily Box2D V3, Bepu, and Jolt.

Unlike Rapier, I did not implement substepping for the time of impact solver, because it is more expensive and complex, and likely much more difficult to parallelize in the future. I believe Box2D V3 is opting for a similar approach for similar reasons.