### PR TITLE
Add `#[reflect(Serialize, Deserialize)]` and register more types

### DIFF
--- a/src/collision/broad_phase.rs
+++ b/src/collision/broad_phase.rs
@@ -66,6 +66,7 @@ pub enum BroadPhaseSet {
 /// A list of entity pairs for potential collisions collected during the broad phase.
 #[derive(Reflect, Resource, Debug, Default, Deref, DerefMut)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Resource)]
 pub struct BroadCollisionPairs(pub Vec<(Entity, Entity)>);
 

--- a/src/collision/collider/constructor.rs
+++ b/src/collision/collider/constructor.rs
@@ -105,9 +105,9 @@ use bevy::utils::HashMap;
 /// }
 /// ```
 #[derive(Component, Clone, Debug, Default, PartialEq, Reflect)]
-#[reflect(Debug, Component, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Component, Debug, PartialEq)]
 pub struct ColliderConstructorHierarchy {
     /// The default collider type used for each entity that isn't included in [`config`](Self::config).
     /// If `None`, all entities except the ones in [`config`](Self::config) will be skipped.
@@ -214,10 +214,9 @@ impl ColliderConstructorHierarchy {
 
 /// Configuration for a specific collider generated from a scene using [`ColliderConstructorHierarchy`].
 #[derive(Clone, Debug, Default, PartialEq, Reflect)]
-#[reflect(Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[cfg_attr(all(feature = "3d", feature = "collider-from-mesh"), reflect(Default))]
+#[reflect(Debug, Default, PartialEq)]
 pub struct ColliderConstructorHierarchyConfig {
     /// The type of collider generated for the mesh.
     ///
@@ -280,12 +279,12 @@ pub struct ColliderConstructorHierarchyConfig {
 /// }
 /// ```
 #[derive(Clone, Debug, PartialEq, Reflect, Component)]
-#[reflect(Debug, Component, PartialEq)]
-#[non_exhaustive]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[cfg_attr(all(feature = "3d", feature = "collider-from-mesh"), derive(Default))]
 #[cfg_attr(all(feature = "3d", feature = "collider-from-mesh"), reflect(Default))]
+#[reflect(Debug, Component, PartialEq)]
+#[non_exhaustive]
 #[allow(missing_docs)]
 pub enum ColliderConstructor {
     /// Constructs a collider with [`Collider::circle`].

--- a/src/collision/collider/constructor.rs
+++ b/src/collision/collider/constructor.rs
@@ -107,7 +107,7 @@ use bevy::utils::HashMap;
 #[derive(Component, Clone, Debug, Default, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component, Debug, PartialEq)]
+#[reflect(Component, Debug, PartialEq, Default)]
 pub struct ColliderConstructorHierarchy {
     /// The default collider type used for each entity that isn't included in [`config`](Self::config).
     /// If `None`, all entities except the ones in [`config`](Self::config) will be skipped.

--- a/src/collision/collider/mod.rs
+++ b/src/collision/collider/mod.rs
@@ -137,6 +137,8 @@ pub trait ScalableCollider: AnyCollider {
 /// ```
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Component)]
 pub struct ColliderParent(pub(crate) Entity);
 
 impl ColliderParent {
@@ -160,6 +162,8 @@ impl MapEntities for ColliderParent {
 /// so you shouldn't modify it manually.
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Component)]
 pub struct ColliderTransform {
     /// The translation of a collider in a rigid body's frame of reference.
     pub translation: Vector,
@@ -230,12 +234,15 @@ impl From<Transform> for ColliderTransform {
 #[doc(alias = "Trigger")]
 #[derive(Reflect, Clone, Component, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct Sensor;
 
 /// The Axis-Aligned Bounding Box of a [collider](Collider).
-#[derive(Clone, Copy, Component, Debug, PartialEq)]
+#[derive(Reflect, Clone, Copy, Component, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Component)]
 pub struct ColliderAabb {
     /// The minimum point of the AABB.
     pub min: Vector,
@@ -427,6 +434,7 @@ pub struct CollisionMargin(pub Scalar);
 /// ```
 #[derive(Reflect, Clone, Component, Debug, Default, Deref, DerefMut, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct CollidingEntities(pub HashSet<Entity>);
 

--- a/src/collision/collider/mod.rs
+++ b/src/collision/collider/mod.rs
@@ -138,7 +138,7 @@ pub trait ScalableCollider: AnyCollider {
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, PartialEq)]
 pub struct ColliderParent(pub(crate) Entity);
 
 impl ColliderParent {
@@ -163,7 +163,7 @@ impl MapEntities for ColliderParent {
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, PartialEq)]
 pub struct ColliderTransform {
     /// The translation of a collider in a rigid body's frame of reference.
     pub translation: Vector,
@@ -235,14 +235,14 @@ impl From<Transform> for ColliderTransform {
 #[derive(Reflect, Clone, Component, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, Default, PartialEq)]
 pub struct Sensor;
 
 /// The Axis-Aligned Bounding Box of a [collider](Collider).
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, PartialEq)]
 pub struct ColliderAabb {
     /// The minimum point of the AABB.
     pub min: Vector,
@@ -435,7 +435,7 @@ pub struct CollisionMargin(pub Scalar);
 #[derive(Reflect, Clone, Component, Debug, Default, Deref, DerefMut, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, Default, PartialEq)]
 pub struct CollidingEntities(pub HashSet<Entity>);
 
 impl MapEntities for CollidingEntities {

--- a/src/collision/collider/parry/mod.rs
+++ b/src/collision/collider/parry/mod.rs
@@ -26,9 +26,9 @@ impl<T: IntoCollider<Collider>> From<T> for Collider {
 ///
 /// See <https://github.com/Unity-Technologies/VHACD#parameters> for details.
 #[derive(Clone, PartialEq, Debug, Reflect)]
-#[reflect(PartialEq, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(PartialEq, Debug)]
 pub struct VhacdParameters {
     /// Maximum concavity.
     ///
@@ -121,9 +121,9 @@ impl From<VhacdParameters> for parry::transformation::vhacd::VHACDParameters {
 /// Controls how the voxelization determines which voxel needs
 /// to be considered empty, and which ones will be considered full.
 #[derive(Hash, Clone, Copy, PartialEq, Eq, Debug, Reflect)]
-#[reflect(Hash, PartialEq, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Hash, PartialEq, Debug)]
 pub enum FillMode {
     /// Only consider full the voxels intersecting the surface of the
     /// shape being voxelized.
@@ -161,9 +161,9 @@ bitflags::bitflags! {
     /// Flags used for the preprocessing of a triangle mesh collider.
     #[repr(transparent)]
     #[derive(Hash, Clone, Copy, PartialEq, Eq, Debug, Reflect)]
-    #[reflect_value(Hash, PartialEq, Debug)]
     #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serialize", reflect_value(Serialize, Deserialize))]
+    #[reflect_value(Hash, PartialEq, Debug)]
     pub struct  TrimeshFlags: u8 {
         /// If set, the half-edge topology of the trimesh will be computed if possible.
         const HALF_EDGE_TOPOLOGY = 0b0000_0001;

--- a/src/collision/contact_query.rs
+++ b/src/collision/contact_query.rs
@@ -263,6 +263,7 @@ pub fn contact_manifolds(
 /// The closest points can be computed using [`closest_points`].
 #[derive(Reflect, Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 pub enum ClosestPoints {
     /// The two shapes are intersecting each other.
     Intersecting,

--- a/src/collision/contact_query.rs
+++ b/src/collision/contact_query.rs
@@ -264,6 +264,7 @@ pub fn contact_manifolds(
 #[derive(Reflect, Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Debug, PartialEq)]
 pub enum ClosestPoints {
     /// The two shapes are intersecting each other.
     Intersecting,

--- a/src/collision/layers.rs
+++ b/src/collision/layers.rs
@@ -69,6 +69,7 @@ impl<L: PhysicsLayer> PhysicsLayer for &L {
 /// ```
 #[derive(Reflect, Clone, Copy, Debug, Deref, DerefMut, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 pub struct LayerMask(pub u32);
 
 impl From<u32> for LayerMask {
@@ -331,6 +332,7 @@ impl Not for LayerMask {
 /// ```
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct CollisionLayers {
     /// The layers that an entity belongs to.

--- a/src/collision/layers.rs
+++ b/src/collision/layers.rs
@@ -67,9 +67,10 @@ impl<L: PhysicsLayer> PhysicsLayer for &L {
 /// // Bitwise operations for `LayerMask` unfortunately can't be const, so we need to access the `u32` values.
 /// pub const COMBINED: LayerMask = LayerMask(FIRST_LAYER.0 | LAST_LAYER.0);
 /// ```
-#[derive(Reflect, Clone, Copy, Debug, Deref, DerefMut, Eq, PartialOrd, Ord)]
+#[derive(Reflect, Clone, Copy, Debug, Deref, DerefMut, Eq, PartialEq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Debug, PartialEq)]
 pub struct LayerMask(pub u32);
 
 impl From<u32> for LayerMask {
@@ -333,7 +334,7 @@ impl Not for LayerMask {
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, PartialEq)]
 pub struct CollisionLayers {
     /// The layers that an entity belongs to.
     #[doc(alias = "groups", alias = "layers")]

--- a/src/collision/layers.rs
+++ b/src/collision/layers.rs
@@ -67,7 +67,7 @@ impl<L: PhysicsLayer> PhysicsLayer for &L {
 /// // Bitwise operations for `LayerMask` unfortunately can't be const, so we need to access the `u32` values.
 /// pub const COMBINED: LayerMask = LayerMask(FIRST_LAYER.0 | LAST_LAYER.0);
 /// ```
-#[derive(Reflect, Clone, Copy, Debug, Deref, DerefMut, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Reflect, Clone, Copy, Debug, Deref, DerefMut, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, PartialEq)]

--- a/src/collision/narrow_phase.rs
+++ b/src/collision/narrow_phase.rs
@@ -168,6 +168,7 @@ struct NarrowPhaseInitialized;
 /// A resource for configuring the [narrow phase](NarrowPhasePlugin).
 #[derive(Resource, Reflect, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Resource)]
 pub struct NarrowPhaseConfig {
     /// The default maximum [speculative margin](SpeculativeMargin) used for

--- a/src/collision/narrow_phase.rs
+++ b/src/collision/narrow_phase.rs
@@ -169,7 +169,7 @@ struct NarrowPhaseInitialized;
 #[derive(Resource, Reflect, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Resource)]
+#[reflect(Debug, Resource, PartialEq)]
 pub struct NarrowPhaseConfig {
     /// The default maximum [speculative margin](SpeculativeMargin) used for
     /// [speculative collisions](dynamics::ccd#speculative-collision). This can be overridden

--- a/src/debug_render/configuration.rs
+++ b/src/debug_render/configuration.rs
@@ -48,6 +48,7 @@ use bevy::{color::palettes::css::*, prelude::*};
 /// ```
 #[derive(Reflect, GizmoConfigGroup)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 pub struct PhysicsGizmos {
     /// The lengths of the axes drawn for an entity at the center of mass.
     pub axis_lengths: Option<Vector>,
@@ -114,6 +115,7 @@ impl Default for PhysicsGizmos {
 /// The scale used for contact normals rendered using gizmos.
 #[derive(Reflect, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 pub enum ContactGizmoScale {
     /// The length of the rendered contact normal is constant.
     Constant(Scalar),
@@ -406,6 +408,7 @@ impl PhysicsGizmos {
 /// ```
 #[derive(Component, Reflect, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct DebugRender {
     /// The lengths of the axes drawn for the entity at the center of mass.

--- a/src/debug_render/configuration.rs
+++ b/src/debug_render/configuration.rs
@@ -116,6 +116,7 @@ impl Default for PhysicsGizmos {
 #[derive(Reflect, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(PartialEq)]
 pub enum ContactGizmoScale {
     /// The length of the rendered contact normal is constant.
     Constant(Scalar),
@@ -409,7 +410,7 @@ impl PhysicsGizmos {
 #[derive(Component, Reflect, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Component, PartialEq)]
 pub struct DebugRender {
     /// The lengths of the axes drawn for the entity at the center of mass.
     pub axis_lengths: Option<Vector>,

--- a/src/dynamics/integrator/mod.rs
+++ b/src/dynamics/integrator/mod.rs
@@ -118,7 +118,7 @@ pub enum IntegrationSet {
 #[derive(Reflect, Resource, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Resource)]
+#[reflect(Debug, Resource)]
 pub struct Gravity(pub Vector);
 
 impl Default for Gravity {

--- a/src/dynamics/integrator/mod.rs
+++ b/src/dynamics/integrator/mod.rs
@@ -117,6 +117,7 @@ pub enum IntegrationSet {
 /// You can also modify gravity while the app is running.
 #[derive(Reflect, Resource, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Resource)]
 pub struct Gravity(pub Vector);
 

--- a/src/dynamics/rigid_body/forces.rs
+++ b/src/dynamics/rigid_body/forces.rs
@@ -90,7 +90,7 @@ impl FloatZero for Scalar {
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, PartialEq)]
 pub struct ExternalForce {
     /// The total external force that will be applied.
     force: Vector,
@@ -230,7 +230,7 @@ impl ExternalForce {
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, PartialEq)]
 pub struct ExternalTorque {
     /// The total external torque that will be applied.
     torque: Torque,
@@ -375,7 +375,7 @@ impl ExternalTorque {
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, PartialEq)]
 pub struct ExternalImpulse {
     /// The total external impulse that will be applied.
     impulse: Vector,
@@ -518,7 +518,7 @@ impl ExternalImpulse {
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, PartialEq)]
 #[doc(alias = "ExternalTorqueImpulse")]
 pub struct ExternalAngularImpulse {
     /// The total external angular impulse that will be applied.

--- a/src/dynamics/rigid_body/forces.rs
+++ b/src/dynamics/rigid_body/forces.rs
@@ -89,6 +89,7 @@ impl FloatZero for Scalar {
 /// consider setting `persistent` to `false` and running [`apply_force`](Self::apply_force) in a system.
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct ExternalForce {
     /// The total external force that will be applied.
@@ -228,6 +229,7 @@ impl ExternalForce {
 /// ```
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct ExternalTorque {
     /// The total external torque that will be applied.
@@ -372,6 +374,7 @@ impl ExternalTorque {
 /// ```
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct ExternalImpulse {
     /// The total external impulse that will be applied.
@@ -514,6 +517,7 @@ impl ExternalImpulse {
 /// ```
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 #[doc(alias = "ExternalTorqueImpulse")]
 pub struct ExternalAngularImpulse {

--- a/src/dynamics/rigid_body/locked_axes.rs
+++ b/src/dynamics/rigid_body/locked_axes.rs
@@ -27,6 +27,7 @@ use crate::prelude::*;
 /// ```
 #[derive(Component, Reflect, Clone, Copy, Debug, Default, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct LockedAxes(u8);
 

--- a/src/dynamics/rigid_body/locked_axes.rs
+++ b/src/dynamics/rigid_body/locked_axes.rs
@@ -28,7 +28,7 @@ use crate::prelude::*;
 #[derive(Component, Reflect, Clone, Copy, Debug, Default, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, Default)]
 pub struct LockedAxes(u8);
 
 impl LockedAxes {

--- a/src/dynamics/rigid_body/mass_properties.rs
+++ b/src/dynamics/rigid_body/mass_properties.rs
@@ -8,6 +8,7 @@ use crate::utils::get_rotated_inertia_tensor;
 /// The mass of a body.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct Mass(pub Scalar);
 
@@ -19,6 +20,7 @@ impl Mass {
 /// The inverse mass of a body.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct InverseMass(pub Scalar);
 
@@ -31,6 +33,7 @@ impl InverseMass {
 #[cfg(feature = "2d")]
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct Inertia(pub Scalar);
 
@@ -44,6 +47,7 @@ pub struct Inertia(pub Scalar);
 #[cfg(feature = "3d")]
 #[derive(Reflect, Clone, Copy, Component, Debug, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct Inertia(pub Matrix3);
 
@@ -119,6 +123,7 @@ impl Inertia {
 #[cfg(feature = "2d")]
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct InverseInertia(pub Scalar);
 
@@ -132,6 +137,7 @@ pub struct InverseInertia(pub Scalar);
 #[cfg(feature = "3d")]
 #[derive(Reflect, Clone, Copy, Component, Debug, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct InverseInertia(pub Matrix3);
 
@@ -185,6 +191,7 @@ impl From<Inertia> for InverseInertia {
 /// The local center of mass of a body.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct CenterOfMass(pub Vector);
 
@@ -277,6 +284,7 @@ impl MassPropertiesBundle {
 /// ```
 #[derive(Reflect, Clone, Copy, Component, Debug, Deref, DerefMut, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct ColliderDensity(pub Scalar);
 
@@ -332,6 +340,7 @@ impl From<Scalar> for ColliderDensity {
 /// ```
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct ColliderMassProperties {
     /// Mass given by collider.

--- a/src/dynamics/rigid_body/mass_properties.rs
+++ b/src/dynamics/rigid_body/mass_properties.rs
@@ -9,7 +9,7 @@ use crate::utils::get_rotated_inertia_tensor;
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, Default, PartialEq)]
 pub struct Mass(pub Scalar);
 
 impl Mass {
@@ -21,7 +21,7 @@ impl Mass {
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, Default, PartialEq)]
 pub struct InverseMass(pub Scalar);
 
 impl InverseMass {
@@ -34,7 +34,7 @@ impl InverseMass {
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, Default, PartialEq)]
 pub struct Inertia(pub Scalar);
 
 /// The local moment of inertia of the body as a 3x3 tensor matrix.
@@ -48,7 +48,7 @@ pub struct Inertia(pub Scalar);
 #[derive(Reflect, Clone, Copy, Component, Debug, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, PartialEq)]
 pub struct Inertia(pub Matrix3);
 
 #[cfg(feature = "3d")]
@@ -124,7 +124,7 @@ impl Inertia {
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, Default, PartialEq)]
 pub struct InverseInertia(pub Scalar);
 
 /// The local inverse moment of inertia of the body as a 3x3 tensor matrix.
@@ -138,7 +138,7 @@ pub struct InverseInertia(pub Scalar);
 #[derive(Reflect, Clone, Copy, Component, Debug, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, PartialEq)]
 pub struct InverseInertia(pub Matrix3);
 
 #[cfg(feature = "3d")]
@@ -192,7 +192,7 @@ impl From<Inertia> for InverseInertia {
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, Default, PartialEq)]
 pub struct CenterOfMass(pub Vector);
 
 impl CenterOfMass {
@@ -285,7 +285,7 @@ impl MassPropertiesBundle {
 #[derive(Reflect, Clone, Copy, Component, Debug, Deref, DerefMut, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, PartialEq)]
 pub struct ColliderDensity(pub Scalar);
 
 impl ColliderDensity {
@@ -341,7 +341,7 @@ impl From<Scalar> for ColliderDensity {
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, PartialEq)]
 pub struct ColliderMassProperties {
     /// Mass given by collider.
     pub mass: Mass,

--- a/src/dynamics/rigid_body/mod.rs
+++ b/src/dynamics/rigid_body/mod.rs
@@ -225,6 +225,7 @@ use derive_more::From;
 /// - [Automatic deactivation with sleeping](Sleeping)
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub enum RigidBody {
     /// Dynamic bodies are bodies that are affected by forces, velocity and collisions.
@@ -277,6 +278,7 @@ impl RigidBody {
 /// or for all entities by setting the [`SleepingThreshold`] to a negative value.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, Eq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct Sleeping;
 
@@ -286,12 +288,14 @@ pub struct Sleeping;
 /// See [`Sleeping`] for further information.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct TimeSleeping(pub Scalar);
 
 /// Indicates that the body can not be deactivated by the physics engine. See [`Sleeping`] for information about sleeping.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, Eq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct SleepingDisabled;
 
@@ -304,6 +308,7 @@ pub struct SleepingDisabled;
 /// At the end of each physics frame, the actual [`Position`] is updated in [`SolverSet::ApplyTranslation`].
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct AccumulatedTranslation(pub Vector);
 
@@ -324,6 +329,7 @@ pub struct AccumulatedTranslation(pub Vector);
 /// ```
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct LinearVelocity(pub Vector);
 
@@ -355,6 +361,7 @@ pub(crate) struct PreSolveLinearVelocity(pub Vector);
 #[cfg(feature = "2d")]
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct AngularVelocity(pub Scalar);
 
@@ -376,6 +383,7 @@ pub struct AngularVelocity(pub Scalar);
 #[cfg(feature = "3d")]
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct AngularVelocity(pub Vector);
 
@@ -426,6 +434,7 @@ pub(crate) struct PreSolveAngularVelocity(pub Vector);
     Component, Reflect, Debug, Clone, Copy, PartialEq, PartialOrd, Default, Deref, DerefMut, From,
 )]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct GravityScale(pub Scalar);
 
@@ -434,8 +443,9 @@ pub struct GravityScale(pub Scalar);
 ///
 /// When combine rules clash with each other, the following priority order is used:
 /// `Max > Multiply > Min > Average`.
-#[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Reflect, Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 pub enum CoefficientCombine {
     // The discriminants allow priority ordering to work automatically via comparison methods
     /// Coefficients are combined by computing their average.
@@ -491,6 +501,7 @@ pub enum CoefficientCombine {
 #[doc(alias = "Elasticity")]
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct Restitution {
     /// The [coefficient of restitution](https://en.wikipedia.org/wiki/Coefficient_of_restitution).
@@ -626,6 +637,7 @@ impl From<Scalar> for Restitution {
 /// ```
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct Friction {
     /// Coefficient of dynamic friction.
@@ -745,6 +757,7 @@ impl From<Scalar> for Friction {
     Component, Reflect, Debug, Clone, Copy, PartialEq, PartialOrd, Default, Deref, DerefMut, From,
 )]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct LinearDamping(pub Scalar);
 
@@ -771,6 +784,7 @@ pub struct LinearDamping(pub Scalar);
     Component, Reflect, Debug, Clone, Copy, PartialEq, PartialOrd, Default, Deref, DerefMut, From,
 )]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct AngularDamping(pub Scalar);
 
@@ -803,6 +817,7 @@ pub struct AngularDamping(pub Scalar);
 #[rustfmt::skip]
 #[derive(Component, Reflect, Debug, Clone, Copy, Default, Deref, DerefMut, From, PartialEq, PartialOrd, Eq, Ord)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct Dominance(pub i8);
 

--- a/src/dynamics/rigid_body/mod.rs
+++ b/src/dynamics/rigid_body/mod.rs
@@ -226,7 +226,7 @@ use derive_more::From;
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, Default, PartialEq)]
 pub enum RigidBody {
     /// Dynamic bodies are bodies that are affected by forces, velocity and collisions.
     #[default]
@@ -279,7 +279,7 @@ impl RigidBody {
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, Eq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, Default, PartialEq)]
 pub struct Sleeping;
 
 /// How long the velocity of the body has been below the [`SleepingThreshold`],
@@ -289,14 +289,14 @@ pub struct Sleeping;
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, Default, PartialEq)]
 pub struct TimeSleeping(pub Scalar);
 
 /// Indicates that the body can not be deactivated by the physics engine. See [`Sleeping`] for information about sleeping.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, Eq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, Default, PartialEq)]
 pub struct SleepingDisabled;
 
 /// Translation accumulated during the physics frame.
@@ -309,7 +309,7 @@ pub struct SleepingDisabled;
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, Default, PartialEq)]
 pub struct AccumulatedTranslation(pub Vector);
 
 /// The linear velocity of a [rigid body](RigidBody).
@@ -330,7 +330,7 @@ pub struct AccumulatedTranslation(pub Vector);
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, Default, PartialEq)]
 pub struct LinearVelocity(pub Vector);
 
 impl LinearVelocity {
@@ -362,7 +362,7 @@ pub(crate) struct PreSolveLinearVelocity(pub Vector);
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, Default, PartialEq)]
 pub struct AngularVelocity(pub Scalar);
 
 /// The angular velocity of a [rigid body](RigidBody) as a rotation axis
@@ -384,7 +384,7 @@ pub struct AngularVelocity(pub Scalar);
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, Default, PartialEq)]
 pub struct AngularVelocity(pub Vector);
 
 impl AngularVelocity {
@@ -435,7 +435,7 @@ pub(crate) struct PreSolveAngularVelocity(pub Vector);
 )]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, Default, PartialEq)]
 pub struct GravityScale(pub Scalar);
 
 /// Determines how coefficients are combined for [`Restitution`] and [`Friction`].
@@ -446,6 +446,7 @@ pub struct GravityScale(pub Scalar);
 #[derive(Reflect, Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Debug, Default, PartialEq)]
 pub enum CoefficientCombine {
     // The discriminants allow priority ordering to work automatically via comparison methods
     /// Coefficients are combined by computing their average.
@@ -502,7 +503,7 @@ pub enum CoefficientCombine {
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, PartialEq)]
 pub struct Restitution {
     /// The [coefficient of restitution](https://en.wikipedia.org/wiki/Coefficient_of_restitution).
     ///
@@ -638,7 +639,7 @@ impl From<Scalar> for Restitution {
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, PartialEq)]
 pub struct Friction {
     /// Coefficient of dynamic friction.
     pub dynamic_coefficient: Scalar,
@@ -758,7 +759,7 @@ impl From<Scalar> for Friction {
 )]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, Default, PartialEq)]
 pub struct LinearDamping(pub Scalar);
 
 /// Automatically slows down a dynamic [rigid body](RigidBody), decreasing its
@@ -785,7 +786,7 @@ pub struct LinearDamping(pub Scalar);
 )]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, Default, PartialEq)]
 pub struct AngularDamping(pub Scalar);
 
 /// **Dominance** allows [dynamic rigid bodies](RigidBody::Dynamic) to dominate
@@ -818,7 +819,7 @@ pub struct AngularDamping(pub Scalar);
 #[derive(Component, Reflect, Debug, Clone, Copy, Default, Deref, DerefMut, From, PartialEq, PartialOrd, Eq, Ord)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, Default, PartialEq)]
 pub struct Dominance(pub i8);
 
 #[cfg(test)]

--- a/src/dynamics/sleeping/mod.rs
+++ b/src/dynamics/sleeping/mod.rs
@@ -58,6 +58,7 @@ impl Plugin for SleepingPlugin {
 /// See [`Sleeping`] for further information about sleeping.
 #[derive(Reflect, Resource, Clone, Copy, PartialEq, PartialOrd, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Resource)]
 pub struct SleepingThreshold {
     /// The maximum linear velocity allowed for a body to be marked as sleeping.
@@ -89,6 +90,7 @@ impl Default for SleepingThreshold {
 /// Default: `0.5`
 #[derive(Reflect, Resource, Clone, Copy, PartialEq, PartialOrd, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Resource)]
 pub struct DeactivationTime(pub Scalar);
 

--- a/src/dynamics/sleeping/mod.rs
+++ b/src/dynamics/sleeping/mod.rs
@@ -59,7 +59,7 @@ impl Plugin for SleepingPlugin {
 #[derive(Reflect, Resource, Clone, Copy, PartialEq, PartialOrd, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Resource)]
+#[reflect(Debug, Resource, PartialEq)]
 pub struct SleepingThreshold {
     /// The maximum linear velocity allowed for a body to be marked as sleeping.
     ///
@@ -91,7 +91,7 @@ impl Default for SleepingThreshold {
 #[derive(Reflect, Resource, Clone, Copy, PartialEq, PartialOrd, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Resource)]
+#[reflect(Debug, Default, PartialEq)]
 pub struct DeactivationTime(pub Scalar);
 
 impl Default for DeactivationTime {

--- a/src/dynamics/solver/joints/distance.rs
+++ b/src/dynamics/solver/joints/distance.rs
@@ -15,7 +15,7 @@ use bevy::{
 #[derive(Component, Clone, Copy, Debug, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component, MapEntities)]
+#[reflect(Debug, Component, MapEntities, PartialEq)]
 pub struct DistanceJoint {
     /// First entity constrained by the joint.
     pub entity1: Entity,

--- a/src/dynamics/solver/joints/distance.rs
+++ b/src/dynamics/solver/joints/distance.rs
@@ -14,7 +14,8 @@ use bevy::{
 /// Distance joints can be useful for things like springs, muscles, and mass-spring networks.
 #[derive(Component, Clone, Copy, Debug, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-#[reflect(MapEntities)]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Component, MapEntities)]
 pub struct DistanceJoint {
     /// First entity constrained by the joint.
     pub entity1: Entity,

--- a/src/dynamics/solver/joints/fixed.rs
+++ b/src/dynamics/solver/joints/fixed.rs
@@ -2,7 +2,10 @@
 
 use crate::{dynamics::solver::xpbd::*, prelude::*};
 use bevy::{
-    ecs::entity::{EntityMapper, MapEntities},
+    ecs::{
+        entity::{EntityMapper, MapEntities},
+        reflect::ReflectMapEntities,
+    },
     prelude::*,
 };
 
@@ -10,8 +13,10 @@ use bevy::{
 ///
 /// You should generally prefer using a single body instead of multiple bodies fixed together,
 /// but fixed joints can be useful for things like rigid structures where a force can dynamically break the joints connecting individual bodies.
-#[derive(Component, Clone, Copy, Debug, PartialEq)]
+#[derive(Component, Clone, Copy, Debug, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Component, MapEntities)]
 pub struct FixedJoint {
     /// First entity constrained by the joint.
     pub entity1: Entity,

--- a/src/dynamics/solver/joints/fixed.rs
+++ b/src/dynamics/solver/joints/fixed.rs
@@ -16,7 +16,7 @@ use bevy::{
 #[derive(Component, Clone, Copy, Debug, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component, MapEntities)]
+#[reflect(Debug, Component, MapEntities, PartialEq)]
 pub struct FixedJoint {
     /// First entity constrained by the joint.
     pub entity1: Entity,

--- a/src/dynamics/solver/joints/mod.rs
+++ b/src/dynamics/solver/joints/mod.rs
@@ -186,6 +186,7 @@ pub trait Joint: Component + PositionConstraint + AngularConstraint {
 #[derive(Clone, Copy, Debug, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Debug, PartialEq)]
 pub struct DistanceLimit {
     /// The minimum distance between two points.
     pub min: Scalar,
@@ -247,6 +248,7 @@ impl DistanceLimit {
 #[derive(Clone, Copy, Debug, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Debug, PartialEq)]
 pub struct AngleLimit {
     /// The minimum angle.
     pub min: Scalar,

--- a/src/dynamics/solver/joints/mod.rs
+++ b/src/dynamics/solver/joints/mod.rs
@@ -187,6 +187,7 @@ pub trait Joint: Component + PositionConstraint + AngularConstraint {
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, PartialEq)]
+#[reflect(Debug, PartialEq)]
 pub struct DistanceLimit {
     /// The minimum distance between two points.
     pub min: Scalar,
@@ -248,6 +249,7 @@ impl DistanceLimit {
 #[derive(Clone, Copy, Debug, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Debug, PartialEq)]
 #[reflect(Debug, PartialEq)]
 pub struct AngleLimit {
     /// The minimum angle.

--- a/src/dynamics/solver/joints/mod.rs
+++ b/src/dynamics/solver/joints/mod.rs
@@ -187,7 +187,6 @@ pub trait Joint: Component + PositionConstraint + AngularConstraint {
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, PartialEq)]
-#[reflect(Debug, PartialEq)]
 pub struct DistanceLimit {
     /// The minimum distance between two points.
     pub min: Scalar,
@@ -249,7 +248,6 @@ impl DistanceLimit {
 #[derive(Clone, Copy, Debug, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Debug, PartialEq)]
 #[reflect(Debug, PartialEq)]
 pub struct AngleLimit {
     /// The minimum angle.

--- a/src/dynamics/solver/joints/mod.rs
+++ b/src/dynamics/solver/joints/mod.rs
@@ -185,6 +185,7 @@ pub trait Joint: Component + PositionConstraint + AngularConstraint {
 /// A limit that indicates that the distance between two points should be between `min` and `max`.
 #[derive(Clone, Copy, Debug, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 pub struct DistanceLimit {
     /// The minimum distance between two points.
     pub min: Scalar,
@@ -243,8 +244,9 @@ impl DistanceLimit {
 }
 
 /// A limit that indicates that angles should be between `alpha` and `beta`.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 pub struct AngleLimit {
     /// The minimum angle.
     pub min: Scalar,

--- a/src/dynamics/solver/joints/prismatic.rs
+++ b/src/dynamics/solver/joints/prismatic.rs
@@ -15,7 +15,7 @@ use bevy::{
 #[derive(Component, Clone, Copy, Debug, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component, MapEntities)]
+#[reflect(Debug, Component, MapEntities, PartialEq)]
 pub struct PrismaticJoint {
     /// First entity constrained by the joint.
     pub entity1: Entity,

--- a/src/dynamics/solver/joints/prismatic.rs
+++ b/src/dynamics/solver/joints/prismatic.rs
@@ -2,15 +2,20 @@
 
 use crate::{dynamics::solver::xpbd::*, prelude::*};
 use bevy::{
-    ecs::entity::{EntityMapper, MapEntities},
+    ecs::{
+        entity::{EntityMapper, MapEntities},
+        reflect::ReflectMapEntities,
+    },
     prelude::*,
 };
 
 /// A prismatic joint prevents relative movement of the attached bodies, except for translation along one `free_axis`.
 ///
 /// Prismatic joints can be useful for things like elevators, pistons, sliding doors and moving platforms.
-#[derive(Component, Clone, Copy, Debug, PartialEq)]
+#[derive(Component, Clone, Copy, Debug, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Component, MapEntities)]
 pub struct PrismaticJoint {
     /// First entity constrained by the joint.
     pub entity1: Entity,

--- a/src/dynamics/solver/joints/revolute.rs
+++ b/src/dynamics/solver/joints/revolute.rs
@@ -2,15 +2,20 @@
 
 use crate::{dynamics::solver::xpbd::*, prelude::*};
 use bevy::{
-    ecs::entity::{EntityMapper, MapEntities},
+    ecs::{
+        entity::{EntityMapper, MapEntities},
+        reflect::ReflectMapEntities,
+    },
     prelude::*,
 };
 
 /// A revolute joint prevents relative movement of the attached bodies, except for rotation around one `aligned_axis`.
 ///
 /// Revolute joints can be useful for things like wheels, fans, revolving doors etc.
-#[derive(Component, Clone, Copy, Debug, PartialEq)]
+#[derive(Component, Clone, Copy, Debug, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Component, MapEntities)]
 pub struct RevoluteJoint {
     /// First entity constrained by the joint.
     pub entity1: Entity,

--- a/src/dynamics/solver/joints/revolute.rs
+++ b/src/dynamics/solver/joints/revolute.rs
@@ -15,7 +15,7 @@ use bevy::{
 #[derive(Component, Clone, Copy, Debug, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component, MapEntities)]
+#[reflect(Debug, Component, MapEntities, PartialEq)]
 pub struct RevoluteJoint {
     /// First entity constrained by the joint.
     pub entity1: Entity,

--- a/src/dynamics/solver/joints/spherical.rs
+++ b/src/dynamics/solver/joints/spherical.rs
@@ -2,15 +2,20 @@
 
 use crate::{dynamics::solver::xpbd::*, prelude::*};
 use bevy::{
-    ecs::entity::{EntityMapper, MapEntities},
+    ecs::{
+        entity::{EntityMapper, MapEntities},
+        reflect::ReflectMapEntities,
+    },
     prelude::*,
 };
 
 /// A spherical joint prevents relative translation of the attached bodies while allowing rotation around all axes.
 ///
 /// Spherical joints can be useful for things like pendula, chains, ragdolls etc.
-#[derive(Component, Clone, Copy, Debug, PartialEq)]
+#[derive(Component, Clone, Copy, Debug, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Component, MapEntities)]
 pub struct SphericalJoint {
     /// First entity constrained by the joint.
     pub entity1: Entity,

--- a/src/dynamics/solver/joints/spherical.rs
+++ b/src/dynamics/solver/joints/spherical.rs
@@ -15,7 +15,7 @@ use bevy::{
 #[derive(Component, Clone, Copy, Debug, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component, MapEntities)]
+#[reflect(Debug, Component, MapEntities, PartialEq)]
 pub struct SphericalJoint {
     /// First entity constrained by the joint.
     pub entity1: Entity,

--- a/src/position.rs
+++ b/src/position.rs
@@ -37,6 +37,7 @@ use crate::math::Matrix;
 /// ```
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct Position(pub Vector);
 
@@ -100,12 +101,14 @@ impl From<&GlobalTransform> for Position {
 /// The translation accumulated before the XPBD position solve.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct PreSolveAccumulatedTranslation(pub Vector);
 
 /// The rotation accumulated before the XPBD position solve.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct PreSolveRotation(pub Rotation);
 
@@ -144,8 +147,9 @@ pub(crate) type RotationValue = Quaternion;
 /// }
 /// ```
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq)]
-#[reflect(Component)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Component)]
 #[cfg(feature = "2d")]
 pub struct Rotation {
     /// The cosine of the rotation angle in radians.
@@ -651,6 +655,7 @@ impl core::ops::Mul<&mut Vector3> for &mut Rotation {
 #[cfg(feature = "3d")]
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct Rotation(pub Quaternion);
 
@@ -920,5 +925,6 @@ impl From<DQuat> for Rotation {
 /// The previous rotation of a body. See [`Rotation`].
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Component)]
 pub struct PreviousRotation(pub Rotation);

--- a/src/position.rs
+++ b/src/position.rs
@@ -38,7 +38,7 @@ use crate::math::Matrix;
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, Default, PartialEq)]
 pub struct Position(pub Vector);
 
 impl Position {
@@ -102,14 +102,14 @@ impl From<&GlobalTransform> for Position {
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, Default, PartialEq)]
 pub struct PreSolveAccumulatedTranslation(pub Vector);
 
 /// The rotation accumulated before the XPBD position solve.
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq, From)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, Default, PartialEq)]
 pub struct PreSolveRotation(pub Rotation);
 
 /// Radians
@@ -149,7 +149,7 @@ pub(crate) type RotationValue = Quaternion;
 #[derive(Reflect, Clone, Copy, Component, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, PartialEq)]
 #[cfg(feature = "2d")]
 pub struct Rotation {
     /// The cosine of the rotation angle in radians.
@@ -656,7 +656,7 @@ impl core::ops::Mul<&mut Vector3> for &mut Rotation {
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, Default, PartialEq)]
 pub struct Rotation(pub Quaternion);
 
 #[cfg(feature = "3d")]
@@ -926,5 +926,5 @@ impl From<DQuat> for Rotation {
 #[derive(Reflect, Clone, Copy, Component, Debug, Default, Deref, DerefMut, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, Default, PartialEq)]
 pub struct PreviousRotation(pub Rotation);

--- a/src/schedule/mod.rs
+++ b/src/schedule/mod.rs
@@ -291,10 +291,10 @@ pub enum PhysicsStepSet {
 ///         .run();
 /// }
 /// ```
-#[derive(Reflect, Resource, Clone, Copy)]
+#[derive(Debug, Reflect, Resource, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Resource)]
+#[reflect(Debug, Resource, PartialEq)]
 pub struct SubstepCount(pub u32);
 
 impl Default for SubstepCount {

--- a/src/schedule/mod.rs
+++ b/src/schedule/mod.rs
@@ -293,6 +293,7 @@ pub enum PhysicsStepSet {
 /// ```
 #[derive(Reflect, Resource, Clone, Copy)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Resource)]
 pub struct SubstepCount(pub u32);
 

--- a/src/schedule/time.rs
+++ b/src/schedule/time.rs
@@ -11,7 +11,6 @@ use crate::prelude::*;
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, PartialEq)]
-#[reflect(Debug, PartialEq)]
 pub enum TimestepMode {
     /// **Fixed timestep**: The physics simulation will be advanced by a fixed `delta`
     /// amount of time every frame until the accumulated `overstep` value has been consumed.
@@ -208,7 +207,6 @@ impl Default for TimestepMode {
 #[derive(Reflect, Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Debug, PartialEq)]
 #[reflect(Debug, PartialEq)]
 pub struct Physics {
     timestep_mode: TimestepMode,

--- a/src/schedule/time.rs
+++ b/src/schedule/time.rs
@@ -11,6 +11,7 @@ use crate::prelude::*;
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, PartialEq)]
+#[reflect(Debug, PartialEq)]
 pub enum TimestepMode {
     /// **Fixed timestep**: The physics simulation will be advanced by a fixed `delta`
     /// amount of time every frame until the accumulated `overstep` value has been consumed.
@@ -207,6 +208,7 @@ impl Default for TimestepMode {
 #[derive(Reflect, Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Debug, PartialEq)]
 #[reflect(Debug, PartialEq)]
 pub struct Physics {
     timestep_mode: TimestepMode,

--- a/src/schedule/time.rs
+++ b/src/schedule/time.rs
@@ -10,6 +10,7 @@ use crate::prelude::*;
 #[derive(Reflect, Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Debug, PartialEq)]
 pub enum TimestepMode {
     /// **Fixed timestep**: The physics simulation will be advanced by a fixed `delta`
     /// amount of time every frame until the accumulated `overstep` value has been consumed.
@@ -206,6 +207,7 @@ impl Default for TimestepMode {
 #[derive(Reflect, Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Debug, PartialEq)]
 pub struct Physics {
     timestep_mode: TimestepMode,
     paused: bool,

--- a/src/schedule/time.rs
+++ b/src/schedule/time.rs
@@ -9,6 +9,7 @@ use crate::prelude::*;
 /// The type of timestep used for the [`Time<Physics>`](Physics) clock.
 #[derive(Reflect, Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 pub enum TimestepMode {
     /// **Fixed timestep**: The physics simulation will be advanced by a fixed `delta`
     /// amount of time every frame until the accumulated `overstep` value has been consumed.
@@ -204,6 +205,7 @@ impl Default for TimestepMode {
 
 #[derive(Reflect, Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 pub struct Physics {
     timestep_mode: TimestepMode,
     paused: bool,

--- a/src/spatial_query/pipeline.rs
+++ b/src/spatial_query/pipeline.rs
@@ -838,8 +838,9 @@ fn entity_from_index_and_gen(index: u32, generation: u32) -> bevy::prelude::Enti
 }
 
 /// The result of a [point projection](spatial_query#point-projection) on a [collider](Collider).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 pub struct PointProjection {
     /// The entity of the collider that the point was projected onto.
     pub entity: Entity,

--- a/src/spatial_query/pipeline.rs
+++ b/src/spatial_query/pipeline.rs
@@ -841,6 +841,7 @@ fn entity_from_index_and_gen(index: u32, generation: u32) -> bevy::prelude::Enti
 #[derive(Clone, Debug, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Debug, PartialEq)]
 pub struct PointProjection {
     /// The entity of the collider that the point was projected onto.
     pub entity: Entity,

--- a/src/spatial_query/pipeline.rs
+++ b/src/spatial_query/pipeline.rs
@@ -842,6 +842,7 @@ fn entity_from_index_and_gen(index: u32, generation: u32) -> bevy::prelude::Enti
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, PartialEq)]
+#[reflect(Debug, PartialEq)]
 pub struct PointProjection {
     /// The entity of the collider that the point was projected onto.
     pub entity: Entity,

--- a/src/spatial_query/pipeline.rs
+++ b/src/spatial_query/pipeline.rs
@@ -842,7 +842,6 @@ fn entity_from_index_and_gen(index: u32, generation: u32) -> bevy::prelude::Enti
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, PartialEq)]
-#[reflect(Debug, PartialEq)]
 pub struct PointProjection {
     /// The entity of the collider that the point was projected onto.
     pub entity: Entity,

--- a/src/spatial_query/query_filter.rs
+++ b/src/spatial_query/query_filter.rs
@@ -32,6 +32,7 @@ use crate::prelude::*;
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, PartialEq)]
+#[reflect(Debug, PartialEq)]
 pub struct SpatialQueryFilter {
     /// Specifies which [collision layers](CollisionLayers) will be included in the [spatial query](crate::spatial_query).
     pub mask: LayerMask,

--- a/src/spatial_query/query_filter.rs
+++ b/src/spatial_query/query_filter.rs
@@ -30,6 +30,7 @@ use crate::prelude::*;
 /// ```
 #[derive(Clone, Debug, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 pub struct SpatialQueryFilter {
     /// Specifies which [collision layers](CollisionLayers) will be included in the [spatial query](crate::spatial_query).
     pub mask: LayerMask,

--- a/src/spatial_query/query_filter.rs
+++ b/src/spatial_query/query_filter.rs
@@ -32,7 +32,6 @@ use crate::prelude::*;
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, PartialEq)]
-#[reflect(Debug, PartialEq)]
 pub struct SpatialQueryFilter {
     /// Specifies which [collision layers](CollisionLayers) will be included in the [spatial query](crate::spatial_query).
     pub mask: LayerMask,

--- a/src/spatial_query/query_filter.rs
+++ b/src/spatial_query/query_filter.rs
@@ -31,6 +31,7 @@ use crate::prelude::*;
 #[derive(Clone, Debug, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Debug, PartialEq)]
 pub struct SpatialQueryFilter {
     /// Specifies which [collision layers](CollisionLayers) will be included in the [spatial query](crate::spatial_query).
     pub mask: LayerMask,

--- a/src/spatial_query/ray_caster.rs
+++ b/src/spatial_query/ray_caster.rs
@@ -70,7 +70,7 @@ use parry::query::{
 #[derive(Component, Clone, Debug, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, PartialEq)]
 pub struct RayCaster {
     /// Controls if the ray caster is enabled.
     pub enabled: bool,
@@ -354,10 +354,10 @@ impl RayCaster {
 ///     }
 /// }
 /// ```
-#[derive(Component, Clone, Default, Reflect)]
+#[derive(Debug, Component, Clone, Default, Reflect, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, Default, PartialEq)]
 pub struct RayHits {
     pub(crate) vector: Vec<RayHitData>,
     /// The number of hits.
@@ -416,6 +416,7 @@ impl MapEntities for RayHits {
 #[derive(Clone, Copy, Debug, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Debug, PartialEq)]
 pub struct RayHitData {
     /// The entity of the collider that was hit by the ray.
     pub entity: Entity,

--- a/src/spatial_query/ray_caster.rs
+++ b/src/spatial_query/ray_caster.rs
@@ -69,6 +69,8 @@ use parry::query::{
 /// ```
 #[derive(Component, Clone, Debug, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Component)]
 pub struct RayCaster {
     /// Controls if the ray caster is enabled.
     pub enabled: bool,
@@ -354,6 +356,8 @@ impl RayCaster {
 /// ```
 #[derive(Component, Clone, Default, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Component)]
 pub struct RayHits {
     pub(crate) vector: Vec<RayHitData>,
     /// The number of hits.
@@ -411,6 +415,7 @@ impl MapEntities for RayHits {
 /// Data related to a hit during a [raycast](spatial_query#raycasting).
 #[derive(Clone, Copy, Debug, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 pub struct RayHitData {
     /// The entity of the collider that was hit by the ray.
     pub entity: Entity,

--- a/src/spatial_query/ray_caster.rs
+++ b/src/spatial_query/ray_caster.rs
@@ -417,7 +417,6 @@ impl MapEntities for RayHits {
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, PartialEq)]
-#[reflect(Debug, PartialEq)]
 pub struct RayHitData {
     /// The entity of the collider that was hit by the ray.
     pub entity: Entity,

--- a/src/spatial_query/ray_caster.rs
+++ b/src/spatial_query/ray_caster.rs
@@ -417,6 +417,7 @@ impl MapEntities for RayHits {
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, PartialEq)]
+#[reflect(Debug, PartialEq)]
 pub struct RayHitData {
     /// The entity of the collider that was hit by the ray.
     pub entity: Entity,

--- a/src/spatial_query/shape_caster.rs
+++ b/src/spatial_query/shape_caster.rs
@@ -53,7 +53,7 @@ use parry::query::{details::TOICompositeShapeShapeBestFirstVisitor, ShapeCastOpt
 #[derive(Component, Clone, Debug, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component)]
 pub struct ShapeCaster {
     /// Controls if the shape caster is enabled.
     pub enabled: bool,
@@ -368,10 +368,10 @@ impl ShapeCaster {
 ///     }
 /// }
 /// ```
-#[derive(Component, Clone, Debug, Reflect)]
+#[derive(Component, Clone, Debug, Reflect, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
-#[reflect(Component)]
+#[reflect(Debug, Component, PartialEq)]
 pub struct ShapeHits {
     pub(crate) vector: Vec<ShapeHitData>,
     pub(crate) count: u32,
@@ -418,6 +418,7 @@ impl MapEntities for ShapeHits {
 #[derive(Clone, Copy, Debug, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Debug, PartialEq)]
 pub struct ShapeHitData {
     /// The entity of the collider that was hit by the shape.
     pub entity: Entity,

--- a/src/spatial_query/shape_caster.rs
+++ b/src/spatial_query/shape_caster.rs
@@ -419,7 +419,6 @@ impl MapEntities for ShapeHits {
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, PartialEq)]
-#[reflect(Debug, PartialEq)]
 pub struct ShapeHitData {
     /// The entity of the collider that was hit by the shape.
     pub entity: Entity,

--- a/src/spatial_query/shape_caster.rs
+++ b/src/spatial_query/shape_caster.rs
@@ -419,6 +419,7 @@ impl MapEntities for ShapeHits {
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 #[reflect(Debug, PartialEq)]
+#[reflect(Debug, PartialEq)]
 pub struct ShapeHitData {
     /// The entity of the collider that was hit by the shape.
     pub entity: Entity,

--- a/src/spatial_query/shape_caster.rs
+++ b/src/spatial_query/shape_caster.rs
@@ -52,6 +52,8 @@ use parry::query::{details::TOICompositeShapeShapeBestFirstVisitor, ShapeCastOpt
 /// ```
 #[derive(Component, Clone, Debug, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Component)]
 pub struct ShapeCaster {
     /// Controls if the shape caster is enabled.
     pub enabled: bool,
@@ -368,6 +370,8 @@ impl ShapeCaster {
 /// ```
 #[derive(Component, Clone, Debug, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
+#[reflect(Component)]
 pub struct ShapeHits {
     pub(crate) vector: Vec<ShapeHitData>,
     pub(crate) count: u32,
@@ -413,6 +417,7 @@ impl MapEntities for ShapeHits {
 /// Data related to a hit during a [shapecast](spatial_query#shapecasting).
 #[derive(Clone, Copy, Debug, PartialEq, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 pub struct ShapeHitData {
     /// The entity of the collider that was hit by the shape.
     pub entity: Entity,

--- a/src/type_registration.rs
+++ b/src/type_registration.rs
@@ -52,6 +52,7 @@ impl Plugin for PhysicsTypeRegistrationPlugin {
             .register_type::<LockedAxes>()
             .register_type::<ColliderParent>()
             .register_type::<Dominance>()
+            .register_type::<ColliderAabb>()
             .register_type::<CollisionLayers>()
             .register_type::<CollidingEntities>()
             .register_type::<CoefficientCombine>()
@@ -68,6 +69,13 @@ impl Plugin for PhysicsTypeRegistrationPlugin {
             .register_type::<ColliderConstructorHierarchy>()
             .register_type::<ColliderConstructorHierarchyConfig>()
             .register_type::<RayCaster>()
-            .register_type::<ShapeCaster>();
+            .register_type::<ShapeCaster>()
+            .register_type::<DistanceJoint>()
+            .register_type::<FixedJoint>()
+            .register_type::<PrismaticJoint>()
+            .register_type::<RevoluteJoint>();
+
+        #[cfg(feature = "3d")]
+        app.register_type::<SphericalJoint>();
     }
 }


### PR DESCRIPTION
# Objective

Updated version of #351.

A lot of types are missing `ReflectSerialize` and `ReflectDeserialize` implementations with the `serialize` feature enabled, and several types are also not registered in the `TypeRegistry`.

## Solution

Add `#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize)]` for types that were missing it, and register more types in the `PhysicsTypeRegistrationPlugin`. I also fixed and added some other derives, including removing `Component` from `CoefficientCombine`.

---

## Migration Guide

`CoefficientCombine` is no longer a component. It was never supposed to be one, and did nothing on an entity anyways.