### PR TITLE
Fix inconsistency between collider constructors and Bevy's primitives

### DIFF
--- a/crates/avian2d/examples/dynamic_character_2d/main.rs
+++ b/crates/avian2d/examples/dynamic_character_2d/main.rs
@@ -50,7 +50,7 @@ fn setup(
             transform: Transform::from_xyz(0.0, -100.0, 0.0),
             ..default()
         },
-        CharacterControllerBundle::new(Collider::capsule(20.0, 12.5)).with_movement(
+        CharacterControllerBundle::new(Collider::capsule(12.5, 20.0)).with_movement(
             1250.0,
             0.92,
             400.0,

--- a/crates/avian2d/examples/kinematic_character_2d/main.rs
+++ b/crates/avian2d/examples/kinematic_character_2d/main.rs
@@ -60,7 +60,7 @@ fn setup(
             transform: Transform::from_xyz(0.0, -100.0, 0.0),
             ..default()
         },
-        CharacterControllerBundle::new(Collider::capsule(20.0, 12.5), Vector::NEG_Y * 1500.0)
+        CharacterControllerBundle::new(Collider::capsule(12.5, 20.0), Vector::NEG_Y * 1500.0)
             .with_movement(1250.0, 0.92, 400.0, (30.0 as Scalar).to_radians()),
     ));
 

--- a/crates/avian2d/examples/sensor.rs
+++ b/crates/avian2d/examples/sensor.rs
@@ -54,7 +54,7 @@ fn setup(
         },
         Character,
         RigidBody::Dynamic,
-        Collider::capsule(20.0, 12.5),
+        Collider::capsule(12.5, 20.0),
         Name::new("Character"),
     ));
 

--- a/crates/avian3d/examples/dynamic_character_3d/main.rs
+++ b/crates/avian3d/examples/dynamic_character_3d/main.rs
@@ -44,7 +44,7 @@ fn setup(
             transform: Transform::from_xyz(0.0, 1.5, 0.0),
             ..default()
         },
-        CharacterControllerBundle::new(Collider::capsule(1.0, 0.4)).with_movement(
+        CharacterControllerBundle::new(Collider::capsule(0.4, 1.0)).with_movement(
             30.0,
             0.92,
             7.0,

--- a/crates/avian3d/examples/kinematic_character_3d/main.rs
+++ b/crates/avian3d/examples/kinematic_character_3d/main.rs
@@ -54,7 +54,7 @@ fn setup(
             transform: Transform::from_xyz(0.0, 1.5, 0.0),
             ..default()
         },
-        CharacterControllerBundle::new(Collider::capsule(1.0, 0.4), Vector::NEG_Y * 9.81 * 2.0)
+        CharacterControllerBundle::new(Collider::capsule(0.4, 1.0), Vector::NEG_Y * 9.81 * 2.0)
             .with_movement(30.0, 0.92, 7.0, (30.0 as Scalar).to_radians()),
     ));
 

--- a/src/collision/collider/backend.rs
+++ b/src/collision/collider/backend.rs
@@ -694,7 +694,7 @@ mod tests {
             HierarchyPlugin,
         ));
 
-        let collider = Collider::capsule(2.0, 0.5);
+        let collider = Collider::capsule(0.5, 2.0);
         let mass_properties = MassPropertiesBundle::new_computed(&collider, 1.0);
 
         let parent = app

--- a/src/collision/collider/constructor.rs
+++ b/src/collision/collider/constructor.rs
@@ -328,17 +328,17 @@ pub enum ColliderConstructor {
     },
     /// Constructs a collider with [`Collider::cylinder`].
     #[cfg(feature = "3d")]
-    Cylinder { height: Scalar, radius: Scalar },
+    Cylinder { radius: Scalar, height: Scalar },
     /// Constructs a collider with [`Collider::cone`].
     #[cfg(feature = "3d")]
-    Cone { height: Scalar, radius: Scalar },
+    Cone { radius: Scalar, height: Scalar },
     /// Constructs a collider with [`Collider::capsule`].
-    Capsule { height: Scalar, radius: Scalar },
+    Capsule { radius: Scalar, height: Scalar },
     /// Constructs a collider with [`Collider::capsule_endpoints`].
     CapsuleEndpoints {
+        radius: Scalar,
         a: Vector,
         b: Vector,
-        radius: Scalar,
     },
     /// Constructs a collider with [`Collider::half_space`].
     HalfSpace { outward_normal: Vector },

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -220,8 +220,8 @@ impl From<TrimeshFlags> for parry::shape::TriMeshFlags {
 /// // Create a ball collider with a given radius
 #[cfg_attr(feature = "2d", doc = "commands.spawn(Collider::circle(0.5));")]
 #[cfg_attr(feature = "3d", doc = "commands.spawn(Collider::sphere(0.5));")]
-/// // Create a capsule collider with a given height and radius
-/// commands.spawn(Collider::capsule(2.0, 0.5));
+/// // Create a capsule collider with a given radius and height
+/// commands.spawn(Collider::capsule(0.5, 2.0));
 /// # }
 /// ```
 ///
@@ -763,34 +763,38 @@ impl Collider {
         .into()
     }
 
-    /// Creates a collider with a cylinder shape defined by its height along the `Y` axis and its radius on the `XZ` plane.
+    /// Creates a collider with a cylinder shape defined by its radius
+    /// on the `XZ` plane and its height along the `Y` axis.
     #[cfg(feature = "3d")]
-    pub fn cylinder(height: Scalar, radius: Scalar) -> Self {
+    pub fn cylinder(radius: Scalar, height: Scalar) -> Self {
         SharedShape::cylinder(height * 0.5, radius).into()
     }
 
-    /// Creates a collider with a cone shape defined by its height along the `Y` axis and the radius of its base on the `XZ` plane.
+    /// Creates a collider with a cone shape defined by the radius of its base
+    /// on the `XZ` plane and its height along the `Y` axis.
     #[cfg(feature = "3d")]
-    pub fn cone(height: Scalar, radius: Scalar) -> Self {
+    pub fn cone(radius: Scalar, height: Scalar) -> Self {
         SharedShape::cone(height * 0.5, radius).into()
     }
 
-    /// Creates a collider with a capsule shape defined by its height along the `Y` axis and its radius.
-    pub fn capsule(height: Scalar, radius: Scalar) -> Self {
+    /// Creates a collider with a capsule shape defined by its radius
+    /// and its height along the `Y` axis, excluding the hemispheres.
+    pub fn capsule(radius: Scalar, length: Scalar) -> Self {
         SharedShape::capsule(
-            (Vector::Y * height * 0.5).into(),
-            (Vector::NEG_Y * height * 0.5).into(),
+            (Vector::Y * length * 0.5).into(),
+            (Vector::NEG_Y * length * 0.5).into(),
             radius,
         )
         .into()
     }
 
-    /// Creates a collider with a capsule shape defined by its end points `a` and `b` and its radius.
-    pub fn capsule_endpoints(a: Vector, b: Vector, radius: Scalar) -> Self {
+    /// Creates a collider with a capsule shape defined by its radius and endpoints `a` and `b`.
+    pub fn capsule_endpoints(radius: Scalar, a: Vector, b: Vector) -> Self {
         SharedShape::capsule(a.into(), b.into(), radius).into()
     }
 
-    /// Creates a collider with a [half-space](https://en.wikipedia.org/wiki/Half-space_(geometry)) shape defined by the outward normal of its planar boundary.
+    /// Creates a collider with a [half-space](https://en.wikipedia.org/wiki/Half-space_(geometry)) shape
+    /// defined by the outward normal of its planar boundary.
     pub fn half_space(outward_normal: Vector) -> Self {
         SharedShape::halfspace(nalgebra::Unit::new_normalize(outward_normal.into())).into()
     }
@@ -1132,14 +1136,14 @@ impl Collider {
                 border_radius,
             )),
             #[cfg(feature = "3d")]
-            ColliderConstructor::Cylinder { height, radius } => {
-                Some(Self::cylinder(height, radius))
+            ColliderConstructor::Cylinder { radius, height } => {
+                Some(Self::cylinder(radius, height))
             }
             #[cfg(feature = "3d")]
-            ColliderConstructor::Cone { height, radius } => Some(Self::cone(height, radius)),
-            ColliderConstructor::Capsule { height, radius } => Some(Self::capsule(height, radius)),
-            ColliderConstructor::CapsuleEndpoints { a, b, radius } => {
-                Some(Self::capsule_endpoints(a, b, radius))
+            ColliderConstructor::Cone { radius, height } => Some(Self::cone(radius, height)),
+            ColliderConstructor::Capsule { radius, height } => Some(Self::capsule(radius, height)),
+            ColliderConstructor::CapsuleEndpoints { radius, a, b } => {
+                Some(Self::capsule_endpoints(radius, a, b))
             }
             ColliderConstructor::HalfSpace { outward_normal } => {
                 Some(Self::half_space(outward_normal))

--- a/src/collision/collider/parry/primitives2d.rs
+++ b/src/collision/collider/parry/primitives2d.rs
@@ -450,8 +450,8 @@ impl PointQuery for RegularPolygonWrapper {
 impl IntoCollider<Collider> for Capsule2d {
     fn collider(&self) -> Collider {
         Collider::capsule(
-            2.0 * self.half_length.adjust_precision(),
             self.radius.adjust_precision(),
+            2.0 * self.half_length.adjust_precision(),
         )
     }
 }

--- a/src/collision/collider/parry/primitives3d.rs
+++ b/src/collision/collider/parry/primitives3d.rs
@@ -74,8 +74,8 @@ impl IntoCollider<Collider> for Cylinder {
 impl IntoCollider<Collider> for Capsule3d {
     fn collider(&self) -> Collider {
         Collider::capsule(
-            2.0 * self.half_length.adjust_precision(),
             self.radius.adjust_precision(),
+            2.0 * self.half_length.adjust_precision(),
         )
     }
 }
@@ -83,8 +83,8 @@ impl IntoCollider<Collider> for Capsule3d {
 impl IntoCollider<Collider> for Cone {
     fn collider(&self) -> Collider {
         Collider::cone(
-            self.height.adjust_precision(),
             self.radius.adjust_precision(),
+            self.height.adjust_precision(),
         )
     }
 }

--- a/src/dynamics/ccd/mod.rs
+++ b/src/dynamics/ccd/mod.rs
@@ -68,7 +68,7 @@
 //!     // Spawn a rigid body with a maximum speculative margin.
 //!     commands.spawn((
 //!         RigidBody::Dynamic,
-//!         Collider::capsule(2.0, 0.5),
+//!         Collider::capsule(0.5, 2.0),
 //!         SpeculativeMargin(2.0),
 //!     ));
 //! }
@@ -169,7 +169,7 @@
 //!     // `SweepMode::NonLinear` is used by default.
 //!     commands.spawn((
 //!         RigidBody::Dynamic,
-//!         Collider::capsule(2.0, 0.5),
+//!         Collider::capsule(0.5, 2.0),
 //!         SweptCcd::default(),
 //!     ));
 //! }
@@ -298,7 +298,7 @@ pub struct SweptCcdSet;
 ///     // Spawn a rigid body with an unbounded speculative margin.
 ///     commands.spawn((
 ///         RigidBody::Dynamic,
-///         Collider::capsule(2.0, 0.5),
+///         Collider::capsule(0.5, 2.0),
 ///         SpeculativeMargin::MAX,
 ///     ));
 /// }

--- a/src/dynamics/rigid_body/locked_axes.rs
+++ b/src/dynamics/rigid_body/locked_axes.rs
@@ -19,7 +19,7 @@ use crate::prelude::*;
 /// fn spawn(mut commands: Commands) {
 ///     commands.spawn((
 ///         RigidBody::Dynamic,
-///         Collider::capsule(1.0, 0.5),
+///         Collider::capsule(0.5, 1.0),
 #[cfg_attr(feature = "2d", doc = "        LockedAxes::ROTATION_LOCKED,")]
 #[cfg_attr(feature = "3d", doc = "        LockedAxes::new().lock_rotation_z(),")]
 ///     ));

--- a/src/dynamics/rigid_body/mod.rs
+++ b/src/dynamics/rigid_body/mod.rs
@@ -794,7 +794,7 @@ pub struct AngularDamping(pub Scalar);
 /// fn spawn_player(mut commands: Commands) {
 ///     commands.spawn((
 ///         RigidBody::Dynamic,
-///         Collider::capsule(1.0, 0.4),
+///         Collider::capsule(0.4, 1.0),
 ///         Dominance(5),
 ///     ));
 /// }

--- a/src/dynamics/rigid_body/world_query.rs
+++ b/src/dynamics/rigid_body/world_query.rs
@@ -366,13 +366,13 @@ mod tests {
         app.add_plugins(MinimalPlugins);
 
         let original_mass_props =
-            MassPropertiesBundle::new_computed(&Collider::capsule(2.4, 0.6), 3.9);
+            MassPropertiesBundle::new_computed(&Collider::capsule(0.6, 2.4), 3.9);
 
         // Spawn an entity with mass properties
         app.world_mut().spawn(original_mass_props.clone());
 
         // Create collider mass properties
-        let collider_mass_props = Collider::capsule(7.4, 2.1).mass_properties(14.3);
+        let collider_mass_props = Collider::capsule(2.1, 7.4).mass_properties(14.3);
 
         // Get the mass properties and then add and subtract the collider mass properties
         let mut query = app.world_mut().query::<MassPropertiesQuery>();


### PR DESCRIPTION
# Objective

The `new` constructors for Bevy's `Cylinder`, `Capsule`, and `Cone` shapes take a radius first, and a height second.

```rust
Capsule::new(radius, height)
```

However, our collider constructors use the opposite order:

```rust
Collider::capsule(height, radius)
```

The reason for this is that I originally followed Parry's argument ordering, and Bevy's primitive shapes were added afterwards with a different ordering.

This is a very unfortunate inconsistency and can easily lead to confusion. Even though changing this will lead to very clear breakage for a large number of applications, I believe it is important that we align ourselves with Bevy here.

## Solution

Make the argument ordering for all collider constructors match Bevy.

---

## Migration Guide

To match Bevy's `Cylinder`, `Capsule`, and `Cone`, the order of arguments has changed for some `Collider` constructors.

- Use `Collider::cylinder(radius, height)` instead of `Collider::cylinder(height, radius)`.
- Use `Collider::capsule(radius, height)` instead of `Collider::capsule(height, radius)`.
- Use `Collider::capsule_endpoints(radius, a, b)` instead of `Collider::capsule_endpoints(a, b, radius)`.
- Use `Collider::cone(radius, height)` instead of `Collider::cone(height, radius)`.