### PR TITLE
Implement collision margin

### DIFF
--- a/src/collision/collider/backend.rs
+++ b/src/collision/collider/backend.rs
@@ -451,6 +451,7 @@ fn update_aabb<C: AnyCollider>(
             &Position,
             &Rotation,
             Option<&ColliderParent>,
+            Option<&CollisionMargin>,
             Option<&SpeculativeMargin>,
             Option<&LinearVelocity>,
             Option<&AngularVelocity>,
@@ -475,16 +476,26 @@ fn update_aabb<C: AnyCollider>(
     let default_speculative_margin = length_unit.0 * narrow_phase_config.default_speculative_margin;
     let contact_tolerance = length_unit.0 * narrow_phase_config.contact_tolerance;
 
-    for (collider, mut aabb, pos, rot, collider_parent, speculative_margin, lin_vel, ang_vel) in
-        &mut colliders
+    for (
+        collider,
+        mut aabb,
+        pos,
+        rot,
+        collider_parent,
+        collision_margin,
+        speculative_margin,
+        lin_vel,
+        ang_vel,
+    ) in &mut colliders
     {
+        let collision_margin = collision_margin.map_or(0.0, |margin| margin.0);
         let speculative_margin =
             speculative_margin.map_or(default_speculative_margin, |margin| margin.0);
 
         if speculative_margin <= 0.0 {
             *aabb = collider
                 .aabb(pos.0, *rot)
-                .grow(Vector::splat(contact_tolerance));
+                .grow(Vector::splat(contact_tolerance + collision_margin));
             continue;
         }
 
@@ -542,7 +553,9 @@ fn update_aabb<C: AnyCollider>(
         };
         // Compute swept AABB, the space that the body would occupy if it was integrated for one frame
         // TODO: Should we expand the AABB in all directions for speculative contacts?
-        *aabb = collider.swept_aabb(start_pos.0, start_rot, end_pos, end_rot);
+        *aabb = collider
+            .swept_aabb(start_pos.0, start_rot, end_pos, end_rot)
+            .grow(Vector::splat(collision_margin));
     }
 }
 

--- a/src/collision/collider/mod.rs
+++ b/src/collision/collider/mod.rs
@@ -341,9 +341,9 @@ impl Default for ColliderAabb {
     }
 }
 
-/// A component that adds an extra margin around [`Collider`] shapes to help maintain
-/// additional separation to other objects. This can be imagined as an extra shell
-/// or skin that adds artificial thickness.
+/// A component that adds an extra margin or "skin" around [`Collider`] shapes to help maintain
+/// additional separation to other objects. This added thickness can help improve
+/// stability and performance in some cases, especially for thin shapes such as trimeshes.
 ///
 /// There are three primary reasons for collision margins:
 ///
@@ -395,8 +395,9 @@ impl Default for ColliderAabb {
 )]
 /// }
 /// ```
-#[derive(Reflect, Clone, Component, Debug, Default, Deref, DerefMut, PartialEq)]
+#[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 #[doc(alias = "ContactSkin")]
 pub struct CollisionMargin(pub Scalar);

--- a/src/collision/collider/mod.rs
+++ b/src/collision/collider/mod.rs
@@ -389,7 +389,7 @@ impl Default for ColliderAabb {
     // A margin of `0.1` is added around the shape.
     commands.spawn((
         RigidBody::Dynamic,
-        Collider::trimesh_from_mesh(&mesh),
+        Collider::trimesh_from_mesh(&mesh).unwrap(),
         CollisionMargin(0.1),
     ));"
 )]

--- a/src/collision/collider/mod.rs
+++ b/src/collision/collider/mod.rs
@@ -6,6 +6,7 @@ use bevy::{
     prelude::*,
     utils::HashSet,
 };
+use derive_more::From;
 
 mod backend;
 mod hierarchy;
@@ -395,7 +396,7 @@ impl Default for ColliderAabb {
 )]
 /// }
 /// ```
-#[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq)]
+#[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]

--- a/src/collision/collider/mod.rs
+++ b/src/collision/collider/mod.rs
@@ -341,6 +341,66 @@ impl Default for ColliderAabb {
     }
 }
 
+/// A component that adds an extra margin around [`Collider`] shapes to help maintain
+/// additional separation to other objects. This can be imagined as an extra shell
+/// or skin that adds artificial thickness.
+///
+/// There are three primary reasons for collision margins:
+///
+/// 1. Collision detection is often more efficient when shapes are not overlapping
+/// further than their collision margins. Deeply overlapping shapes require
+/// more expensive collision algorithms.
+///
+/// 2. Some shapes such as triangles and planes are infinitely thin,
+/// which can cause precision errors. A collision margin adds artificial
+/// thickness to shapes, improving stability.
+///
+/// 3. Overall, collision margins give the physics engine more
+/// room for error when resolving contacts. This can also help
+/// prevent visible artifacts such as objects poking through the ground.
+///
+/// If a rigid body with a [`CollisionMargin`] has colliders as child entities,
+/// and those colliders don't have their own [`CollisionMargin`] components,
+/// the colliders will use the rigid body's [`CollisionMargin`].
+///
+/// # Example
+///
+/// ```
+#[cfg_attr(feature = "2d", doc = "use avian2d::prelude::*;")]
+#[cfg_attr(feature = "3d", doc = "use avian3d::prelude::*;")]
+/// use bevy::prelude::*;
+///
+/// fn setup(mut commands: Commands) {
+#[cfg_attr(
+    feature = "2d",
+    doc = "    // Spawn a rigid body with a collider.
+    // A margin of `0.1` is added around the shape.
+    commands.spawn((
+        RigidBody::Dynamic,
+        Collider::capsule(2.0, 0.5),
+        CollisionMargin(0.1),
+    ));"
+)]
+#[cfg_attr(
+    feature = "3d",
+    doc = "    let mesh = Mesh::from(Torus::default());
+
+    // Spawn a rigid body with a triangle mesh collider.
+    // A margin of `0.1` is added around the shape.
+    commands.spawn((
+        RigidBody::Dynamic,
+        Collider::trimesh_from_mesh(&mesh),
+        CollisionMargin(0.1),
+    ));"
+)]
+/// }
+/// ```
+#[derive(Reflect, Clone, Component, Debug, Default, Deref, DerefMut, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[reflect(Component)]
+#[doc(alias = "ContactSkin")]
+pub struct CollisionMargin(pub Scalar);
+
 /// A component that stores the entities that are colliding with an entity.
 ///
 /// This component is automatically added for all entities with a [`Collider`],

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -820,6 +820,9 @@ impl Collider {
     /// Creates a collider with a triangle mesh shape defined by its vertex and index buffers.
     ///
     /// Note that the resulting collider will be hollow and have no interior. This makes it more prone to tunneling and other collision issues.
+    ///
+    /// The [`CollisionMargin`] component can be used to add thickness to the shape if needed.
+    /// For thin shapes like triangle meshes, it can help improve collision stability and performance.
     pub fn trimesh(vertices: Vec<Vector>, indices: Vec<[u32; 3]>) -> Self {
         let vertices = vertices.into_iter().map(|v| v.into()).collect();
         SharedShape::trimesh(vertices, indices).into()
@@ -829,6 +832,9 @@ impl Collider {
     /// and flags controlling the preprocessing.
     ///
     /// Note that the resulting collider will be hollow and have no interior. This makes it more prone to tunneling and other collision issues.
+    ///
+    /// The [`CollisionMargin`] component can be used to add thickness to the shape if needed.
+    /// For thin shapes like triangle meshes, it can help improve collision stability and performance.
     pub fn trimesh_with_config(
         vertices: Vec<Vector>,
         indices: Vec<[u32; 3]>,
@@ -936,6 +942,11 @@ impl Collider {
 
     /// Creates a collider with a triangle mesh shape from a `Mesh`.
     ///
+    /// Note that the resulting collider will be hollow and have no interior. This makes it more prone to tunneling and other collision issues.
+    ///
+    /// The [`CollisionMargin`] component can be used to add thickness to the shape if needed.
+    /// For thin shapes like triangle meshes, it can help improve collision stability and performance.
+    ///
     /// ## Example
     ///
     /// ```
@@ -967,6 +978,11 @@ impl Collider {
 
     /// Creates a collider with a triangle mesh shape from a `Mesh` using the given [`TrimeshFlags`]
     /// for controlling the preprocessing.
+    ///
+    /// Note that the resulting collider will be hollow and have no interior. This makes it more prone to tunneling and other collision issues.
+    ///
+    /// The [`CollisionMargin`] component can be used to add thickness to the shape if needed.
+    /// For thin shapes like triangle meshes, it can help improve collision stability and performance.
     ///
     /// ## Example
     ///

--- a/src/collision/collider/world_query.rs
+++ b/src/collision/collider/world_query.rs
@@ -16,6 +16,7 @@ pub struct ColliderQuery<C: AnyCollider> {
     pub rotation: Ref<'static, Rotation>,
     pub accumulated_translation: Option<Ref<'static, AccumulatedTranslation>>,
     pub transform: Option<&'static ColliderTransform>,
+    pub collision_margin: Option<&'static CollisionMargin>,
     pub speculative_margin: Option<&'static SpeculativeMargin>,
     pub is_rb: Has<RigidBody>,
     pub is_sensor: Has<Sensor>,

--- a/src/collision/narrow_phase.rs
+++ b/src/collision/narrow_phase.rs
@@ -606,7 +606,7 @@ impl<'w, 's, C: AnyCollider> NarrowPhase<'w, 's, C> {
         body2: &RigidBodyQueryReadOnlyItem,
         collider1: &ColliderQueryItem<C>,
         collider2: &ColliderQueryItem<C>,
-        collision_margin: Scalar,
+        collision_margin: impl Into<CollisionMargin> + Copy,
         contact_softness: ContactSoftnessCoefficients,
         delta_secs: Scalar,
     ) {

--- a/src/collision/narrow_phase.rs
+++ b/src/collision/narrow_phase.rs
@@ -294,14 +294,14 @@ fn generate_constraints<C: AnyCollider>(
             //
             // The collision margin adds artificial thickness to colliders for performance
             // and stability. See the `CollisionMargin` documentation for more details.
-            let collision_margin1 = collider1.collision_margin.map_or(
-                rb_collision_margin1.map_or(0.0, |margin| margin.0),
-                |margin| margin.0,
-            );
-            let collision_margin2 = collider2.collision_margin.map_or(
-                rb_collision_margin2.map_or(0.0, |margin| margin.0),
-                |margin| margin.0,
-            );
+            let collision_margin1 = collider1
+                .collision_margin
+                .or(rb_collision_margin1)
+                .map_or(0.0, |margin| margin.0);
+            let collision_margin2 = collider2
+                .collision_margin
+                .or(rb_collision_margin2)
+                .map_or(0.0, |margin| margin.0);
             let collision_margin_sum = collision_margin1 + collision_margin2;
 
             // Generate contact constraints for the computed contacts
@@ -423,42 +423,40 @@ impl<'w, 's, C: AnyCollider> NarrowPhase<'w, 's, C> {
 
         // The rigid body's collision margin and speculative margin will be used
         // if the collider doesn't have them specified.
-        let (mut lin_vel1, rb_collision_margin1, rb_speculative_margin1) =
-            body1_bundle.as_ref().map_or(
-                (Vector::ZERO, None, None),
-                |(body, collision_margin, speculative_margin)| {
-                    (
-                        body.linear_velocity.0,
-                        *collision_margin,
-                        *speculative_margin,
-                    )
-                },
-            );
-        let (mut lin_vel2, rb_collision_margin2, rb_speculative_margin2) =
-            body2_bundle.as_ref().map_or(
-                (Vector::ZERO, None, None),
-                |(body, collision_margin, speculative_margin)| {
-                    (
-                        body.linear_velocity.0,
-                        *collision_margin,
-                        *speculative_margin,
-                    )
-                },
-            );
+        let (mut lin_vel1, rb_collision_margin1, rb_speculative_margin1) = body1_bundle
+            .as_ref()
+            .map(|(body, collision_margin, speculative_margin)| {
+                (
+                    body.linear_velocity.0,
+                    *collision_margin,
+                    *speculative_margin,
+                )
+            })
+            .unwrap_or_default();
+        let (mut lin_vel2, rb_collision_margin2, rb_speculative_margin2) = body2_bundle
+            .as_ref()
+            .map(|(body, collision_margin, speculative_margin)| {
+                (
+                    body.linear_velocity.0,
+                    *collision_margin,
+                    *speculative_margin,
+                )
+            })
+            .unwrap_or_default();
 
         // Use the collider's own collision margin if specified, and fall back to the body's
         // collision margin.
         //
         // The collision margin adds artificial thickness to colliders for performance
         // and stability. See the `CollisionMargin` documentation for more details.
-        let collision_margin1 = collider1.collision_margin.map_or(
-            rb_collision_margin1.map_or(0.0, |margin| margin.0),
-            |margin| margin.0,
-        );
-        let collision_margin2 = collider2.collision_margin.map_or(
-            rb_collision_margin2.map_or(0.0, |margin| margin.0),
-            |margin| margin.0,
-        );
+        let collision_margin1 = collider1
+            .collision_margin
+            .or(rb_collision_margin1)
+            .map_or(0.0, |margin| margin.0);
+        let collision_margin2 = collider2
+            .collision_margin
+            .or(rb_collision_margin2)
+            .map_or(0.0, |margin| margin.0);
         let collision_margin_sum = collision_margin1 + collision_margin2;
 
         // Use the collider's own speculative margin if specified, and fall back to the body's

--- a/src/collision/narrow_phase.rs
+++ b/src/collision/narrow_phase.rs
@@ -279,15 +279,30 @@ fn generate_constraints<C: AnyCollider>(
         let body2_bundle = collider2
             .parent
             .and_then(|p| narrow_phase.body_query.get(p.get()).ok());
-        if let (Some(body1), Some(body2)) = (
-            body1_bundle.map(|(body, _)| body),
-            body2_bundle.map(|(body, _)| body),
+        if let (Some((body1, rb_collision_margin1)), Some((body2, rb_collision_margin2))) = (
+            body1_bundle.map(|(body, rb_collision_margin1, _)| (body, rb_collision_margin1)),
+            body2_bundle.map(|(body, rb_collision_margin2, _)| (body, rb_collision_margin2)),
         ) {
             // At least one of the bodies must be dynamic for contact constraints
             // to be generated.
             if !body1.rb.is_dynamic() && !body2.rb.is_dynamic() {
                 continue;
             }
+
+            // Use the collider's own collision margin if specified, and fall back to the body's
+            // collision margin.
+            //
+            // The collision margin adds artificial thickness to colliders for performance
+            // and stability. See the `CollisionMargin` documentation for more details.
+            let collision_margin1 = collider1.collision_margin.map_or(
+                rb_collision_margin1.map_or(0.0, |margin| margin.0),
+                |margin| margin.0,
+            );
+            let collision_margin2 = collider2.collision_margin.map_or(
+                rb_collision_margin2.map_or(0.0, |margin| margin.0),
+                |margin| margin.0,
+            );
+            let collision_margin_sum = collision_margin1 + collision_margin2;
 
             // Generate contact constraints for the computed contacts
             // and add them to `constraints`.
@@ -298,6 +313,7 @@ fn generate_constraints<C: AnyCollider>(
                 &body2,
                 &collider1,
                 &collider2,
+                collision_margin_sum,
                 *contact_softness,
                 delta_secs,
             );
@@ -314,7 +330,15 @@ fn generate_constraints<C: AnyCollider>(
 pub struct NarrowPhase<'w, 's, C: AnyCollider> {
     parallel_commands: ParallelCommands<'w, 's>,
     collider_query: Query<'w, 's, ColliderQuery<C>>,
-    body_query: Query<'w, 's, (RigidBodyQueryReadOnly, Option<&'static SpeculativeMargin>)>,
+    body_query: Query<
+        'w,
+        's,
+        (
+            RigidBodyQueryReadOnly,
+            Option<&'static CollisionMargin>,
+            Option<&'static SpeculativeMargin>,
+        ),
+    >,
     /// Contacts found by the narrow phase.
     pub collisions: ResMut<'w, Collisions>,
     /// Configuration options for the narrow phase.
@@ -399,16 +423,43 @@ impl<'w, 's, C: AnyCollider> NarrowPhase<'w, 's, C> {
 
         // The rigid body's collision margin and speculative margin will be used
         // if the collider doesn't have them specified.
-        let (mut lin_vel1, rb_speculative_margin1) = body1_bundle
-            .as_ref()
-            .map_or((Vector::ZERO, None), |(body, speculative_margin)| {
-                (body.linear_velocity.0, *speculative_margin)
-            });
-        let (mut lin_vel2, rb_speculative_margin2) = body2_bundle
-            .as_ref()
-            .map_or((Vector::ZERO, None), |(body, speculative_margin)| {
-                (body.linear_velocity.0, *speculative_margin)
-            });
+        let (mut lin_vel1, rb_collision_margin1, rb_speculative_margin1) =
+            body1_bundle.as_ref().map_or(
+                (Vector::ZERO, None, None),
+                |(body, collision_margin, speculative_margin)| {
+                    (
+                        body.linear_velocity.0,
+                        *collision_margin,
+                        *speculative_margin,
+                    )
+                },
+            );
+        let (mut lin_vel2, rb_collision_margin2, rb_speculative_margin2) =
+            body2_bundle.as_ref().map_or(
+                (Vector::ZERO, None, None),
+                |(body, collision_margin, speculative_margin)| {
+                    (
+                        body.linear_velocity.0,
+                        *collision_margin,
+                        *speculative_margin,
+                    )
+                },
+            );
+
+        // Use the collider's own collision margin if specified, and fall back to the body's
+        // collision margin.
+        //
+        // The collision margin adds artificial thickness to colliders for performance
+        // and stability. See the `CollisionMargin` documentation for more details.
+        let collision_margin1 = collider1.collision_margin.map_or(
+            rb_collision_margin1.map_or(0.0, |margin| margin.0),
+            |margin| margin.0,
+        );
+        let collision_margin2 = collider2.collision_margin.map_or(
+            rb_collision_margin2.map_or(0.0, |margin| margin.0),
+            |margin| margin.0,
+        );
+        let collision_margin_sum = collision_margin1 + collision_margin2;
 
         // Use the collider's own speculative margin if specified, and fall back to the body's
         // speculative margin.
@@ -452,7 +503,8 @@ impl<'w, 's, C: AnyCollider> NarrowPhase<'w, 's, C> {
 
         // The maximum distance at which contacts are detected.
         // At least as large as the contact tolerance.
-        let max_contact_distance = effective_speculative_margin.max(*self.contact_tolerance);
+        let max_contact_distance =
+            effective_speculative_margin.max(*self.contact_tolerance) + collision_margin_sum;
 
         self.compute_contact_pair(&collider1, &collider2, max_contact_distance)
     }
@@ -542,6 +594,10 @@ impl<'w, 's, C: AnyCollider> NarrowPhase<'w, 's, C> {
     /// Generates [`ContactConstraint`]s for the given bodies and their corresponding colliders
     /// based on the given `contacts`. The constraints are added to the `constraints` vector.
     ///
+    /// The `collision_margin` can be used to add artificial thickness to the colliders,
+    /// which can improve performance and stability in some cases. See [`CollisionMargin`]
+    /// for more details.
+    ///
     /// The `contact_softness` is used to tune the damping and stiffness of the contact constraints.
     #[allow(clippy::too_many_arguments)]
     pub fn generate_constraints(
@@ -552,6 +608,7 @@ impl<'w, 's, C: AnyCollider> NarrowPhase<'w, 's, C> {
         body2: &RigidBodyQueryReadOnlyItem,
         collider1: &ColliderQueryItem<C>,
         collider2: &ColliderQueryItem<C>,
+        collision_margin: Scalar,
         contact_softness: ContactSoftnessCoefficients,
         delta_secs: Scalar,
     ) {
@@ -604,6 +661,7 @@ impl<'w, 's, C: AnyCollider> NarrowPhase<'w, 's, C> {
                 collider2.entity,
                 collider1.transform.copied(),
                 collider2.transform.copied(),
+                collision_margin,
                 // TODO: Shouldn't this be the effective speculative margin?
                 *self.default_speculative_margin,
                 friction,

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -128,6 +128,11 @@
 //! For shapes that are intended to be solid from the inside, it is recommended
 //! to use convex decomposition instead.
 //!
+//! If you must use triangle mesh colliders and are having stability issues, consider
+//! giving them a small amount of extra thickness using the [`CollisionMargin`] component.
+//! This helps prevent objects from passing through the surface while also reducing
+//! numerical errors and improving performance.
+//!
 //! Finally, making the [physics timestep](Physics) smaller can also help.
 //! However, this comes at the cost of worse performance for the entire simulation.
 use crate::prelude::*;

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -229,6 +229,7 @@ use bevy::{
     ecs::{intern::Interned, query::QueryData, schedule::ScheduleLabel},
     prelude::*,
 };
+use derive_more::From;
 use parry::query::{
     cast_shapes, cast_shapes_nonlinear, NonlinearRigidMotion, ShapeCastHit, ShapeCastOptions,
 };
@@ -308,7 +309,7 @@ pub struct SweptCcdSet;
 ///     ));
 /// }
 /// ```
-#[derive(Component, Clone, Copy, Debug, Deref, DerefMut, PartialEq, Reflect)]
+#[derive(Component, Clone, Copy, Debug, Deref, DerefMut, PartialEq, Reflect, From)]
 #[reflect(Component)]
 #[doc(alias = "SweptCcdPredictionDistance")]
 pub struct SpeculativeMargin(pub Scalar);

--- a/src/dynamics/solver/contact/mod.rs
+++ b/src/dynamics/solver/contact/mod.rs
@@ -91,14 +91,17 @@ impl ContactConstraint {
         collider_entity2: Entity,
         collider_transform1: Option<ColliderTransform>,
         collider_transform2: Option<ColliderTransform>,
-        collision_margin: Scalar,
-        speculative_margin: Scalar,
+        collision_margin: impl Into<CollisionMargin>,
+        speculative_margin: impl Into<SpeculativeMargin>,
         friction: Friction,
         restitution: Restitution,
         softness: SoftnessCoefficients,
         warm_start: bool,
         delta_secs: Scalar,
     ) -> Self {
+        let collision_margin: Scalar = collision_margin.into().0;
+        let speculative_margin: Scalar = speculative_margin.into().0;
+
         let normal = *body1.rotation * manifold.normal1;
 
         // TODO: Cache these?

--- a/src/dynamics/solver/contact/mod.rs
+++ b/src/dynamics/solver/contact/mod.rs
@@ -91,6 +91,7 @@ impl ContactConstraint {
         collider_entity2: Entity,
         collider_transform1: Option<ColliderTransform>,
         collider_transform2: Option<ColliderTransform>,
+        collision_margin: Scalar,
         speculative_margin: Scalar,
         friction: Friction,
         restitution: Restitution,
@@ -131,6 +132,8 @@ impl ContactConstraint {
                 contact.point2 = transform.rotation * contact.point2 + transform.translation;
                 contact.normal2 = transform.rotation * contact.normal2;
             }
+
+            contact.penetration += collision_margin;
 
             let effective_distance = -contact.penetration;
 

--- a/src/type_registration.rs
+++ b/src/type_registration.rs
@@ -57,6 +57,8 @@ impl Plugin for PhysicsTypeRegistrationPlugin {
             .register_type::<ColliderTransform>()
             .register_type::<PreviousColliderTransform>()
             .register_type::<SpeculativeMargin>()
+            .register_type::<SweptCcd>()
+            .register_type::<CollisionMargin>()
             .register_type::<NarrowPhaseConfig>()
             .register_type::<SolverConfig>()
             .register_type::<SyncConfig>()


### PR DESCRIPTION
# Objective

Collisions for thin objects such as triangle meshes can sometimes have stability and performance issues, especially when dynamically colliding against other thin objects.

- Infinitely thin objects are more prone to numerical issues and tunneling. Two trimeshes colliding against each other can easily get stuck in an intersecting state or have other collision issues.
- Collision algorithms for intersecting objects are typically more expensive than for the non-intersecting state. Trimesh collisions can be very expensive if the trimesh has dense geometry.

To allow users to mitigate these issues when necessary, engines such as Rapier and Bullet provide a *collision margin* or *contact skin* that forces the solver to maintain an artificial separation distance between objects. It can be thought of as a kind of shell that adds thickness to colliders, reducing the issues mentioned above.

## Solution

Add a `CollisionMargin` component. It can be used to add artifical thickness to any collider for collisions.

```rust
commands.spawn((
    RigidBody::Dynamic,
    Collider::trimesh_from_mesh(&mesh),
    CollisionMargin(0.05),
));
```

Without a collision margin:

https://github.com/Jondolf/bevy_xpbd/assets/57632562/0364168b-81e9-4887-a2fa-10a23b87481e

With a collision margin:

https://github.com/Jondolf/bevy_xpbd/assets/57632562/b41a3cbc-0709-4c3f-9f20-1b73d2d48e76