### PR TITLE
Fix `GlobalTransform` updates for entities with non-physics children

### DIFF
--- a/src/plugins/sync/mod.rs
+++ b/src/plugins/sync/mod.rs
@@ -383,7 +383,7 @@ pub fn update_previous_global_transforms(
 // Propagation is unnecessary for everything else, because the physics engine should only modify the positions
 // of rigid bodies and their descendants. Bevy runs its own propagation near the end of the frame.
 
-/// Updates the [`GlobalTransform`] component of physics entities that aren't in the hierarchy.
+/// Updates the [`GlobalTransform`] component of physics entities that don't have other physics entities in the hierarchy.
 #[allow(clippy::type_complexity)]
 pub fn sync_simple_transforms_physics(
     mut query: ParamSet<(
@@ -392,7 +392,10 @@ pub fn sync_simple_transforms_physics(
             (
                 Or<(Changed<Transform>, Added<GlobalTransform>)>,
                 Without<Parent>,
-                Without<Children>,
+                Or<(
+                    Without<AncestorMarker<RigidBody>>,
+                    Without<AncestorMarker<ColliderMarker>>,
+                )>,
                 Or<(With<RigidBody>, With<ColliderMarker>)>,
             ),
         >,
@@ -400,7 +403,10 @@ pub fn sync_simple_transforms_physics(
             (Ref<Transform>, &mut GlobalTransform),
             (
                 Without<Parent>,
-                Without<Children>,
+                Or<(
+                    Without<AncestorMarker<RigidBody>>,
+                    Without<AncestorMarker<ColliderMarker>>,
+                )>,
                 Or<(With<RigidBody>, With<ColliderMarker>)>,
             ),
         >,


### PR DESCRIPTION
# Objective

#380 significantly sped up transform propagation by reducing unnecessary work with physics entity ancestor markers. However, it also seems to have caused a severe bug: `GlobalTransform` is not updated for rigid bodies that have children that all are *not* physics entities.

The problem lies in `propagate_transforms_physics`, which *only* iterates through entities that are marked as ancestors of rigid bodies or colliders. Rigid bodies that have children but no physics entity descendants are just skipped.

## Solution

In `sync_simple_transforms_physics`, don't only iterate through rigid bodies with no children, but also through rigid bodies that have children but are *not* ancestors of other physics entities.